### PR TITLE
add tests for stream behavior, updates, and summary events

### DIFF
--- a/docs/service_spec.md
+++ b/docs/service_spec.md
@@ -44,7 +44,7 @@ A `POST` request indicates that the test harness wants to start an instance of t
 * `configuration` (object, required): SDK configuration. Properties are:
   * `credential` (string, required): The SDK key.
   * `startWaitTimeMs` (number, optional): The initialization timeout in milliseconds. If omitted or zero, the default is 5000 (5 seconds).
-  * `timeoutOk` (boolean, optional): If true, the test service should _not_ return an error for client initialization timing out (that is, a timeout is an expected condition in this test and we still want to be able to use the client). The default behavior is that a timeout should return a `500` error.
+  * `initCanFail` (boolean, optional): If true, the test service should _not_ return an error for client initialization failing in a way that still makes the client instance available (for instance, due to a timeout or a 401 error). See discussion of error handling below.
   * `streaming` (object, optional): Enables streaming mode and provides streaming configuration. Currently the test harness only supports streaming mode, so this will be inferred if it is omitted. Properties are
     * `baseUri` (string, optional): The base URI for the streaming service. For contract testing, this will be the URI of a simulated streaming endpoint that the test harness provides. If it is null or an empty string, the SDK should connect to the real LaunchDarkly streaming service.
   * `events` (object, optional): Enables events and provides events configuration, or disables events if it is omitted or null. Properties are:
@@ -60,7 +60,11 @@ The response to a valid request is any HTTP `2xx` status, with a `Location` head
 
 If any parameters are invalid, return HTTP `400`.
 
-If client initialization throws an exception, or it times out and `timeoutOk` was _not_ set to true, return HTTP `500`.
+If client initialization fails, the desired behavior depends on how it failed and whether `initCanFail` was set:
+
+* If `initCanFail` was set to true, then the test service should tolerate any kind of initialization failure where the client instance is still available. For instance, if initialization times out, or stops immediately due to getting a 401 error from LaunchDarkly, all of our SDKs still allow the application to continue using the client instance even though it may not have valid flag data; that might be an expected condition in a test, in which case `initCanFail` will be true.
+* If `initCanFail` was not set to true, then errors of that kind should be treated as unexpected failures and return an HTTP `500` error, preferably with some descriptive text in the response body that can be logged by the test harness.
+* Any kind of error that does _not_ make the client instance available should always cause a `500`. For instance, in languages that support exceptions, if an exception is thrown from the constructor then there is no client instance.
 
 ### Send command: `POST <URL of SDK client instance>`
 

--- a/docs/service_spec.md
+++ b/docs/service_spec.md
@@ -47,6 +47,7 @@ A `POST` request indicates that the test harness wants to start an instance of t
   * `initCanFail` (boolean, optional): If true, the test service should _not_ return an error for client initialization failing in a way that still makes the client instance available (for instance, due to a timeout or a 401 error). See discussion of error handling below.
   * `streaming` (object, optional): Enables streaming mode and provides streaming configuration. Currently the test harness only supports streaming mode, so this will be inferred if it is omitted. Properties are
     * `baseUri` (string, optional): The base URI for the streaming service. For contract testing, this will be the URI of a simulated streaming endpoint that the test harness provides. If it is null or an empty string, the SDK should connect to the real LaunchDarkly streaming service.
+    * `initialRetryDelayMs` (number, optional): The initial stream retry delay in milliseconds. If omitted, use the SDK's default value.
   * `events` (object, optional): Enables events and provides events configuration, or disables events if it is omitted or null. Properties are:
     * `baseUri` (string, optional): The base URI for the events service. For contract testing, this will be the URI of a simulated event-recorder endpoint that the test harness provides. If it is null or an empty string, the SDK should connect to the real LaunchDarkly events service.
     * `capacity` (number, optional): If specified and greater than zero, the event buffer capacity should be set to this value.

--- a/framework/harness/mock_endpoints.go
+++ b/framework/harness/mock_endpoints.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"io/ioutil"
 	"net/http"
+	"net/url"
 	"strconv"
 	"strings"
 	"sync"
@@ -50,8 +51,10 @@ type MockEndpoint struct {
 type IncomingRequestInfo struct {
 	Headers http.Header
 	Method  string
+	URL     url.URL
 	Body    []byte
 	Context context.Context
+	Cancel  context.CancelFunc
 }
 
 func newMockEndpointsManager(externalBaseURL string, logger framework.Logger) *mockEndpointsManager {
@@ -140,8 +143,10 @@ func (m *mockEndpointsManager) serveHTTP(w http.ResponseWriter, r *http.Request)
 	incoming := &IncomingRequestInfo{
 		Headers: r.Header,
 		Method:  r.Method,
+		URL:     url,
 		Body:    body,
 		Context: ctx,
+		Cancel:  canceller,
 	}
 
 	e.lock.Lock()

--- a/framework/harness/test_service.go
+++ b/framework/harness/test_service.go
@@ -215,6 +215,7 @@ func (e *TestServiceEntity) SendCommandWithParams(
 		if err = json.Unmarshal(body, responseOut); err != nil {
 			return err
 		}
+		logger.Printf("Response: %s", string(body))
 	}
 	return nil
 }

--- a/mockld/sdk_data.go
+++ b/mockld/sdk_data.go
@@ -161,3 +161,10 @@ func (b *ServerSDKDataBuilder) RawSegment(key string, data json.RawMessage) *Ser
 	b.segments[key] = data
 	return b
 }
+
+func (b *ServerSDKDataBuilder) Segment(segments ...ldmodel.Segment) *ServerSDKDataBuilder {
+	for _, segment := range segments {
+		b = b.RawSegment(segment.Key, jsonhelpers.ToJSON(segment))
+	}
+	return b
+}

--- a/mockld/streaming_service_test.go
+++ b/mockld/streaming_service_test.go
@@ -27,7 +27,7 @@ func TestStreamingServiceServerSide(t *testing.T) {
 
 	initialData := EmptyServerSDKData()
 
-	service := NewStreamingService(sdkKey, initialData, testLog.Loggers.ForLevel(ldlog.Debug))
+	service := NewStreamingService(initialData, testLog.Loggers.ForLevel(ldlog.Debug))
 
 	httphelpers.WithServer(service, func(server *httptest.Server) {
 		endpointURL := server.URL + "/all"

--- a/sdktests/custom_matchers.go
+++ b/sdktests/custom_matchers.go
@@ -48,6 +48,19 @@ func EvalResponseReason() m.MatcherTransform {
 		EnsureInputValueType(servicedef.EvaluateFlagResponse{})
 }
 
+func EvalAllFlagsStateMap() m.MatcherTransform {
+	return m.Transform(
+		"result reason",
+		func(value interface{}) (interface{}, error) {
+			return value.(servicedef.EvaluateAllFlagsResponse).State, nil
+		}).
+		EnsureInputValueType(servicedef.EvaluateAllFlagsResponse{})
+}
+
+func EvalAllFlagsValueForKeyShouldEqual(key string, value ldvalue.Value) m.Matcher {
+	return EvalAllFlagsStateMap().Should(m.ValueForKey(key).Should(m.JSONEqual(value)))
+}
+
 func CanonicalizedEventJSON() m.MatcherTransform {
 	return m.Transform(
 		"event",

--- a/sdktests/helpers.go
+++ b/sdktests/helpers.go
@@ -3,16 +3,51 @@ package sdktests
 import (
 	"encoding/json"
 	"fmt"
+	"time"
 
+	"github.com/launchdarkly/sdk-test-harness/framework/harness"
 	"github.com/launchdarkly/sdk-test-harness/framework/ldtest"
 	"github.com/launchdarkly/sdk-test-harness/mockld"
 	"github.com/launchdarkly/sdk-test-harness/servicedef"
+
+	"gopkg.in/launchdarkly/go-sdk-common.v2/ldtime"
+	"gopkg.in/launchdarkly/go-sdk-common.v2/lduser"
 	"gopkg.in/launchdarkly/go-sdk-common.v2/ldvalue"
+	"gopkg.in/launchdarkly/go-server-sdk-evaluation.v1/ldbuilders"
 	"gopkg.in/launchdarkly/go-server-sdk-evaluation.v1/ldmodel"
+
+	"github.com/stretchr/testify/require"
 )
 
 var dummyValue0, dummyValue1, dummyValue2, dummyValue3 ldvalue.Value = ldvalue.String("a"), //nolint:gochecknoglobals
 	ldvalue.String("b"), ldvalue.String("c"), ldvalue.String("d")
+
+func basicEvaluateFlag(
+	t *ldtest.T,
+	client *SDKClient,
+	flagKey string,
+	user lduser.User,
+	defaultValue ldvalue.Value,
+) ldvalue.Value {
+	result := client.EvaluateFlag(t, servicedef.EvaluateFlagParams{
+		FlagKey:      flagKey,
+		User:         &user,
+		ValueType:    servicedef.ValueTypeAny,
+		DefaultValue: defaultValue,
+	})
+	return result.Value
+}
+
+func expectNoMoreRequests(t *ldtest.T, endpoint *harness.MockEndpoint) {
+	_, err := endpoint.AwaitConnection(time.Millisecond * 100)
+	require.Error(t, err, "did not expect another request, but got one")
+}
+
+func expectRequest(t *ldtest.T, endpoint *harness.MockEndpoint, timeout time.Duration) harness.IncomingRequestInfo {
+	request, err := endpoint.AwaitConnection(timeout)
+	require.NoError(t, err, "timed out waiting for request")
+	return request
+}
 
 func getValueTypesToTest(t *ldtest.T) []servicedef.ValueType {
 	// For strongly-typed SDKs, make sure we test each of the typed Variation methods to prove
@@ -52,6 +87,71 @@ func inferDefaultFromFlag(sdkData mockld.ServerSDKData, flagKey string) ldvalue.
 	default:
 		return ldvalue.Null()
 	}
+}
+
+func makeFlagToCheckSegmentMatch(
+	flagKey string,
+	segmentKey string,
+	valueIfNotIncluded, valueIfIncluded ldvalue.Value,
+) ldmodel.FeatureFlag {
+	return ldbuilders.NewFlagBuilder(flagKey).Version(1).
+		On(true).FallthroughVariation(0).Variations(valueIfNotIncluded, valueIfIncluded).
+		AddRule(ldbuilders.NewRuleBuilder().Variation(1).Clauses(
+			ldbuilders.Clause("", ldmodel.OperatorSegmentMatch, ldvalue.String(segmentKey)),
+		)).
+		Build()
+}
+
+func makeFlagVersionsWithValues(key string, version1, version2 int, value1, value2 ldvalue.Value) (
+	ldmodel.FeatureFlag, ldmodel.FeatureFlag) {
+	flag1 := ldbuilders.NewFlagBuilder(key).Version(version1).
+		On(false).OffVariation(0).Variations(value1, value2).Build()
+	flag2 := ldbuilders.NewFlagBuilder(key).Version(version2).
+		On(false).OffVariation(1).Variations(value1, value2).Build()
+	return flag1, flag2
+}
+
+func checkForUpdatedValue(
+	t *ldtest.T,
+	client *SDKClient,
+	flagKey string,
+	user lduser.User,
+	previousValue ldvalue.Value,
+	updatedValue ldvalue.Value,
+	defaultValue ldvalue.Value,
+) func() bool {
+	return func() bool {
+		actualValue := basicEvaluateFlag(t, client, flagKey, user, defaultValue)
+		if actualValue.Equal(updatedValue) {
+			return true
+		}
+		if !actualValue.Equal(previousValue) {
+			require.Fail(t, "SDK returned neither previous value nor updated value",
+				"previous: %s, updated: %s, actual: %s", previousValue, updatedValue, actualValue)
+		}
+		return false
+	}
+}
+
+func pollUntilFlagValueUpdated(
+	t *ldtest.T,
+	client *SDKClient,
+	flagKey string,
+	user lduser.User,
+	previousValue ldvalue.Value,
+	updatedValue ldvalue.Value,
+	defaultValue ldvalue.Value,
+) {
+	// We can't assume that the SDK will immediately apply the new flag data as soon as it has
+	// reconnected, so we have to poll till the new data shows up
+	require.Eventually(
+		t,
+		checkForUpdatedValue(t, client, flagKey, user, previousValue, updatedValue, defaultValue),
+		time.Second, time.Millisecond*50, "timed out without seeing updated flag value")
+}
+
+func timeValueAsPointer(value ldtime.UnixMillisecondTime) *ldtime.UnixMillisecondTime {
+	return &value
 }
 
 func testDescFromType(valueType servicedef.ValueType) string {

--- a/sdktests/server_side_data_store_updates.go
+++ b/sdktests/server_side_data_store_updates.go
@@ -1,0 +1,225 @@
+package sdktests
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/launchdarkly/go-test-helpers/v2/jsonhelpers"
+	m "github.com/launchdarkly/go-test-helpers/v2/matchers"
+	"github.com/launchdarkly/sdk-test-harness/framework/ldtest"
+	"github.com/launchdarkly/sdk-test-harness/mockld"
+	"github.com/launchdarkly/sdk-test-harness/servicedef"
+
+	"gopkg.in/launchdarkly/go-sdk-common.v2/lduser"
+	"gopkg.in/launchdarkly/go-sdk-common.v2/ldvalue"
+	"gopkg.in/launchdarkly/go-server-sdk-evaluation.v1/ldbuilders"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func doServerSideDataStoreStreamUpdateTests(t *ldtest.T) {
+	// These tests verify that the SDK's default data store correctly implements updates and
+	// deletes with versioning.
+	//
+	// Since our mechanism for putting updates into the SDK is our stream test fixture, these
+	// tests also verify that the stream is working correctly.
+
+	flagKey := "flagkey"
+	segmentKey := "segment-key"
+	versionBefore := 100
+	valueBefore := ldvalue.String("valueBefore")
+	valueAfter := ldvalue.String("valueAfter")
+	defaultValue := ldvalue.String("defaultValue")
+	user := lduser.NewUser("user-key")
+
+	versionDeltaDesc := func(delta int) string {
+		switch {
+		case delta < 0:
+			return "lower version"
+		case delta > 0:
+			return "higher version"
+		default:
+			return "same version"
+		}
+	}
+
+	isAppliedDesc := func(b bool) string {
+		if b {
+			return "is applied"
+		}
+		return "is not applied"
+	}
+
+	for _, isDelete := range []bool{false, true} {
+		operationDesc := "patch"
+		if isDelete {
+			operationDesc = "delete"
+		}
+
+		for _, versionDelta := range []int{1, 0, -1} {
+			versionAfter := versionBefore + versionDelta
+			shouldApply := versionDelta > 0
+
+			flagTestDesc := fmt.Sprintf("flag %s with %s %s",
+				operationDesc, versionDeltaDesc(versionDelta), isAppliedDesc(shouldApply))
+
+			t.Run(flagTestDesc, func(t *ldtest.T) {
+				flagBefore, flagAfter := makeFlagVersionsWithValues(flagKey, versionBefore, versionAfter, valueBefore, valueAfter)
+				dataBefore := mockld.NewServerSDKDataBuilder().Flag(flagBefore).Build()
+				stream := NewSDKDataSource(t, dataBefore)
+				client := NewSDKClient(t, stream)
+
+				actualValue1 := basicEvaluateFlag(t, client, flagKey, user, defaultValue)
+				m.In(t).Assert(actualValue1, m.JSONEqual(valueBefore))
+
+				if isDelete {
+					stream.Service().PushDelete("flags", flagKey, versionAfter)
+				} else {
+					stream.Service().PushUpdate("flags", flagKey, jsonhelpers.ToJSON(flagAfter))
+				}
+
+				expectedValueIfUpdated := valueAfter
+				if isDelete {
+					expectedValueIfUpdated = defaultValue
+				}
+
+				if shouldApply {
+					pollUntilFlagValueUpdated(t, client, flagKey, user, valueBefore, expectedValueIfUpdated, defaultValue)
+				} else {
+					require.Never(
+						t,
+						checkForUpdatedValue(t, client, flagKey, user, valueBefore, expectedValueIfUpdated, defaultValue),
+						time.Millisecond*100,
+						time.Millisecond*20,
+						"flag value was updated, but it should not have been",
+					)
+				}
+
+				allFlags := client.EvaluateAllFlags(t, servicedef.EvaluateAllFlagsParams{User: &user})
+				if shouldApply {
+					if isDelete {
+						assert.NotContains(t, allFlags.State, flagKey)
+					} else {
+						m.In(t).Assert(allFlags, EvalAllFlagsValueForKeyShouldEqual(flagKey, expectedValueIfUpdated))
+					}
+				} else {
+					m.In(t).Assert(allFlags, EvalAllFlagsValueForKeyShouldEqual(flagKey, valueBefore))
+				}
+			})
+
+			segmentTestDesc := fmt.Sprintf("segment %s with %s %s",
+				operationDesc, versionDeltaDesc(versionDelta), isAppliedDesc(shouldApply))
+
+			t.Run(segmentTestDesc, func(t *ldtest.T) {
+				segmentBefore := ldbuilders.NewSegmentBuilder(segmentKey).Version(versionBefore).
+					Included(user.GetKey()).Build()
+				segmentAfter := ldbuilders.NewSegmentBuilder(segmentKey).Version(versionAfter).
+					Build() // user is not included in segmentAfter
+
+				// Configure this flag so that if the user is included in the segment, it returns variation 0
+				// (valueBefore); otherwise it returns variation 1 (valueAfter).
+				flag := makeFlagToCheckSegmentMatch(flagKey, segmentKey, valueAfter, valueBefore)
+
+				dataBefore := mockld.NewServerSDKDataBuilder().Flag(flag).Segment(segmentBefore).Build()
+				stream := NewSDKDataSource(t, dataBefore)
+				client := NewSDKClient(t, stream)
+
+				actualValue1 := basicEvaluateFlag(t, client, flagKey, user, ldvalue.Null())
+				m.In(t).Assert(actualValue1, m.JSONEqual(valueBefore))
+
+				if isDelete {
+					stream.Service().PushDelete("segments", segmentKey, versionAfter)
+				} else {
+					stream.Service().PushUpdate("segments", segmentKey, jsonhelpers.ToJSON(segmentAfter))
+				}
+
+				// If we successfully delete the segment, the effect is the same as if we had updated the
+				// segment to not include the user. SDKs should treat "segment not found" as equivalent to
+				// "user not included in segment"; they should _not_ treat this as an error that would
+				// make the flag return a default value.
+				expectedValueIfUpdated := valueAfter
+
+				if shouldApply {
+					pollUntilFlagValueUpdated(t, client, flagKey, user, valueBefore, valueAfter, defaultValue)
+				} else {
+					require.Never(
+						t,
+						checkForUpdatedValue(t, client, flagKey, user, valueBefore, expectedValueIfUpdated, defaultValue),
+						time.Millisecond*100,
+						time.Millisecond*20,
+						"flag value was updated, but it should not have been",
+					)
+				}
+
+				// Note that we can't directly test for the existence of a segment, as we can test for the
+				// existence of a flag, because segments aren't surfaced at all in the SDK API.
+			})
+		}
+
+		t.Run(fmt.Sprintf("flag %s for previously nonexistent flag is applied", operationDesc), func(t *ldtest.T) {
+			version := 100
+			flag := ldbuilders.NewFlagBuilder(flagKey).Version(100).
+				On(false).OffVariation(0).Variations(valueAfter).Build()
+
+			stream := NewSDKDataSource(t, mockld.EmptyServerSDKData())
+			client := NewSDKClient(t, stream)
+
+			actualValue1 := basicEvaluateFlag(t, client, flagKey, user, defaultValue)
+			m.In(t).Assert(actualValue1, m.JSONEqual(defaultValue))
+
+			if isDelete {
+				stream.Service().PushDelete("flags", flagKey, version)
+
+				// A delete for an unknown flag should be persisted by the SDK so it knows this version was
+				// deleted. A subsequent update for the same flag with an equal or lower version should be ignored.
+				stream.Service().PushUpdate("flags", flagKey, jsonhelpers.ToJSON(flag))
+				require.Never(
+					t,
+					checkForUpdatedValue(t, client, flagKey, user, defaultValue, valueAfter, defaultValue),
+					time.Millisecond*100,
+					time.Millisecond*20,
+					"flag update after deletion should have been ignored due to version; deletion was not persisted",
+				)
+			} else {
+				stream.Service().PushUpdate("flags", flagKey, jsonhelpers.ToJSON(flag))
+
+				pollUntilFlagValueUpdated(t, client, flagKey, user, defaultValue, valueAfter, defaultValue)
+			}
+		})
+
+		t.Run(fmt.Sprintf("segment %s for previously nonexistent segment is applied", operationDesc), func(t *ldtest.T) {
+			version := 100
+			segment := ldbuilders.NewSegmentBuilder(segmentKey).Version(version).
+				Included(user.GetKey()).Build()
+			flag := makeFlagToCheckSegmentMatch(flagKey, segmentKey, valueBefore, valueAfter)
+
+			dataBefore := mockld.NewServerSDKDataBuilder().Flag(flag).Build() // data does *not* include segment yet
+			stream := NewSDKDataSource(t, dataBefore)
+			client := NewSDKClient(t, stream)
+
+			actualValue1 := basicEvaluateFlag(t, client, flagKey, user, ldvalue.Null())
+			m.In(t).Assert(actualValue1, m.JSONEqual(valueBefore))
+
+			if isDelete {
+				stream.Service().PushDelete("segments", segmentKey, version)
+
+				// A delete for an unknown segment should be persisted by the SDK so it knows this version was
+				// deleted. A subsequent update for the same segment with an equal or lower version should be ignored.
+				stream.Service().PushUpdate("segments", segmentKey, jsonhelpers.ToJSON(segment))
+				require.Never(
+					t,
+					checkForUpdatedValue(t, client, flagKey, user, valueBefore, valueAfter, defaultValue),
+					time.Millisecond*100,
+					time.Millisecond*20,
+					"segment update after deletion should have been ignored due to version; deletion was not persisted",
+				)
+			} else {
+				stream.Service().PushUpdate("segments", segmentKey, jsonhelpers.ToJSON(segment))
+
+				// Now that the segment exists, the flag should return the "after" value
+				pollUntilFlagValueUpdated(t, client, flagKey, user, valueBefore, valueAfter, defaultValue)
+			}
+		})
+	}
+}

--- a/sdktests/server_side_eval.go
+++ b/sdktests/server_side_eval.go
@@ -85,7 +85,7 @@ func RunParameterizedServerSideClientNotReadyEvalTests(t *ldtest.T) {
 
 	dataSource := NewSDKDataSource(t, mockld.BlockingUnavailableSDKData(mockld.ServerSideSDK))
 	client := NewSDKClient(t,
-		WithConfig(servicedef.SDKConfigParams{StartWaitTimeMS: 1, TimeoutOK: true}),
+		WithConfig(servicedef.SDKConfigParams{StartWaitTimeMS: 1, InitCanFail: true}),
 		dataSource)
 
 	for _, valueType := range getValueTypesToTest(t) {

--- a/sdktests/server_side_eval_all_flags.go
+++ b/sdktests/server_side_eval_all_flags.go
@@ -298,7 +298,7 @@ func doServerSideAllFlagsDetailsOnlyForTrackedFlagsTest(t *ldtest.T) {
 func doServerSideAllFlagsClientNotReadyTest(t *ldtest.T) {
 	dataSource := NewSDKDataSource(t, mockld.BlockingUnavailableSDKData(mockld.ServerSideSDK))
 	client := NewSDKClient(t,
-		WithConfig(servicedef.SDKConfigParams{StartWaitTimeMS: 1, TimeoutOK: true}),
+		WithConfig(servicedef.SDKConfigParams{StartWaitTimeMS: 1, InitCanFail: true}),
 		dataSource)
 	user := lduser.NewUser("user-key")
 

--- a/sdktests/server_side_events_buffer.go
+++ b/sdktests/server_side_events_buffer.go
@@ -17,7 +17,7 @@ func doServerSideEventBufferTests(t *ldtest.T) {
 	capacity := 20
 	extraItemsOverCapacity := 3 // arbitrary non-zero value for how many events to try to add past the limit
 	eventsConfig := baseEventsConfig()
-	eventsConfig.Capacity = capacity
+	eventsConfig.Capacity = ldvalue.NewOptionalInt(capacity)
 
 	userFactory := NewUserFactory("doServerSideEventCapacityTests",
 		func(b lduser.UserBuilder) { b.Name("my favorite user") })

--- a/sdktests/server_side_stream_request.go
+++ b/sdktests/server_side_stream_request.go
@@ -1,0 +1,52 @@
+package sdktests
+
+import (
+	"strings"
+	"time"
+
+	"github.com/launchdarkly/sdk-test-harness/framework/ldtest"
+	"github.com/launchdarkly/sdk-test-harness/mockld"
+	"github.com/launchdarkly/sdk-test-harness/servicedef"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func doServerSideStreamRequestTests(t *ldtest.T) {
+	t.Run("headers", func(t *ldtest.T) {
+		sdkKey := "my-sdk-key"
+
+		dataSource := NewSDKDataSource(t, mockld.EmptyServerSDKData())
+		_ = NewSDKClient(t, WithConfig(servicedef.SDKConfigParams{
+			Credential: sdkKey,
+		}), dataSource)
+
+		request := expectRequest(t, dataSource.Endpoint(), time.Second)
+
+		assert.Equal(t, sdkKey, request.Headers.Get("Authorization"))
+		assert.NotEqual(t, sdkKey, request.Headers.Get("User-Agent"))
+	})
+
+	t.Run("URL path is correct when base URI has a trailing slash", func(t *ldtest.T) {
+		dataSource := NewSDKDataSource(t, mockld.EmptyServerSDKData())
+		_ = NewSDKClient(t, WithConfig(servicedef.SDKConfigParams{
+			Streaming: &servicedef.SDKConfigStreamingParams{
+				BaseURI: strings.TrimSuffix(dataSource.Endpoint().BaseURL(), "/") + "/",
+			},
+		}))
+
+		request := expectRequest(t, dataSource.Endpoint(), time.Second)
+		assert.Equal(t, "/all", request.URL.Path)
+	})
+
+	t.Run("URL path is correct when base URI has no trailing slash", func(t *ldtest.T) {
+		dataSource := NewSDKDataSource(t, mockld.EmptyServerSDKData())
+		_ = NewSDKClient(t, WithConfig(servicedef.SDKConfigParams{
+			Streaming: &servicedef.SDKConfigStreamingParams{
+				BaseURI: strings.TrimSuffix(dataSource.Endpoint().BaseURL(), "/"),
+			},
+		}))
+
+		request := expectRequest(t, dataSource.Endpoint(), time.Second)
+		assert.Equal(t, "/all", request.URL.Path)
+	})
+}

--- a/sdktests/server_side_stream_retry.go
+++ b/sdktests/server_side_stream_retry.go
@@ -1,0 +1,256 @@
+package sdktests
+
+import (
+	"fmt"
+	"net/http"
+	"time"
+
+	"github.com/launchdarkly/sdk-test-harness/framework/harness"
+	"github.com/launchdarkly/sdk-test-harness/framework/ldtest"
+	"github.com/launchdarkly/sdk-test-harness/mockld"
+	"github.com/launchdarkly/sdk-test-harness/servicedef"
+
+	"github.com/launchdarkly/go-test-helpers/v2/httphelpers"
+	m "github.com/launchdarkly/go-test-helpers/v2/matchers"
+	"gopkg.in/launchdarkly/go-sdk-common.v2/ldtime"
+	"gopkg.in/launchdarkly/go-sdk-common.v2/lduser"
+	"gopkg.in/launchdarkly/go-sdk-common.v2/ldvalue"
+)
+
+const briefDelay ldtime.UnixMillisecondTime = 1
+
+func baseStreamConfig(endpoint *harness.MockEndpoint) *servicedef.SDKConfigStreamingParams {
+	return &servicedef.SDKConfigStreamingParams{
+		BaseURI:             endpoint.BaseURL(),
+		InitialRetryDelayMs: timeValueAsPointer(briefDelay),
+	}
+}
+
+func doServerSideStreamRetryTests(t *ldtest.T) {
+	recoverableErrors := []int{400, 408, 429, 500, 503}
+	unrecoverableErrors := []int{401, 403, 405} // really all 4xx errors that aren't 400, 408, or 429
+
+	expectedValueV1 := ldvalue.Int(1)
+	expectedValueV2 := ldvalue.Int(2)
+	flagKey := "flag"
+	flagV1, flagV2 := makeFlagVersionsWithValues(flagKey, 1, 2, expectedValueV1, expectedValueV2)
+	dataV1 := mockld.NewServerSDKDataBuilder().Flag(flagV1).Build()
+	dataV2 := mockld.NewServerSDKDataBuilder().Flag(flagV2).Build()
+	user := lduser.NewUser("user-key")
+
+	t.Run("retry after stream is closed", func(t *ldtest.T) {
+		stream1 := NewSDKDataSourceWithoutEndpoint(t, dataV1)
+		stream2 := NewSDKDataSourceWithoutEndpoint(t, dataV2)
+		handler := httphelpers.SequentialHandler(
+			stream1.Handler(), // first request gets the first stream data
+			stream2.Handler(), // second request gets the second stream data
+		)
+		streamEndpoint := requireContext(t).harness.NewMockEndpoint(handler, nil, t.DebugLogger())
+		t.Defer(streamEndpoint.Close)
+
+		client := NewSDKClient(t,
+			WithConfig(servicedef.SDKConfigParams{
+				Streaming: baseStreamConfig(streamEndpoint),
+			}),
+		)
+		result := client.EvaluateAllFlags(t, servicedef.EvaluateAllFlagsParams{User: &user})
+		m.In(t).Assert(result, EvalAllFlagsValueForKeyShouldEqual(flagKey, expectedValueV1))
+
+		// Get the request info for the first request
+		request1 := expectRequest(t, streamEndpoint, time.Second*5)
+
+		// Now cause the stream to close; this should trigger a reconnect
+		request1.Cancel()
+
+		// Expect the second request; it succeeds and gets the second stream data
+		expectRequest(t, streamEndpoint, time.Millisecond*100)
+
+		// Check that the client got the new data from the second stream
+		pollUntilFlagValueUpdated(t, client, flagKey, user, expectedValueV1, expectedValueV2, ldvalue.Null())
+	})
+
+	t.Run("initial retry delay is applied", func(t *ldtest.T) {
+		// Since execution time in a test environment is highly unpredictable, we can't really make
+		// expectations about seeing specific retry delays. But we can at least verify that if we set
+		// the initial delay to a very large value, we should not see a reconnection attempt within a
+		// short time.
+
+		stream := NewSDKDataSource(t, dataV1)
+		client := NewSDKClient(t,
+			WithConfig(servicedef.SDKConfigParams{
+				Streaming: &servicedef.SDKConfigStreamingParams{
+					InitialRetryDelayMs: timeValueAsPointer(10000),
+				},
+			}),
+			stream,
+		)
+		result := client.EvaluateAllFlags(t, servicedef.EvaluateAllFlagsParams{User: &user})
+		m.In(t).Assert(result, EvalAllFlagsValueForKeyShouldEqual(flagKey, expectedValueV1))
+
+		// Get the request info for the first request
+		request1 := expectRequest(t, stream.Endpoint(), time.Second*5)
+
+		// Now cause the stream to close; this should trigger a reconnect
+		request1.Cancel()
+
+		// We set the initial delay to 10 seconds (which, due to our subtractive jitter behavior,
+		// means it should be between 5 and 10 seconds), so we should definitely not see another
+		// connection attempt within 100 ms.
+		//
+		// Note that if the SDK configuration options were just not working, so that it was
+		// impossible to change the initial retry delay and it remained at its default value of
+		// 1 second (which is really 500-1000ms), then this test would still pass because 100ms
+		// is too short a timeout. But in that case, the other tests in this file would fail,
+		// since they set a very short retry delay and expect to see connections in much less
+		// than 500ms. So, the failure condition we're really checking for here is "the SDK does
+		// not do a delay at all, it retries immediately".
+		expectNoMoreRequests(t, stream.Endpoint())
+	})
+
+	shouldRetryAfterErrorOnInitialConnect := func(t *ldtest.T, errorHandler http.Handler) {
+		stream := NewSDKDataSourceWithoutEndpoint(t, dataV1)
+		handler := httphelpers.SequentialHandler(
+			errorHandler,     // first request gets the error
+			errorHandler,     // second request also gets the error
+			stream.Handler(), // third request succeeds and gets the stream
+		)
+		streamEndpoint := requireContext(t).harness.NewMockEndpoint(handler, nil, t.DebugLogger())
+		t.Defer(streamEndpoint.Close)
+
+		client := NewSDKClient(t,
+			WithConfig(servicedef.SDKConfigParams{
+				Streaming: baseStreamConfig(streamEndpoint),
+			}),
+		)
+		result := client.EvaluateAllFlags(t, servicedef.EvaluateAllFlagsParams{User: &user})
+		m.In(t).Assert(result, EvalAllFlagsValueForKeyShouldEqual(flagKey, expectedValueV1))
+
+		for i := 0; i < 3; i++ { // expect three requests
+			expectRequest(t, streamEndpoint, time.Second*5)
+		}
+
+		expectNoMoreRequests(t, streamEndpoint)
+	}
+
+	t.Run("retry after I/O error on initial connect", func(t *ldtest.T) {
+		shouldRetryAfterErrorOnInitialConnect(t, httphelpers.BrokenConnectionHandler())
+	})
+
+	t.Run("retry after recoverable HTTP error on initial connect", func(t *ldtest.T) {
+		for _, status := range recoverableErrors {
+			t.Run(fmt.Sprintf("error %d", status), func(t *ldtest.T) {
+				shouldRetryAfterErrorOnInitialConnect(t, httphelpers.HandlerWithStatus(status))
+			})
+		}
+	})
+
+	shouldRetryAfterErrorOnReconnect := func(t *ldtest.T, errorHandler http.Handler) {
+		stream1 := NewSDKDataSourceWithoutEndpoint(t, dataV1)
+		stream2 := NewSDKDataSourceWithoutEndpoint(t, dataV2)
+		handler := httphelpers.SequentialHandler(
+			stream1.Handler(), // first request gets the first stream data
+			errorHandler,      // second request gets the error
+			errorHandler,      // third request also gets the error
+			stream2.Handler(), // fourth request gets the second stream data
+		)
+		streamEndpoint := requireContext(t).harness.NewMockEndpoint(handler, nil, t.DebugLogger())
+		t.Defer(streamEndpoint.Close)
+
+		client := NewSDKClient(t,
+			WithConfig(servicedef.SDKConfigParams{
+				Streaming: baseStreamConfig(streamEndpoint),
+			}),
+		)
+		result := client.EvaluateAllFlags(t, servicedef.EvaluateAllFlagsParams{User: &user})
+		m.In(t).Assert(result, EvalAllFlagsValueForKeyShouldEqual(flagKey, expectedValueV1))
+
+		// Get the request info for the first request
+		request1 := expectRequest(t, streamEndpoint, time.Second*5)
+
+		// Now cause the stream to close; this should trigger a reconnect
+		request1.Cancel()
+
+		// Expect the second request; it will receive an error, causing another attempt
+		_ = expectRequest(t, streamEndpoint, time.Millisecond*100)
+
+		// Expect the third request; it will also receive an error, causing another attempt
+		_ = expectRequest(t, streamEndpoint, time.Millisecond*100)
+
+		// expect the fourth request; this one succeeds and gets the second stream data
+		_ = expectRequest(t, streamEndpoint, time.Millisecond*100)
+
+		// check that the client got the new data from the second stream
+		pollUntilFlagValueUpdated(t, client, flagKey, user, expectedValueV1, expectedValueV2, ldvalue.Null())
+	}
+
+	t.Run("retry after I/O error on reconnect", func(t *ldtest.T) {
+		shouldRetryAfterErrorOnReconnect(t, httphelpers.BrokenConnectionHandler())
+	})
+
+	t.Run("retry after recoverable HTTP error on reconnect", func(t *ldtest.T) {
+		for _, status := range recoverableErrors {
+			t.Run(fmt.Sprintf("error %d", status), func(t *ldtest.T) {
+				shouldRetryAfterErrorOnReconnect(t, httphelpers.HandlerWithStatus(status))
+			})
+		}
+	})
+
+	t.Run("do not retry after unrecoverable HTTP error on initial connect", func(t *ldtest.T) {
+		for _, status := range unrecoverableErrors {
+			t.Run(fmt.Sprintf("error %d", status), func(t *ldtest.T) {
+				stream := NewSDKDataSourceWithoutEndpoint(t, dataV1)
+				handler := httphelpers.SequentialHandler(
+					httphelpers.HandlerWithStatus(status), // first request gets the error
+					stream.Handler(),                      // second request would succeed and get the stream, but shouldn't happen
+				)
+				streamEndpoint := requireContext(t).harness.NewMockEndpoint(handler, nil, t.DebugLogger())
+				t.Defer(streamEndpoint.Close)
+
+				_ = NewSDKClient(t,
+					WithConfig(servicedef.SDKConfigParams{
+						InitCanFail: true,
+						Streaming:   baseStreamConfig(streamEndpoint),
+					}),
+				)
+
+				_ = expectRequest(t, streamEndpoint, time.Second*5)
+
+				expectNoMoreRequests(t, streamEndpoint)
+			})
+		}
+	})
+
+	t.Run("do not retry after unrecoverable HTTP error on reconnect", func(t *ldtest.T) {
+		for _, status := range unrecoverableErrors {
+			t.Run(fmt.Sprintf("error %d", status), func(t *ldtest.T) {
+				stream := NewSDKDataSourceWithoutEndpoint(t, dataV1)
+				handler := httphelpers.SequentialHandler(
+					stream.Handler(),                      // first request gets the stream data
+					httphelpers.HandlerWithStatus(status), // second request gets the error
+					stream.Handler(),                      // third request would get the stream again, but shouldn't happen
+				)
+				streamEndpoint := requireContext(t).harness.NewMockEndpoint(handler, nil, t.DebugLogger())
+				t.Defer(streamEndpoint.Close)
+
+				client := NewSDKClient(t,
+					WithConfig(servicedef.SDKConfigParams{
+						Streaming: baseStreamConfig(streamEndpoint),
+					}),
+				)
+				result := client.EvaluateAllFlags(t, servicedef.EvaluateAllFlagsParams{User: &user})
+				m.In(t).Assert(result, EvalAllFlagsValueForKeyShouldEqual(flagKey, expectedValueV1))
+
+				// get the request info for the first request
+				request1 := expectRequest(t, streamEndpoint, time.Second*5)
+
+				// now cause the stream to close; this should trigger a reconnect
+				request1.Cancel()
+
+				// expect the second request; it will receive an error
+				_ = expectRequest(t, streamEndpoint, time.Millisecond*100)
+
+				expectNoMoreRequests(t, streamEndpoint)
+			})
+		}
+	})
+}

--- a/sdktests/server_side_stream_validation.go
+++ b/sdktests/server_side_stream_validation.go
@@ -1,0 +1,129 @@
+package sdktests
+
+import (
+	"encoding/json"
+	"time"
+
+	"github.com/launchdarkly/go-test-helpers/v2/httphelpers"
+	"github.com/launchdarkly/go-test-helpers/v2/jsonhelpers"
+	m "github.com/launchdarkly/go-test-helpers/v2/matchers"
+	"github.com/launchdarkly/sdk-test-harness/framework/ldtest"
+	"github.com/launchdarkly/sdk-test-harness/mockld"
+	"github.com/launchdarkly/sdk-test-harness/servicedef"
+	"gopkg.in/launchdarkly/go-sdk-common.v2/lduser"
+	"gopkg.in/launchdarkly/go-sdk-common.v2/ldvalue"
+)
+
+func doServerSideStreamValidationTests(t *ldtest.T) {
+	expectedValueV1 := ldvalue.Int(1)
+	expectedValueV2 := ldvalue.Int(2)
+	flagKey := "flag"
+	flagV1, flagV2 := makeFlagVersionsWithValues(flagKey, 1, 2, expectedValueV1, expectedValueV2)
+	dataV1 := mockld.NewServerSDKDataBuilder().Flag(flagV1).Build()
+	dataV2 := mockld.NewServerSDKDataBuilder().Flag(flagV2).Build()
+	user := lduser.NewUser("user-key")
+
+	shouldDropAndReconnectAfterEvent := func(t *ldtest.T, badEventName string, badEventData json.RawMessage) {
+		stream1 := NewSDKDataSourceWithoutEndpoint(t, dataV1)
+		stream2 := NewSDKDataSourceWithoutEndpoint(t, dataV2)
+		handler := httphelpers.SequentialHandler(
+			stream1.Handler(), // first request gets the first stream data
+			stream2.Handler(), // second request gets the second stream data
+		)
+		streamEndpoint := requireContext(t).harness.NewMockEndpoint(handler, nil, t.DebugLogger())
+		t.Defer(streamEndpoint.Close)
+
+		client := NewSDKClient(t,
+			WithConfig(servicedef.SDKConfigParams{
+				Streaming: baseStreamConfig(streamEndpoint),
+			}),
+		)
+		result := client.EvaluateAllFlags(t, servicedef.EvaluateAllFlagsParams{User: &user})
+		m.In(t).Assert(result, EvalAllFlagsValueForKeyShouldEqual(flagKey, expectedValueV1))
+
+		// Get & discard the request info for the first request
+		_ = expectRequest(t, streamEndpoint, time.Second*5)
+
+		// Send the bad event; this should cause the SDK to drop the first stream
+		stream1.Service().PushEvent(badEventName, badEventData)
+
+		// Expect the second request; it succeeds and gets the second stream data
+		_ = expectRequest(t, streamEndpoint, time.Millisecond*100)
+
+		// Check that the client got the new data from the second stream
+		pollUntilFlagValueUpdated(t, client, flagKey, user, expectedValueV1, expectedValueV2, ldvalue.Null())
+	}
+
+	t.Run("drop and reconnect if stream event has malformed JSON", func(t *ldtest.T) {
+		t.Run("put event", func(t *ldtest.T) {
+			shouldDropAndReconnectAfterEvent(t, "put", []byte(`{sorry`))
+		})
+
+		t.Run("patch event", func(t *ldtest.T) {
+			shouldDropAndReconnectAfterEvent(t, "patch", []byte(`{sorry`))
+		})
+
+		t.Run("delete event", func(t *ldtest.T) {
+			shouldDropAndReconnectAfterEvent(t, "delete", []byte(`{sorry`))
+		})
+	})
+
+	t.Run("drop and reconnect if stream event has well-formed JSON not matching schema", func(t *ldtest.T) {
+		t.Run("put event", func(t *ldtest.T) {
+			shouldDropAndReconnectAfterEvent(t, "put", []byte(`{"data":{"flags": true, "segments":{}}}`))
+		})
+
+		t.Run("patch event", func(t *ldtest.T) {
+			shouldDropAndReconnectAfterEvent(t, "patch", []byte(`{"path":"/flags/x","data":true}`))
+		})
+
+		t.Run("delete event", func(t *ldtest.T) {
+			shouldDropAndReconnectAfterEvent(t, "delete", []byte(`{"path":"/flags/x","version":"no"`))
+		})
+	})
+
+	shouldIgnoreEvent := func(t *ldtest.T, eventName string, eventData json.RawMessage) {
+		dataSource := NewSDKDataSource(t, dataV1)
+		client := NewSDKClient(t, WithConfig(servicedef.SDKConfigParams{
+			Streaming: &servicedef.SDKConfigStreamingParams{
+				InitialRetryDelayMs: timeValueAsPointer(briefDelay), // brief delay so we can easily detect if it reconnects
+			},
+		}), dataSource)
+
+		result := client.EvaluateAllFlags(t, servicedef.EvaluateAllFlagsParams{User: &user})
+		m.In(t).Assert(result, EvalAllFlagsValueForKeyShouldEqual(flagKey, expectedValueV1))
+
+		// Get & discard the request info for the first request
+		_ = expectRequest(t, dataSource.Endpoint(), time.Second*5)
+
+		// Push an event that isn't recognized, but isn't bad enough to cause any problems
+		dataSource.Service().PushEvent(eventName, eventData)
+
+		// Then, push a patch event, so we can detect if the SDK continued processing the stream as it should
+		dataSource.Service().PushUpdate("flags", flagKey, jsonhelpers.ToJSON(flagV2))
+
+		// Check that the client got the new data
+		pollUntilFlagValueUpdated(t, client, flagKey, user, expectedValueV1, expectedValueV2, ldvalue.Null())
+
+		// Verify that it did not reconnect
+		expectNoMoreRequests(t, dataSource.Endpoint())
+	}
+
+	t.Run("unrecognized data that can be safely ignored", func(t *ldtest.T) {
+		// SDKs are required to be tolerant of some kinds of unrecognized data, to leave room for future
+		// expansion.
+
+		t.Run("unknown event name with JSON body", func(t *ldtest.T) {
+			shouldIgnoreEvent(t, "whatever", []byte(`{}`))
+		})
+
+		t.Run("unknown event name with non-JSON body", func(t *ldtest.T) {
+			// The SDK shouldn't try to parse the data field at all for an unknown event type
+			shouldIgnoreEvent(t, "whatever", []byte(`not JSON`))
+		})
+
+		t.Run("patch event with unrecognized path kind", func(t *ldtest.T) {
+			shouldIgnoreEvent(t, "patch", []byte(`{"path": "/cats/Jack", "data": {}}`))
+		})
+	})
+}

--- a/sdktests/testapi_sdk_data.go
+++ b/sdktests/testapi_sdk_data.go
@@ -1,6 +1,8 @@
 package sdktests
 
 import (
+	"net/http"
+
 	"github.com/launchdarkly/sdk-test-harness/framework/harness"
 	"github.com/launchdarkly/sdk-test-harness/framework/ldtest"
 	"github.com/launchdarkly/sdk-test-harness/mockld"
@@ -10,6 +12,7 @@ import (
 // SDKDataSource is a test fixture that provides a callback endpoint for SDK clients to connect to,
 // simulating the LaunchDarkly streaming or polling service.
 type SDKDataSource struct {
+	streamingService  *mockld.StreamingService
 	streamingEndpoint *harness.MockEndpoint
 }
 
@@ -19,18 +22,46 @@ type SDKDataSource struct {
 // when this test scope exits. It can be reused by subtests until then. Debug output related to the
 // data source will be attached to this test scope.
 func NewSDKDataSource(t *ldtest.T, data mockld.SDKData) *SDKDataSource {
-	ss := mockld.NewStreamingService(defaultSDKKey, data, t.DebugLogger())
+	ss := mockld.NewStreamingService(data, t.DebugLogger())
 	streamingEndpoint := requireContext(t).harness.NewMockEndpoint(ss, nil, t.DebugLogger())
 	t.Defer(streamingEndpoint.Close)
 
 	t.Debug("setting SDK data to: %s", string(data.Serialize()))
 
-	return &SDKDataSource{streamingEndpoint: streamingEndpoint}
+	return &SDKDataSource{streamingService: ss, streamingEndpoint: streamingEndpoint}
 }
 
+// NewSDKDataSourceWithoutEndpoint is the same as NewSDKDataSource, but it does not allocate an
+// endpoint to accept incoming requests. Use this if you want to configure the endpoint separately,
+// for instance if you want it to delegate some requests to the data source but return an error
+// for some other requests.
+func NewSDKDataSourceWithoutEndpoint(t *ldtest.T, data mockld.SDKData) *SDKDataSource {
+	ss := mockld.NewStreamingService(data, t.DebugLogger())
+
+	t.Debug("setting SDK data to: %s", string(data.Serialize()))
+
+	return &SDKDataSource{streamingService: ss, streamingEndpoint: nil}
+}
+
+// Endpoint returns the low-level object that manages incoming requests.
+func (d *SDKDataSource) Endpoint() *harness.MockEndpoint { return d.streamingEndpoint }
+
+// Service returns the low-level object that manages the stream data.
+func (d *SDKDataSource) Service() *mockld.StreamingService { return d.streamingService }
+
+// Handler returns the HTTP handler for the stream. Since StreamingService implements http.Handler
+// already, this is the same as Service() but makes the purpose clearer.
+func (d *SDKDataSource) Handler() http.Handler { return d.streamingService }
+
 // ApplyConfiguration updates the SDK client configuration for NewSDKClient, causing the SDK
-// to connect to the appropriate base URI for the test fixture.
+// to connect to the appropriate base URI for the data source test fixture. This only works if
+// the data source was created along with its own endpoint, with NewSDKDataSource; if it was
+// created as a handler to be used in a separately configured endpoint, you have to set the
+// base URI in the test logic rather than using this shortcut.
 func (d *SDKDataSource) ApplyConfiguration(config *servicedef.SDKConfigParams) {
+	if d.streamingEndpoint == nil {
+		panic("Tried to use an SDKDataSource without its own endpoint as a parameter to NewSDKClient")
+	}
 	if config.Streaming == nil {
 		config.Streaming = &servicedef.SDKConfigStreamingParams{}
 	} else {

--- a/sdktests/testsuite_server_side.go
+++ b/sdktests/testsuite_server_side.go
@@ -26,9 +26,15 @@ func RunServerSideTestSuite(
 	}
 
 	return ldtest.Run(config, func(t *ldtest.T) {
+		t.Run("data store", doServerSideDataStoreTests)
 		t.Run("evaluation", DoServerSideEvalTests)
 		t.Run("events", doServerSideEventTests)
+		t.Run("streaming", doServerSideStreamTests)
 	})
+}
+
+func doServerSideDataStoreTests(t *ldtest.T) {
+	t.Run("updates from stream", doServerSideDataStoreStreamUpdateTests)
 }
 
 func doServerSideEventTests(t *ldtest.T) {
@@ -40,4 +46,10 @@ func doServerSideEventTests(t *ldtest.T) {
 	t.Run("alias events", doServerSideAliasEventTests)
 	t.Run("user properties", doServerSideEventUserTests)
 	t.Run("event capacity", doServerSideEventBufferTests)
+}
+
+func doServerSideStreamTests(t *ldtest.T) {
+	t.Run("requests", doServerSideStreamRequestTests)
+	t.Run("retry behavior", doServerSideStreamRetryTests)
+	t.Run("validation", doServerSideStreamValidationTests)
 }

--- a/servicedef/sdk_config.go
+++ b/servicedef/sdk_config.go
@@ -3,6 +3,7 @@ package servicedef
 import (
 	"gopkg.in/launchdarkly/go-sdk-common.v2/ldtime"
 	"gopkg.in/launchdarkly/go-sdk-common.v2/lduser"
+	"gopkg.in/launchdarkly/go-sdk-common.v2/ldvalue"
 )
 
 type SDKConfigParams struct {
@@ -20,7 +21,7 @@ type SDKConfigStreamingParams struct {
 
 type SDKConfigEventParams struct {
 	BaseURI                 string                     `json:"baseUri,omitempty"`
-	Capacity                int                        `json:"capacity,omitempty"`
+	Capacity                ldvalue.OptionalInt        `json:"capacity,omitempty"`
 	EnableDiagnostics       bool                       `json:"enableDiagnostics"`
 	AllAttributesPrivate    bool                       `json:"allAttributesPrivate,omitempty"`
 	GlobalPrivateAttributes []lduser.UserAttribute     `json:"globalPrivateAttributes,omitempty"`

--- a/servicedef/sdk_config.go
+++ b/servicedef/sdk_config.go
@@ -8,13 +8,14 @@ import (
 type SDKConfigParams struct {
 	Credential      string                     `json:"credential"`
 	StartWaitTimeMS ldtime.UnixMillisecondTime `json:"startWaitTimeMs,omitempty"`
-	TimeoutOK       bool                       `json:"timeoutOk,omitempty"`
+	InitCanFail     bool                       `json:"initCanFail,omitempty"`
 	Streaming       *SDKConfigStreamingParams  `json:"streaming,omitempty"`
 	Events          *SDKConfigEventParams      `json:"events,omitempty"`
 }
 
 type SDKConfigStreamingParams struct {
-	BaseURI string `json:"baseUri,omitempty"`
+	BaseURI             string                      `json:"baseUri,omitempty"`
+	InitialRetryDelayMs *ldtime.UnixMillisecondTime `json:"initialRetryDelayMs,omitempty"`
 }
 
 type SDKConfigEventParams struct {


### PR DESCRIPTION
This PR adds some more big areas of core functionality to the contract tests, including quite a few things that can't be done by integration-harness:

* General stream HTTP and retry behavior (see tasks in [sc-138807](https://app.shortcut.com/launchdarkly/story/138807/tests-for-stream-behavior))
* Updates are stored correctly with versioning when received from the stream ​(see [sc-138804](https://app.shortcut.com/launchdarkly/story/138804/tests-for-streaming-flag-updates))
* Summary event counters work correctly when there's more than one version of a flag (this was not included in the previous summary event tests, because it requires sending a stream update)

I believe sdk-test-harness's test coverage in these areas is now on par with the very thorough unit tests in the Go and Java SDKs, except in one area: it's not possible to _directly_ query user segments via the SDK API, so the tests for updating/deleting segments are done indirectly by evaluating a flag.

There are breaking changes to the test service API here, sorry:

* The name of the top-level config parameter `timeoutOk` was changed to `initCanFail`, since timeouts are not the only kind of initialization error we're testing now (it could also be a 401 error, for instance).
* There's also a new parameter in the streaming config section, `initialRetryDelayMs`.