### PR TITLE
add parameterized tests for date & semver operators

### DIFF
--- a/testdata/data-files/server-side-eval/operators-date-equal-or-invalid.yml
+++ b/testdata/data-files/server-side-eval/operators-date-equal-or-invalid.yml
@@ -1,0 +1,89 @@
+---
+name: operators - date - equal or invalid
+
+constants:
+  IS_MATCH:
+    value: true
+    variationIndex: 0
+    reason: { kind: "RULE_MATCH", ruleIndex: 0, ruleId: "ruleid" }
+  IS_NOT_MATCH:
+    value: false
+    variationIndex: 1
+    reason: { kind: "FALLTHROUGH" }
+  base_flag: &base_flag
+    on: true
+    fallthrough: { variation: 1 }
+    variations: [ true, false ]
+  base_rule: &base_rule
+    id: ruleid
+    variation: 0
+
+parameters:
+  # do permutations of each VALUE1 with each VALUE2; these are values that are either invalid as dates,
+  # or valid as dates but equal to each other
+  -
+    - VALUE1: "not valid"
+    - VALUE1: true
+    - VALUE1: null
+    - VALUE1: "2017-12-06T00:00:00.000-07:00"
+    - VALUE1: "2017-12-06T07:00:00.000Z"
+    - VALUE1: 1512543600000
+  -
+    - VALUE2: "not valid"
+    - VALUE2: true
+    - VALUE2: null
+    - VALUE2: "2017-12-06T00:00:00.000-07:00"
+    - VALUE2: "2017-12-06T07:00:00.000Z"
+    - VALUE2: 1512543600000
+
+sdkData:
+  flags:
+    test-after-value1:
+      <<: *base_flag
+      rules:
+        - <<: *base_rule
+          clauses:
+            - { attribute: attrname, op: "after", values: [ "<VALUE1>" ] }
+    test-after-value2:
+      <<: *base_flag
+      rules:
+        - <<: *base_rule
+          clauses:
+            - { attribute: attrname, op: "after", values: [ "<VALUE2>" ] }
+    test-before-value1:
+      <<: *base_flag
+      rules:
+        - <<: *base_rule
+          clauses:
+            - { attribute: attrname, op: "before", values: [ "<VALUE1>" ] }
+    test-before-value2:
+      <<: *base_flag
+      rules:
+        - <<: *base_rule
+          clauses:
+            - { attribute: attrname, op: "before", values: [ "<VALUE2>" ] }
+
+evaluations:
+  - name: "<VALUE1> before <VALUE2> fails"
+    flagKey: test-before-value2
+    user: { key: "user-key", custom: { attrname: "<VALUE1>" } }
+    default: false
+    expect: <IS_NOT_MATCH>
+
+  - name: "<VALUE2> before <VALUE1> fails"
+    flagKey: test-before-value1
+    user: { key: "user-key", custom: { attrname: "<VALUE2>" } }
+    default: false
+    expect: <IS_NOT_MATCH>
+
+  - name: "<VALUE1> after <VALUE2> fails"
+    flagKey: test-after-value2
+    user: { key: "user-key", custom: { attrname: "<VALUE1>" } }
+    default: false
+    expect: <IS_NOT_MATCH>
+
+  - name: "<VALUE2> after <VALUE1> fails"
+    flagKey: test-after-value1
+    user: { key: "user-key", custom: { attrname: "<VALUE2>" } }
+    default: false
+    expect: <IS_NOT_MATCH>

--- a/testdata/data-files/server-side-eval/operators-date-unequal.yml
+++ b/testdata/data-files/server-side-eval/operators-date-unequal.yml
@@ -1,0 +1,83 @@
+---
+name: operators - date - unequal
+
+constants:
+  IS_MATCH:
+    value: true
+    variationIndex: 0
+    reason: { kind: "RULE_MATCH", ruleIndex: 0, ruleId: "ruleid" }
+  IS_NOT_MATCH:
+    value: false
+    variationIndex: 1
+    reason: { kind: "FALLTHROUGH" }
+  base_flag: &base_flag
+    on: true
+    fallthrough: { variation: 1 }
+    variations: [ true, false ]
+  base_rule: &base_rule
+    id: ruleid
+    variation: 0
+
+parameters:
+  # do permutations of each LOWER_VALUE with each HIGHER_VALUE; all of the values in
+  # each group represent the same timestamp
+  -
+    - LOWER_VALUE: "2017-12-06T00:00:00.000-07:00"
+    - LOWER_VALUE: "2017-12-06T07:00:00.000Z"  # same time but in UTC
+    - LOWER_VALUE: 1512543600000  # same time as epoch milliseconds
+  -
+    - HIGHER_VALUE: "2017-12-06T00:01:01.000-07:00"
+    - HIGHER_VALUE: "2017-12-06T07:01:01.000Z"
+    - HIGHER_VALUE: 1512543601000
+
+sdkData:
+  flags:
+    test-after-higher:
+      <<: *base_flag
+      rules:
+        - <<: *base_rule
+          clauses:
+            - { attribute: attrname, op: "after", values: [ "<HIGHER_VALUE>" ] }
+    test-after-lower:
+      <<: *base_flag
+      rules:
+        - <<: *base_rule
+          clauses:
+            - { attribute: attrname, op: "after", values: [ "<LOWER_VALUE>" ] }
+    test-before-higher:
+      <<: *base_flag
+      rules:
+        - <<: *base_rule
+          clauses:
+            - { attribute: attrname, op: "before", values: [ "<HIGHER_VALUE>" ] }
+    test-before-lower:
+      <<: *base_flag
+      rules:
+        - <<: *base_rule
+          clauses:
+            - { attribute: attrname, op: "before", values: [ "<LOWER_VALUE>" ] }
+
+evaluations:
+  - name: "<LOWER_VALUE> after <HIGHER_VALUE> fails"
+    flagKey: test-after-higher
+    user: { key: "user-key", custom: { attrname: "<LOWER_VALUE>" } }
+    default: false
+    expect: <IS_NOT_MATCH>
+
+  - name: "<HIGHER_VALUE> after <LOWER_VALUE> passes"
+    flagKey: test-after-lower
+    user: { key: "user-key", custom: { attrname: "<HIGHER_VALUE>" } }
+    default: false
+    expect: <IS_MATCH>
+
+  - name: "<LOWER_VALUE> before <HIGHER_VALUE> passes"
+    flagKey: test-before-higher
+    user: { key: "user-key", custom: { attrname: "<LOWER_VALUE>" } }
+    default: false
+    expect: <IS_MATCH>
+
+  - name: "<HIGHER_VALUE> before <LOWER_VALUE> fails"
+    flagKey: test-before-lower
+    user: { key: "user-key", custom: { attrname: "<HIGHER_VALUE>" } }
+    default: false
+    expect: <IS_NOT_MATCH>

--- a/testdata/data-files/server-side-eval/operators-semver-equal-or-invalid.yml
+++ b/testdata/data-files/server-side-eval/operators-semver-equal-or-invalid.yml
@@ -1,0 +1,96 @@
+---
+name: operators - semver - equal or invalid
+
+constants:
+  IS_MATCH:
+    value: true
+    variationIndex: 0
+    reason: { kind: "RULE_MATCH", ruleIndex: 0, ruleId: "ruleid" }
+  IS_NOT_MATCH:
+    value: false
+    variationIndex: 1
+    reason: { kind: "FALLTHROUGH" }
+  base_flag: &base_flag
+    on: true
+    fallthrough: { variation: 1 }
+    variations: [ true, false ]
+  base_rule: &base_rule
+    id: ruleid
+    variation: 0
+
+parameters:
+  - VALUE1: "2.0.0"
+    VALUE2: "2.0.0"
+    EXPECT: <IS_MATCH>
+  - VALUE1: "2.0"
+    VALUE2: "2.0.0"
+    EXPECT: <IS_MATCH>
+  - VALUE1: "2"
+    VALUE2: "2.0.0"
+    EXPECT: <IS_MATCH>
+  - VALUE1: "2.0.0+build"
+    VALUE2: "2.0.0"
+    EXPECT: <IS_MATCH>
+  - VALUE1: "2.0.0-rc"
+    VALUE2: "2.0.0-rc"
+    EXPECT: <IS_MATCH>
+  - VALUE1: "2.0-rc"
+    VALUE2: "2.0.0-rc"
+    EXPECT: <IS_MATCH>
+  - VALUE1: "2-rc"
+    VALUE2: "2.0.0-rc"
+    EXPECT: <IS_MATCH>
+  - VALUE1: "2.0.0-rc+build"
+    VALUE2: "2.0.0-rc"
+    EXPECT: <IS_MATCH>
+
+  # invalid values
+  - VALUE1: "02.0.0"
+    VALUE2: "2.0.0"
+    EXPECT: <IS_NOT_MATCH>
+  - VALUE1: "v2.0.0"
+    VALUE2: "2.0.0"
+    EXPECT: <IS_NOT_MATCH>
+  - VALUE1: "2.0.0.0"
+    VALUE2: "2.0.0"
+    EXPECT: <IS_NOT_MATCH>
+  - VALUE1: 2
+    VALUE2: "2.0.0"
+    EXPECT: <IS_NOT_MATCH>
+  - VALUE1: 2.0
+    VALUE2: "2.0.0"
+    EXPECT: <IS_NOT_MATCH>
+  - VALUE1: true
+    VALUE2: "2.0.0"
+    EXPECT: <IS_NOT_MATCH>
+  - VALUE1: null
+    VALUE2: "2.0.0"
+    EXPECT: <IS_NOT_MATCH>
+
+sdkData:
+  flags:
+    test-semVerEqual-value1:
+      <<: *base_flag
+      rules:
+        - <<: *base_rule
+          clauses:
+            - { attribute: attrname, op: "semVerEqual", values: [ "<VALUE1>" ] }
+    test-semVerEqual-value2:
+      <<: *base_flag
+      rules:
+        - <<: *base_rule
+          clauses:
+            - { attribute: attrname, op: "semVerEqual", values: [ "<VALUE2>" ] }
+
+evaluations:
+  - name: "<VALUE1> semVerEqual <VALUE2>"
+    flagKey: test-semVerEqual-value2
+    user: { key: "user-key", custom: { attrname: "<VALUE1>" } }
+    default: false
+    expect: <EXPECT>
+
+  - name: "<VALUE2> semVerEqual <VALUE1>"
+    flagKey: test-semVerEqual-value1
+    user: { key: "user-key", custom: { attrname: "<VALUE2>" } }
+    default: false
+    expect: <EXPECT>

--- a/testdata/data-files/server-side-eval/operators-semver-unequal.yml
+++ b/testdata/data-files/server-side-eval/operators-semver-unequal.yml
@@ -1,0 +1,132 @@
+---
+name: operators - semver - unequal
+
+constants:
+  IS_MATCH:
+    value: true
+    variationIndex: 0
+    reason: { kind: "RULE_MATCH", ruleIndex: 0, ruleId: "ruleid" }
+  IS_NOT_MATCH:
+    value: false
+    variationIndex: 1
+    reason: { kind: "FALLTHROUGH" }
+  base_flag: &base_flag
+    on: true
+    fallthrough: { variation: 1 }
+    variations: [ true, false ]
+  base_rule: &base_rule
+    id: ruleid
+    variation: 0
+
+parameters:
+  - LOWER_VALUE: "1.0.0"
+    HIGHER_VALUE: "2.0.0"
+
+  - LOWER_VALUE: "1.0"
+    HIGHER_VALUE: "2.0"
+  
+  - LOWER_VALUE: "1"
+    HIGHER_VALUE: "2"
+
+  - LOWER_VALUE: "2.0.0"
+    HIGHER_VALUE: "2.1.0"
+
+  - LOWER_VALUE: "2.0"
+    HIGHER_VALUE: "2.1"
+
+  - LOWER_VALUE: "2.0.0"
+    HIGHER_VALUE: "2.0.1"
+
+  - LOWER_VALUE: "2.0.0-rc"
+    HIGHER_VALUE: "2.0.0"  # released version > prerelease version
+
+  - LOWER_VALUE: "2.0.0-rc"
+    HIGHER_VALUE: "2.0.0-rc.1"
+
+  - LOWER_VALUE: "2.0.0-rc.2.green"
+    HIGHER_VALUE: "2.0.0-rc.10.green"  # numeric comparison: 10 > 2
+    
+  - LOWER_VALUE: "2.0.0-rc.2.green"
+    HIGHER_VALUE: "2.0.0-rc.2.red"  # string comparison: red > green
+
+  - LOWER_VALUE: "2.0.0-rc.2.green"
+    HIGHER_VALUE: "2.0.0-rc.2.green.1"  # adding more version components makes it greater
+    
+  - LOWER_VALUE: "2.0.0-rc.2.green"
+    HIGHER_VALUE: "2.0.1-rc.2.green"
+
+sdkData:
+  flags:
+    test-semVerEqualHigher:
+      <<: *base_flag
+      rules:
+        - <<: *base_rule
+          clauses:
+            - { attribute: attrname, op: "semVerEqual", values: [ "<HIGHER_VALUE>" ] }
+    test-semVerEqualLower:
+      <<: *base_flag
+      rules:
+        - <<: *base_rule
+          clauses:
+            - { attribute: attrname, op: "semVerEqual", values: [ "<LOWER_VALUE>" ] }
+    test-semVerLessThanHigher:
+      <<: *base_flag
+      rules:
+        - <<: *base_rule
+          clauses:
+            - { attribute: attrname, op: "semVerLessThan", values: [ "<HIGHER_VALUE>" ] }
+    test-semVerLessThanLower:
+      <<: *base_flag
+      rules:
+        - <<: *base_rule
+          clauses:
+            - { attribute: attrname, op: "semVerLessThan", values: [ "<LOWER_VALUE>" ] }
+    test-semVerGreaterThanLower:
+      <<: *base_flag
+      rules:
+        - <<: *base_rule
+          clauses:
+            - { attribute: attrname, op: "semVerGreaterThan", values: [ "<LOWER_VALUE>" ] }
+    test-semVerGreaterThanHigher:
+      <<: *base_flag
+      rules:
+        - <<: *base_rule
+          clauses:
+            - { attribute: attrname, op: "semVerGreaterThan", values: [ "<HIGHER_VALUE>" ] }
+
+evaluations:
+  - name: "<LOWER_VALUE> semVerEqual <HIGHER_VALUE> fails"
+    flagKey: test-semVerEqualHigher
+    user: { key: "user-key", custom: { attrname: "<LOWER_VALUE>" } }
+    default: false
+    expect: <IS_NOT_MATCH>
+
+  - name: "<HIGHER_VALUE> semVerEqual <LOWER_VALUE> fails"
+    flagKey: test-semVerEqualLower
+    user: { key: "user-key", custom: { attrname: "<HIGHER_VALUE>" } }
+    default: false
+    expect: <IS_NOT_MATCH>
+
+  - name: "<LOWER_VALUE> semVerLessThan <HIGHER_VALUE> passes"
+    flagKey: test-semVerLessThanHigher
+    user: { key: "user-key", custom: { attrname: "<LOWER_VALUE>" } }
+    default: false
+    expect: <IS_MATCH>
+
+  - name: "<HIGHER_VALUE> semVerLessThan <LOWER_VALUE> fails"
+    flagKey: test-semVerLessThanLower
+    user: { key: "user-key", custom: { attrname: "<HIGHER_VALUE>" } }
+    default: false
+    expect: <IS_NOT_MATCH>
+
+  - name: "<HIGHER_VALUE> semVerGreaterThan <LOWER_VALUE> passes"
+    flagKey: test-semVerGreaterThanLower
+    user: { key: "user-key", custom: { attrname: "<HIGHER_VALUE>" } }
+    default: false
+    expect: <IS_MATCH>
+
+  - name: "<LOWER_VALUE> semVerGreaterThan <HIGHER_VALUE> fails"
+    flagKey: test-semVerGreaterThanHigher
+    user: { key: "user-key", custom: { attrname: "<LOWER_VALUE>" } }
+    default: false
+    expect: <IS_NOT_MATCH>


### PR DESCRIPTION
There's no new Go logic for these - I'm just using the existing file-driven parameterized test.

I used slightly different strategies in each file for how to iterate over all the desired values - see PR comments. It might be possible in the future to redesign the syntax & the parser to make these clearer.