### PR TITLE
add AllFlagsState tests and revise command semantics for it

### DIFF
--- a/mockld/sdk_data.go
+++ b/mockld/sdk_data.go
@@ -136,8 +136,11 @@ func (b *ServerSDKDataBuilder) RawFlag(key string, data json.RawMessage) *Server
 	return b
 }
 
-func (b *ServerSDKDataBuilder) Flag(flag ldmodel.FeatureFlag) *ServerSDKDataBuilder {
-	return b.RawFlag(flag.Key, jsonhelpers.ToJSON(flag))
+func (b *ServerSDKDataBuilder) Flag(flags ...ldmodel.FeatureFlag) *ServerSDKDataBuilder {
+	for _, flag := range flags {
+		b = b.RawFlag(flag.Key, jsonhelpers.ToJSON(flag))
+	}
+	return b
 }
 
 func (b *ServerSDKDataBuilder) RawSegment(key string, data json.RawMessage) *ServerSDKDataBuilder {

--- a/sdktests/server_side_eval.go
+++ b/sdktests/server_side_eval.go
@@ -19,6 +19,7 @@ import (
 
 func DoServerSideEvalTests(t *ldtest.T) {
 	RunParameterizedServerSideEvalTests(t)
+	t.Run("all flags state", RunServerSideEvalAllFlagsTests)
 }
 
 func RunParameterizedServerSideEvalTests(t *ldtest.T) {
@@ -60,13 +61,13 @@ func RunParameterizedServerSideEvalTests(t *ldtest.T) {
 								User: &test.User,
 							})
 							if test.Expect.VariationIndex.IsDefined() {
-								require.Contains(t, result.Values, test.FlagKey)
+								require.Contains(t, result.State, test.FlagKey)
 							}
 							expectedValue := test.Expect.Value
 							if !test.Expect.VariationIndex.IsDefined() {
 								expectedValue = ldvalue.Null()
 							}
-							m.AssertThat(t, result.Values[test.FlagKey], m.Equal(expectedValue))
+							m.AssertThat(t, result.State[test.FlagKey], m.Equal(expectedValue))
 						})
 					}
 				})

--- a/sdktests/server_side_eval_all_flags.go
+++ b/sdktests/server_side_eval_all_flags.go
@@ -1,0 +1,330 @@
+package sdktests
+
+import (
+	"encoding/json"
+	"fmt"
+
+	"github.com/launchdarkly/sdk-test-harness/framework/ldtest"
+	"github.com/launchdarkly/sdk-test-harness/mockld"
+	"github.com/launchdarkly/sdk-test-harness/servicedef"
+
+	"gopkg.in/launchdarkly/go-sdk-common.v2/ldtime"
+	"gopkg.in/launchdarkly/go-sdk-common.v2/lduser"
+	"gopkg.in/launchdarkly/go-sdk-common.v2/ldvalue"
+	"gopkg.in/launchdarkly/go-server-sdk-evaluation.v1/ldbuilders"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// Note that all of the tests in this file assume that the SDK will produce a compact JSON
+// representation of the flags state, by omitting all boolean properties that are false, and
+// omitting all nullable properties that are null.
+
+var dummyValue0, dummyValue1, dummyValue2, dummyValue3 ldvalue.Value = ldvalue.String("a"), //nolint:gochecknoglobals
+	ldvalue.String("b"), ldvalue.String("c"), ldvalue.String("d")
+
+func RunServerSideEvalAllFlagsTests(t *ldtest.T) {
+	t.Run("default behavior", doServerSideAllFlagsBasicTest)
+	t.Run("with reasons", doServerSideAllFlagsWithReasonsTest)
+	t.Run("client-side filter", doServerSideAllFlagsClientSideOnlyTest)
+	t.Run("details only for tracked flags", doServerSideAllFlagsDetailsOnlyForTrackedFlagsTest)
+	t.Run("experimentation", doServerSideAllFlagsExperimentationTest)
+}
+
+func doServerSideAllFlagsBasicTest(t *ldtest.T) {
+	flag1 := ldbuilders.NewFlagBuilder("flag1").Version(100).
+		Variations(dummyValue0, ldvalue.String("value1")).
+		On(false).OffVariation(1).
+		Build()
+
+	// flag2 has event tracking enabled
+	flag2 := ldbuilders.NewFlagBuilder("flag2").Version(200).
+		Variations(dummyValue0, dummyValue1, ldvalue.String("value2")).
+		On(false).OffVariation(2).
+		TrackEvents(true).
+		Build()
+
+	// flag3 has debugging enabled
+	flag3DebugTime := ldtime.UnixMillisNow() + 100000
+	flag3 := ldbuilders.NewFlagBuilder("flag3").Version(300).
+		Variations(dummyValue0, dummyValue1, dummyValue2, ldvalue.String("value3")).
+		On(false).OffVariation(3).
+		DebugEventsUntilDate(flag3DebugTime).
+		Build()
+
+	// flag4 had debugging enabled, but the timestamp is in the past so debugging is no longer enabled
+	flag4DebugTime := ldtime.UnixMillisNow() - 100000
+	flag4 := ldbuilders.NewFlagBuilder("flag4").Version(400).
+		Variations(dummyValue0, dummyValue1, dummyValue2, dummyValue3, ldvalue.String("value4")).
+		On(false).OffVariation(4).
+		DebugEventsUntilDate(flag4DebugTime).
+		Build()
+
+	// flag5 returns a MALFORMED_FLAG error due to an invalid offVariation
+	flag5 := ldbuilders.NewFlagBuilder("flag5").Version(500).
+		Variations(dummyValue0, dummyValue1).
+		On(false).OffVariation(-1).
+		Build()
+
+	dataBuilder := mockld.NewServerSDKDataBuilder()
+	dataBuilder.Flag(flag1, flag2, flag3, flag4, flag5)
+
+	dataSource := NewSDKDataSource(t, dataBuilder.Build())
+	client := NewSDKClient(t, dataSource)
+	user := lduser.NewUser("user-key")
+
+	result := client.EvaluateAllFlags(t, servicedef.EvaluateAllFlagsParams{
+		User: &user,
+	})
+	resultJSON, _ := json.Marshal(result.State)
+	expectedJSON := `{
+		"flag1": "value1",
+		"flag2": "value2",
+		"flag3": "value3",
+		"flag4": "value4",
+		"flag5": null,
+		"$flagsState": {
+			"flag1": {
+				"variation": 1, "version": 100
+			},
+			"flag2": {
+				"variation": 2, "version": 200, "trackEvents": true
+			},
+			"flag3": {
+				"variation": 3, "version": 300, "debugEventsUntilDate": ` + fmt.Sprintf("%d", flag3DebugTime) + `
+			},
+			"flag4": {
+				"variation": 4, "version": 400, "debugEventsUntilDate": ` + fmt.Sprintf("%d", flag4DebugTime) + `
+			},
+			"flag5": {
+				"version": 500
+			}
+		},
+		"$valid": true
+	}`
+	assert.JSONEq(t, expectedJSON, string(resultJSON))
+}
+
+func doServerSideAllFlagsWithReasonsTest(t *ldtest.T) {
+	t.RequireCapability(servicedef.CapabilityAllFlagsWithReasons)
+
+	// flag1 has reason "OFF"
+	flag1 := ldbuilders.NewFlagBuilder("flag1").Version(100).
+		Variations(dummyValue0, ldvalue.String("value1")).
+		On(false).OffVariation(1).
+		Build()
+
+	// flag2 has reason "FALLTHROUGH"
+	flag2 := ldbuilders.NewFlagBuilder("flag2").Version(200).
+		Variations(dummyValue0, dummyValue1, ldvalue.String("value2")).
+		On(true).FallthroughVariation(2).
+		Build()
+
+	// flag3 returns a MALFORMED_FLAG error due to an invalid offVariation
+	flag3 := ldbuilders.NewFlagBuilder("flag3").Version(300).
+		Variations(dummyValue0, dummyValue1).
+		On(false).OffVariation(-1).
+		Build()
+
+	dataBuilder := mockld.NewServerSDKDataBuilder()
+	dataBuilder.Flag(flag1, flag2, flag3)
+
+	dataSource := NewSDKDataSource(t, dataBuilder.Build())
+	client := NewSDKClient(t, dataSource)
+	user := lduser.NewUser("user-key")
+
+	result := client.EvaluateAllFlags(t, servicedef.EvaluateAllFlagsParams{
+		User:        &user,
+		WithReasons: true,
+	})
+	resultJSON, _ := json.Marshal(result.State)
+	expectedJSON := `{
+		"flag1": "value1",
+		"flag2": "value2",
+		"flag3": null,
+		"$flagsState": {
+			"flag1": {
+				"variation": 1, "version": 100, "reason": { "kind": "OFF" }
+			},
+			"flag2": {
+				"variation": 2, "version": 200, "reason": { "kind": "FALLTHROUGH" }
+			},
+			"flag3": {
+				"version": 300, "reason": { "kind": "ERROR", "errorKind": "MALFORMED_FLAG" }
+			}
+		},
+		"$valid": true
+	}`
+	assert.JSONEq(t, expectedJSON, string(resultJSON))
+}
+
+func doServerSideAllFlagsClientSideOnlyTest(t *ldtest.T) {
+	t.RequireCapability(servicedef.CapabilityAllFlagsClientSideOnly)
+
+	flag1 := ldbuilders.NewFlagBuilder("server-side-1").Build()
+	flag2 := ldbuilders.NewFlagBuilder("server-side-2").Build()
+	flag3 := ldbuilders.NewFlagBuilder("client-side-1").SingleVariation(ldvalue.String("value1")).
+		ClientSideUsingEnvironmentID(true).Build()
+	flag4 := ldbuilders.NewFlagBuilder("client-side-2").SingleVariation(ldvalue.String("value2")).
+		ClientSideUsingEnvironmentID(true).Build()
+
+	dataBuilder := mockld.NewServerSDKDataBuilder()
+	dataBuilder.Flag(flag1, flag2, flag3, flag4)
+
+	dataSource := NewSDKDataSource(t, dataBuilder.Build())
+	client := NewSDKClient(t, dataSource)
+	user := lduser.NewUser("user-key")
+
+	result := client.EvaluateAllFlags(t, servicedef.EvaluateAllFlagsParams{
+		User:           &user,
+		ClientSideOnly: true,
+	})
+	assert.Contains(t, result.State, flag3.Key)
+	assert.Contains(t, result.State, flag4.Key)
+	assert.NotContains(t, result.State, flag1.Key)
+	assert.NotContains(t, result.State, flag2.Key)
+}
+
+func doServerSideAllFlagsDetailsOnlyForTrackedFlagsTest(t *ldtest.T) {
+	// Note that it's really only the *reason* that is omitted for untracked flags in this mode.
+	// The variation index and flag version always must be included, because they're used in
+	// summary events.
+
+	t.RequireCapability(servicedef.CapabilityAllFlagsDetailsOnlyForTrackedFlags)
+
+	// flag1 does not get a reason because it's not in any of the other categories below
+	flag1 := ldbuilders.NewFlagBuilder("flag1").Version(100).
+		Variations(dummyValue0, ldvalue.String("value1")).
+		On(false).OffVariation(1).
+		Build()
+
+	// flag2 has event tracking enabled, and a reason of OFF
+	flag2 := ldbuilders.NewFlagBuilder("flag2").Version(200).
+		Variations(dummyValue0, dummyValue1, ldvalue.String("value2")).
+		On(false).OffVariation(2).
+		TrackEvents(true).
+		Build()
+
+	// flag3 has debugging enabled, and a reason of OFF
+	flag3DebugTime := ldtime.UnixMillisNow() + 100000
+	flag3 := ldbuilders.NewFlagBuilder("flag3").Version(300).
+		Variations(dummyValue0, dummyValue1, dummyValue2, ldvalue.String("value3")).
+		On(false).OffVariation(3).
+		DebugEventsUntilDate(flag3DebugTime).
+		Build()
+
+	// flag4 involves an experiment, and has a reason of FALLTHROUGH
+	flag4 := ldbuilders.NewFlagBuilder("flag4").Version(400).
+		Variations(dummyValue0, dummyValue1, dummyValue2, dummyValue3, ldvalue.String("value4")).
+		On(true).FallthroughVariation(4).TrackEventsFallthrough(true).
+		Build()
+
+	dataBuilder := mockld.NewServerSDKDataBuilder()
+	dataBuilder.Flag(flag1, flag2, flag3, flag4)
+
+	dataSource := NewSDKDataSource(t, dataBuilder.Build())
+	client := NewSDKClient(t, dataSource)
+	user := lduser.NewUser("user-key")
+
+	result := client.EvaluateAllFlags(t, servicedef.EvaluateAllFlagsParams{
+		User:                       &user,
+		WithReasons:                true,
+		DetailsOnlyForTrackedFlags: true,
+	})
+	resultJSON, _ := json.Marshal(result.State)
+	expectedJSON := `{
+		"flag1": "value1",
+		"flag2": "value2",
+		"flag3": "value3",
+		"flag4": "value4",
+		"$flagsState": {
+			"flag1": {
+				"variation": 1, "version": 100
+			},
+			"flag2": {
+				"variation": 2, "version": 200, "reason": { "kind": "OFF" }, "trackEvents": true
+			},
+			"flag3": {
+				"variation": 3, "version": 300, "reason": { "kind": "OFF" },
+				"debugEventsUntilDate": ` + fmt.Sprintf("%d", flag3DebugTime) + `
+			},
+			"flag4": {
+				"variation": 4, "version": 400, "reason": { "kind": "FALLTHROUGH" }, "trackEvents": true, "trackReason": true
+			}
+		},
+		"$valid": true
+	}`
+	assert.JSONEq(t, expectedJSON, string(resultJSON))
+}
+
+func doServerSideAllFlagsExperimentationTest(t *ldtest.T) {
+	// flag1 has experiment behavior because it's a fallthrough and has trackEventsFallthrough=true
+	flag1 := ldbuilders.NewFlagBuilder("flag1").Version(100).
+		Variations(dummyValue0, ldvalue.String("value1")).
+		On(true).FallthroughVariation(1).
+		TrackEventsFallthrough(true).
+		Build()
+
+	// flag2 has experiment behavior because it's a rule match and has trackEvents=true on that rule
+	flag2 := ldbuilders.NewFlagBuilder("flag2").Version(200).
+		Variations(dummyValue0, dummyValue1, ldvalue.String("value2")).
+		On(true).FallthroughVariation(0).
+		AddRule(ldbuilders.NewRuleBuilder().ID("rule0").Variation(2).TrackEvents(true)).
+		Build()
+
+	dataBuilder := mockld.NewServerSDKDataBuilder()
+	dataBuilder.Flag(flag1, flag2)
+
+	dataSource := NewSDKDataSource(t, dataBuilder.Build())
+	client := NewSDKClient(t, dataSource)
+	user := lduser.NewUser("user-key")
+
+	result := client.EvaluateAllFlags(t, servicedef.EvaluateAllFlagsParams{
+		User: &user,
+	})
+	resultJSON, _ := json.Marshal(result.State)
+	expectedJSON := `{
+		"flag1": "value1",
+		"flag2": "value2",
+		"$flagsState": {
+			"flag1": {
+				"variation": 1, "version": 100, "reason": { "kind": "FALLTHROUGH" },
+				"trackEvents": true, "trackReason": true
+			},
+			"flag2": {
+				"variation": 2, "version": 200, "reason": { "kind": "RULE_MATCH", "ruleIndex": 0, "ruleId": "rule0" },
+				"trackEvents": true, "trackReason": true
+			}
+		},
+		"$valid": true
+	}`
+	assert.JSONEq(t, expectedJSON, string(resultJSON))
+}
+
+// func canonicalizeAllFlagsData(originalData map[string]ldvalue.Value) map[string]ldvalue.Value {
+// 	ret := make(map[string]ldvalue.Value, len(originalData))
+// 	for k, v := range originalData {
+// 		if k != "$flagsState" {
+// 			ret[k] = v
+// 			continue
+// 		}
+// 		buildMeta := ldvalue.ObjectBuild()
+// 		for flagKey, flagMetaValue := range v.AsValueMap().AsMap() {
+// 			flagMetaMap := flagMetaValue.AsValueMap().AsArbitraryValueMap()
+// 			setDefaultValue(flagMetaMap, "variation", nil)
+// 			setDefaultValue(flagMetaMap, "reason", nil)
+// 			setDefaultValue(flagMetaMap, "trackEvents", false)
+// 			setDefaultValue(flagMetaMap, "trackReason", false)
+// 			setDefaultValue(flagMetaMap, "debugEventsUntilDate", nil)
+// 			buildMeta.Set(flagKey, ldvalue.CopyArbitraryValue(flagMetaMap))
+// 		}
+// 		ret[k] = buildMeta.Build()
+// 	}
+// 	return ret
+// }
+
+// func setDefaultValue(m map[string]interface{}, key string, defaultValue interface{}) {
+// 	if _, ok := m[key]; !ok {
+// 		m[key] = defaultValue
+// 	}
+// }

--- a/sdktests/server_side_eval_all_flags.go
+++ b/sdktests/server_side_eval_all_flags.go
@@ -206,7 +206,6 @@ func doServerSideAllFlagsErrorInFlagTest(t *ldtest.T) {
 		}`
 		assert.JSONEq(t, expectedJSON, string(resultJSON))
 	})
-
 }
 
 func doServerSideAllFlagsClientSideOnlyTest(t *ldtest.T) {

--- a/sdktests/server_side_eval_all_flags.go
+++ b/sdktests/server_side_eval_all_flags.go
@@ -75,7 +75,7 @@ func doServerSideAllFlagsBasicTest(t *ldtest.T) {
 	result := client.EvaluateAllFlags(t, servicedef.EvaluateAllFlagsParams{
 		User: &user,
 	})
-	resultJSON, _ := json.Marshal(result.State)
+	resultJSON, _ := json.Marshal(canonicalizeAllFlagsData(result.State))
 	expectedJSON := `{
 		"flag1": "value1",
 		"flag2": "value2",
@@ -136,7 +136,7 @@ func doServerSideAllFlagsWithReasonsTest(t *ldtest.T) {
 		User:        &user,
 		WithReasons: true,
 	})
-	resultJSON, _ := json.Marshal(result.State)
+	resultJSON, _ := json.Marshal(canonicalizeAllFlagsData(result.State))
 	expectedJSON := `{
 		"flag1": "value1",
 		"flag2": "value2",
@@ -224,7 +224,7 @@ func doServerSideAllFlagsDetailsOnlyForTrackedFlagsTest(t *ldtest.T) {
 		WithReasons:                true,
 		DetailsOnlyForTrackedFlags: true,
 	})
-	resultJSON, _ := json.Marshal(result.State)
+	resultJSON, _ := json.Marshal(canonicalizeAllFlagsData(result.State))
 	expectedJSON := `{
 		"flag1": "value1",
 		"flag2": "value2",
@@ -244,4 +244,15 @@ func doServerSideAllFlagsDetailsOnlyForTrackedFlagsTest(t *ldtest.T) {
 		"$valid": true
 	}`
 	assert.JSONEq(t, expectedJSON, string(resultJSON))
+}
+
+func canonicalizeAllFlagsData(originalData map[string]ldvalue.Value) map[string]ldvalue.Value {
+	ret := make(map[string]ldvalue.Value, len(originalData))
+	for k, v := range originalData {
+		ret[k] = v
+	}
+	if _, found := ret["$valid"]; !found {
+		ret["$valid"] = ldvalue.Bool(true)
+	}
+	return ret
 }

--- a/servicedef/command_params.go
+++ b/servicedef/command_params.go
@@ -49,11 +49,14 @@ type EvaluateFlagResponse struct {
 }
 
 type EvaluateAllFlagsParams struct {
-	User *lduser.User `json:"user,omitempty"`
+	User                       *lduser.User `json:"user,omitempty"`
+	WithReasons                bool         `json:"withReasons"`
+	ClientSideOnly             bool         `json:"clientSideOnly"`
+	DetailsOnlyForTrackedFlags bool         `json:"detailsOnlyForTrackedFlags"`
 }
 
 type EvaluateAllFlagsResponse struct {
-	Values map[string]ldvalue.Value `json:"values"`
+	State map[string]ldvalue.Value `json:"state"`
 }
 
 type CustomEventParams struct {

--- a/servicedef/service_params.go
+++ b/servicedef/service_params.go
@@ -6,6 +6,10 @@ const (
 	CapabilityClientSide    = "client-side"
 	CapabilityServerSide    = "server-side"
 	CapabilityStronglyTyped = "strongly-typed"
+
+	CapabilityAllFlagsWithReasons                = "all-flags-with-reasons"
+	CapabilityAllFlagsClientSideOnly             = "all-flags-client-side-only"
+	CapabilityAllFlagsDetailsOnlyForTrackedFlags = "all-flags-details-only-for-tracked-flags"
 )
 
 type StatusRep struct {


### PR DESCRIPTION
This adds tests to more thoroughly verify the behavior of the SDK method that's normally called `AllFlagsState` or something similar. Note that this includes a breaking change to the semantics of the "evaluate-all" test service command, but that's allowed since we don't yet have a stable release of sdk-test-harness.

This covers almost everything in the [SDK multi-flag evaluation specification](https://launchdarkly.atlassian.net/wiki/spaces/ENG/pages/2014643203/SDK+multi-flag+evaluation+specification). Things it does _not_ cover are:
1. The experimentation-related logic that causes `trackReason` to be set under some circumstances. That behavior has not been added to most SDKs yet, so I'm implementing this subset of the tests to allow us to have an interim release of the test harness that can be used with the existing SDKs.
2. The expectation that `AllFlagsState` should return an invalid state if the client is not yet initialized. The test harness doesn't currently have a way to simulate this condition; I'll implement it in [sc-138705](https://app.shortcut.com/launchdarkly/story/138705/tests-for-client-not-ready-state).
3. APIs allowing an application to query individual properties of the flags state object programmatically. In other words, these tests only look at the JSON representation that would be passed to front-end code. I think that that makes sense, given that we have very specific requirements for what's in that representation, whereas methods like "convert this to a key-value map" or "tell me the value for a specific flag" are nice-to-have features that we've only provided in a few SDKs.

I made an assumption in these tests that we did not previously have in a spec (since there was no spec), but that I _think_ has been followed in all SDKs and that I think is highly desirable: false boolean properties and null nullable properties should always be omitted from the JSON representation. The rationale for this is now described in the spec.

However, I did _not_ require that the SDKs omit `$valid` when it is true, as described in the spec. The JS SDK still does have that behavior (that is, it only considers the data to be invalid if `$valid` is explicitly false), but I believe most or all of the SDKs are always setting the property, so the tests consider it acceptable either way.