### PR TITLE
implement "client not ready" evaluation tests

### DIFF
--- a/docs/service_spec.md
+++ b/docs/service_spec.md
@@ -44,6 +44,7 @@ A `POST` request indicates that the test harness wants to start an instance of t
 * `configuration` (object, required): SDK configuration. Properties are:
   * `credential` (string, required): The SDK key.
   * `startWaitTimeMs` (number, optional): The initialization timeout in milliseconds. If omitted or zero, the default is 5000 (5 seconds).
+  * `timeoutOk` (boolean, optional): If true, the test service should _not_ return an error for client initialization timing out (that is, a timeout is an expected condition in this test and we still want to be able to use the client). The default behavior is that a timeout should return a `500` error.
   * `streaming` (object, optional): Enables streaming mode and provides streaming configuration. Currently the test harness only supports streaming mode, so this will be inferred if it is omitted. Properties are
     * `baseUri` (string, optional): The base URI for the streaming service. For contract testing, this will be the URI of a simulated streaming endpoint that the test harness provides. If it is null or an empty string, the SDK should connect to the real LaunchDarkly streaming service.
   * `events` (object, optional): Enables events and provides events configuration, or disables events if it is omitted or null. Properties are:
@@ -57,6 +58,8 @@ A `POST` request indicates that the test harness wants to start an instance of t
 The response to a valid request is any HTTP `2xx` status, with a `Location` header whose value is the URL of the test service resource representing this SDK client instance (that is, the one that would be used for "Close client" or "Send command" as described below).
 
 If any parameters are invalid, return HTTP `400`.
+
+If client initialization throws an exception, or it times out and `timeoutOk` was _not_ set to true, return HTTP `500`.
 
 ### Send command: `POST <URL of SDK client instance>`
 

--- a/docs/service_spec.md
+++ b/docs/service_spec.md
@@ -43,15 +43,16 @@ A `POST` request indicates that the test harness wants to start an instance of t
 * `tag` (string, required): A string describing the current test, if desired for logging.
 * `configuration` (object, required): SDK configuration. Properties are:
   * `credential` (string, required): The SDK key.
+  * `startWaitTimeMs` (number, optional): The initialization timeout in milliseconds. If omitted or zero, the default is 5000 (5 seconds).
   * `streaming` (object, optional): Enables streaming mode and provides streaming configuration. Currently the test harness only supports streaming mode, so this will be inferred if it is omitted. Properties are
     * `baseUri` (string, optional): The base URI for the streaming service. For contract testing, this will be the URI of a simulated streaming endpoint that the test harness provides. If it is null or an empty string, the SDK should connect to the real LaunchDarkly streaming service.
   * `events` (object, optional): Enables events and provides events configuration, or disables events if it is omitted or null. Properties are:
-    * `baseUri`: The base URI for the events service. For contract testing, this will be the URI of a simulated event-recorder endpoint that the test harness provides. If it is null or an empty string, the SDK should connect to the real LaunchDarkly events service.
-    * `enableDiagnostics`: If true, diagnostic events should be enabled. Otherwise they should be disabled.
-    * `allAttributesPrivate`: Corresponds to the SDK configuration property of the same name.
-    * `globalPrivateAttributes`: Corresponds to the `privateAttributes` property in the SDK configuration (rather than in an individual user).
-    * `flushIntervalMs`: The event flush interval in milliseconds. If omitted or zero, use the SDK's default value.
-    * `inlineUsers`: Corresponds to the SDK configuration property of the same name.
+    * `baseUri` (string, optional): The base URI for the events service. For contract testing, this will be the URI of a simulated event-recorder endpoint that the test harness provides. If it is null or an empty string, the SDK should connect to the real LaunchDarkly events service.
+    * `enableDiagnostics` (boolean, optional): If true, diagnostic events should be enabled. Otherwise they should be disabled.
+    * `allAttributesPrivate` (boolean, optional): Corresponds to the SDK configuration property of the same name.
+    * `globalPrivateAttributes` (array, optional): Corresponds to the `privateAttributes` property in the SDK configuration (rather than in an individual user).
+    * `flushIntervalMs` (number, optional): The event flush interval in milliseconds. If omitted or zero, use the SDK's default value.
+    * `inlineUsers` (boolean, optional): Corresponds to the SDK configuration property of the same name.
 
 The response to a valid request is any HTTP `2xx` status, with a `Location` header whose value is the URL of the test service resource representing this SDK client instance (that is, the one that would be used for "Close client" or "Send command" as described below).
 

--- a/mockld/sdk_data.go
+++ b/mockld/sdk_data.go
@@ -24,6 +24,20 @@ type SDKData interface {
 	Serialize() []byte
 }
 
+type blockingUnavailableSDKData struct {
+	kind SDKKind
+}
+
+// BlockingUnavailableSDKData returns an object that will cause the mock streaming service *not* to provide
+// any data. It will accept connections, but then hang. This allows us to simulate a state where the SDK
+// client times out without initializing, because it has not received any "put" event.
+func BlockingUnavailableSDKData(sdkKind SDKKind) SDKData {
+	return blockingUnavailableSDKData{kind: sdkKind}
+}
+
+func (b blockingUnavailableSDKData) SDKKind() SDKKind  { return b.kind }
+func (b blockingUnavailableSDKData) Serialize() []byte { return nil }
+
 // ServerSDKData contains simulated LaunchDarkly environment data for a server-side SDK.
 //
 // This includes the full JSON configuration of every flag and segment, in the same format that is used in

--- a/sdktests/server_side_eval_all_flags.go
+++ b/sdktests/server_side_eval_all_flags.go
@@ -28,6 +28,7 @@ func RunServerSideEvalAllFlagsTests(t *ldtest.T) {
 	t.Run("with reasons", doServerSideAllFlagsWithReasonsTest)
 	t.Run("client-side filter", doServerSideAllFlagsClientSideOnlyTest)
 	t.Run("details only for tracked flags", doServerSideAllFlagsDetailsOnlyForTrackedFlagsTest)
+	t.Run("client not ready", doServerSideAllFlagsClientNotReadyTest)
 }
 
 func doServerSideAllFlagsBasicTest(t *ldtest.T) {
@@ -242,6 +243,24 @@ func doServerSideAllFlagsDetailsOnlyForTrackedFlagsTest(t *ldtest.T) {
 			}
 		},
 		"$valid": true
+	}`
+	assert.JSONEq(t, expectedJSON, string(resultJSON))
+}
+
+func doServerSideAllFlagsClientNotReadyTest(t *ldtest.T) {
+	dataSource := NewSDKDataSource(t, mockld.BlockingUnavailableSDKData(mockld.ServerSideSDK))
+	client := NewSDKClient(t,
+		WithConfig(servicedef.SDKConfigParams{StartWaitTimeMS: 1, TimeoutOK: true}),
+		dataSource)
+	user := lduser.NewUser("user-key")
+
+	result := client.EvaluateAllFlags(t, servicedef.EvaluateAllFlagsParams{
+		User: &user,
+	})
+	resultJSON, _ := json.Marshal(result.State)
+	expectedJSON := `{
+		"$valid": false,
+		"$flagsState": {}
 	}`
 	assert.JSONEq(t, expectedJSON, string(resultJSON))
 }

--- a/servicedef/sdk_config.go
+++ b/servicedef/sdk_config.go
@@ -6,9 +6,11 @@ import (
 )
 
 type SDKConfigParams struct {
-	Credential string                    `json:"credential"`
-	Streaming  *SDKConfigStreamingParams `json:"streaming,omitempty"`
-	Events     *SDKConfigEventParams     `json:"events,omitempty"`
+	Credential      string                     `json:"credential"`
+	StartWaitTimeMS ldtime.UnixMillisecondTime `json:"startWaitTimeMs,omitempty"`
+	TimeoutOK       bool                       `json:"timeoutOk,omitempty"`
+	Streaming       *SDKConfigStreamingParams  `json:"streaming,omitempty"`
+	Events          *SDKConfigEventParams      `json:"events,omitempty"`
 }
 
 type SDKConfigStreamingParams struct {

--- a/testdata/data-files/server-side-eval-client-not-ready/errors-client-not-ready.yml
+++ b/testdata/data-files/server-side-eval-client-not-ready/errors-client-not-ready.yml
@@ -1,0 +1,37 @@
+---
+name: client not ready for evaluation (<TYPE_NAME>)
+
+constants:
+  USER: { key: "user-key" }
+  NOT_READY_FLAG_RESULT:
+    value: <TYPE_DEFAULT>
+    reason: { "kind": "ERROR", "errorKind": "CLIENT_NOT_READY" }
+
+parameters:
+  - TYPE_NAME: bool
+    TYPE_VALUE: true
+    TYPE_DEFAULT: false
+
+  - TYPE_NAME: int
+    TYPE_VALUE: 1
+    TYPE_DEFAULT: -1
+
+  - TYPE_NAME: double
+    TYPE_VALUE: 1.5
+    TYPE_DEFAULT: 0.5
+
+  - TYPE_NAME: string
+    TYPE_VALUE: "a"
+    TYPE_DEFAULT: "x"
+
+  - TYPE_NAME: any
+    TYPE_VALUE: 3
+    TYPE_DEFAULT: false
+
+evaluations:
+  - name: not ready
+    flagKey: no-such-flag
+    user: <USER>
+    valueType: <TYPE_NAME>
+    default: <TYPE_DEFAULT>
+    expect: <NOT_READY_FLAG_RESULT>


### PR DESCRIPTION
These tests cause a deliberate timeout of client initialization, to verify that evaluation methods work as expected under this condition.

The relevant specs are [Feature flag evaluation algorithm - I.1](https://launchdarkly.atlassian.net/wiki/spaces/ENG/pages/1874789423/Feature+flag+evaluation+algorithm#I.-Before-evaluating-a-flag) and [SDK multi-flag evaluation specification - I.1](https://launchdarkly.atlassian.net/wiki/spaces/ENG/pages/2014643203/SDK+multi-flag+evaluation+specification#I.-Before-starting-evaluations).