### PR TITLE
implement big segments tests

### DIFF
--- a/docs/service_spec.md
+++ b/docs/service_spec.md
@@ -32,7 +32,7 @@ This means that the SDK's method for evaluating all flags at once has an option 
 
 This means that the SDK's method for evaluating all flags at once has an option for filtering the result to only include evaluation reason data if the SDK will need it for events (due to event tracking or debugging or an experiment).
 
-#### Capability `"big-segment"`
+#### Capability `"big-segments"`
 
 This means that the SDK supports Big Segments and can be configured with a custom Big Segment store.
 
@@ -196,7 +196,7 @@ The service supports the following requests. For simplicity and to ensure that H
 
 The test service should send this request when the SDK calls the method for getting store metadata. The request body is ignored. The response is a JSON object with these properties:
 
-* `lastUpToDate`: The epoch millisecond time that the simulated store was last updated.
+* `lastUpToDate` (number, required): The epoch millisecond time that the simulated store was last updated.
 
 #### Get user membership: `POST /getMembership`
 

--- a/docs/service_spec.md
+++ b/docs/service_spec.md
@@ -32,6 +32,12 @@ This means that the SDK's method for evaluating all flags at once has an option 
 
 This means that the SDK's method for evaluating all flags at once has an option for filtering the result to only include evaluation reason data if the SDK will need it for events (due to event tracking or debugging or an experiment).
 
+#### Capability `"big-segment"`
+
+This means that the SDK supports Big Segments and can be configured with a custom Big Segment store.
+
+For tests that involve Big Segments, the test harness will provide parameters in the `bigSegments` property of the configuration object, including a `callbackUri` that points to one of the test harness's callback services (see [Callback endpoints](#callback-endpoints)). The test service should configure the SDK with its own implementation of a Big Segment store, where every method of the store delegates to a corresponding endpoint in the callback service.
+
 ### Stop test service: `DELETE /`
 
 The test harness sends this request at the end of a test run if you have specified `--stop-service-at-end` on the [command line](./running.md). The test service should simply quit. This is a convenience so CI scripts can simply start the test service in the background and assume it will be stopped for them.
@@ -56,6 +62,9 @@ A `POST` request indicates that the test harness wants to start an instance of t
     * `globalPrivateAttributes` (array, optional): Corresponds to the `privateAttributes` property in the SDK configuration (rather than in an individual user).
     * `flushIntervalMs` (number, optional): The event flush interval in milliseconds. If omitted or zero, use the SDK's default value.
     * `inlineUsers` (boolean, optional): Corresponds to the SDK configuration property of the same name.
+  * `bigSegments` (object, optional): Enables and configures Big Segments. Properties are:
+    * `callbackUri` (string, required): The base URI for the big segments store callback fixture. See [Callback fixtures](#callback-fixtures).
+    * `userCacheSize`, `userCacheTimeMs`, `statusPollIntervalMS`, `staleAfterMs`: These correspond to the standard optional configuration parameters for every SDK that supports Big Segments.
 
 The response to a valid request is any HTTP `2xx` status, with a `Location` header whose value is the URL of the test service resource representing this SDK client instance (that is, the one that would be used for "Close client" or "Send command" as described below).
 
@@ -166,3 +175,41 @@ The response should be an empty 2xx response.
 If `command` is `"flush"`, the test service should tell the SDK to initiate an event flush.
 
 The response should be an empty 2xx response.
+
+## Callback endpoints
+
+As part of the contract tests, the test harness may need to simulate services that are external to the SDK. This allows it to control all of the data that the SDK sees.
+
+The test harness will tell the service where to find these simulated services by passing `baseUri` or `callbackUri` parameters in the service configuration. All of these URIs will point to some endpoint created by the test harness, which is only valid during the lifetime of the specific tests(s) where it is used. They will all have the same hostname and port, the same one that is controlled by the `-port` command-line parameter; the test harness does not listen on multiple ports (so it is safe to expose just one port if it is deployed in Docker).
+
+### Streaming service
+
+Most of the tests involve injecting some simulated LaunchDarkly environment data into the SDK. The test harness does this with a callback service that mimics the behavior of the LaunchDarkly streaming endpoints.
+
+### Big segments service
+
+SDKs that support Big Segments normally allow the application to configure them with one of several database integrations, using a generic "Big Segment store" interface. The test harness cannot test the integrations for specific databases such as Redis, but it can test whether the SDK sends the expected queries to the database and handles the results correctly. It does this by setting `bigSegments.callbackUri` in the test service configuration to point to a callback service.
+
+The service supports the following requests. For simplicity and to ensure that HTTP clients will not do any caching, they all use the `POST` method.
+
+#### Get metadata: `POST /getMetadata`
+
+The test service should send this request when the SDK calls the method for getting store metadata. The request body is ignored. The response is a JSON object with these properties:
+
+* `lastUpToDate`: The epoch millisecond time that the simulated store was last updated.
+
+#### Get user membership: `POST /getMembership`
+
+The test service should send this request when the SDK calls the method for getting a user's Big Segment membership.
+
+The request body is a JSON object with these properties:
+
+* `userHash` (string, required): A hash of the user key. There is a standard algorithm for computing this; the test harness will check the hash to ensure that the SDK follows the specification.
+
+The response body is a JSON object with these properties:
+
+* `values` (object, optional): A set of properties where each property key is a segment reference string (in the standard format used by SDK Big Segment data), and each value is either `true`, `false`, or `null`.
+
+The test service's Big Segment store implementation should return a corresponding membership state to the SDK. When the SDK queries the membership for any given segment reference string, it gets either `true`, `false`, or "no value" (any key that does not exist in the object should be considered "no value", same as if it had a null value).
+
+On platforms where the membership object is nullable, so that the query method could return null/nil instead of a membership object with no values, the test service should return null/nil if `values` is omitted or null. This lets the test harness verify that the SDK treats these two scenarios as equivalent and does not throw any kind of null reference error.

--- a/framework/ldtest/test_scope.go
+++ b/framework/ldtest/test_scope.go
@@ -81,8 +81,8 @@ func (t *T) run(action func(*T)) {
 		if t.failed {
 			t.env.results.Failures = append(t.env.results.Failures, result)
 		}
-		for _, cleanupFn := range t.cleanups {
-			cleanupFn()
+		for i := len(t.cleanups) - 1; i >= 0; i-- {
+			t.cleanups[i]()
 		}
 	}()
 

--- a/go.mod
+++ b/go.mod
@@ -4,6 +4,7 @@ go 1.17
 
 require (
 	github.com/fatih/color v1.13.0
+	github.com/gorilla/mux v1.8.0
 	github.com/launchdarkly/eventsource v1.6.2
 	github.com/launchdarkly/go-test-helpers/v2 v2.3.0
 	github.com/stretchr/testify v1.7.0

--- a/go.sum
+++ b/go.sum
@@ -6,6 +6,8 @@ github.com/fatih/color v1.13.0/go.mod h1:kLAiJbzzSOZDVNGyDpeOxJ47H46qBXwg5ILebYF
 github.com/google/uuid v1.1.1/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/google/uuid v1.1.2 h1:EVhdT+1Kseyi1/pUmXKaFxYsDNy9RQYkMWRH68J/W7Y=
 github.com/google/uuid v1.1.2/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
+github.com/gorilla/mux v1.8.0 h1:i40aqfkR1h2SlN9hojwV5ZA91wcXFOvkdNIeFDP5koI=
+github.com/gorilla/mux v1.8.0/go.mod h1:DVbg23sWSpFRCP0SfiEN6jmj59UnW/n46BH5rLB71So=
 github.com/josharian/intern v1.0.0 h1:vlS4z54oSdjm0bgjRigI+G1HpF+tI+9rE5LLzOg8HmY=
 github.com/josharian/intern v1.0.0/go.mod h1:5DoeVV0s6jJacbCEi61lwdGj/aVlrQvzHFFd8Hwg//Y=
 github.com/kr/pretty v0.1.0 h1:L/CwN0zerZDmRFUapSPitk6f+Q3+0za1rQkzVuMiMFI=

--- a/mockld/big_segment_store.go
+++ b/mockld/big_segment_store.go
@@ -10,6 +10,9 @@ import (
 	"gopkg.in/launchdarkly/go-sdk-common.v2/ldtime"
 )
 
+// MockBigSegmentStoreService is the low-level component providing the mock endpoints for the
+// Big Segments test fixture. The higher-level component sdktests.BigSegmentStore decorates this
+// to make it more convenient to use in test logic.
 type MockBigSegmentStoreService struct {
 	service             *callbackService
 	getMetadataFn       func() (ldtime.UnixMillisecondTime, error)

--- a/mockld/big_segment_store.go
+++ b/mockld/big_segment_store.go
@@ -1,0 +1,66 @@
+package mockld
+
+import (
+	"encoding/json"
+	"net/http"
+
+	"github.com/launchdarkly/sdk-test-harness/framework"
+	cf "github.com/launchdarkly/sdk-test-harness/servicedef/callbackfixtures"
+
+	"gopkg.in/launchdarkly/go-sdk-common.v2/ldtime"
+)
+
+type MockBigSegmentStoreService struct {
+	service             *callbackService
+	getMetadataFn       func() (ldtime.UnixMillisecondTime, error)
+	getUserMembershipFn func(string) (map[string]bool, error)
+}
+
+func NewMockBigSegmentStoreService(
+	getMetadata func() (ldtime.UnixMillisecondTime, error),
+	getUserMembership func(string) (map[string]bool, error),
+	logger framework.Logger,
+) *MockBigSegmentStoreService {
+	service := newCallbackService(logger, "BigSegmentStore")
+	m := &MockBigSegmentStoreService{service: service, getMetadataFn: getMetadata, getUserMembershipFn: getUserMembership}
+	service.addPath(cf.BigSegmentStorePathGetMetadata, m.doGetMetadata)
+	service.addPath(cf.BigSegmentStorePathGetMembership, m.doGetUserMembership)
+	return m
+}
+
+func (m *MockBigSegmentStoreService) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	m.service.router.ServeHTTP(w, r)
+}
+
+func (m *MockBigSegmentStoreService) doGetMetadata(*json.Decoder) (interface{}, error) {
+	var lastUpToDate ldtime.UnixMillisecondTime
+	var err error
+	if m.getMetadataFn != nil {
+		lastUpToDate, err = m.getMetadataFn()
+	}
+
+	if err != nil {
+		return nil, err
+	}
+
+	return cf.BigSegmentStoreGetMetadataResponse{LastUpToDate: lastUpToDate}, nil
+}
+
+func (m *MockBigSegmentStoreService) doGetUserMembership(readParams *json.Decoder) (interface{}, error) {
+	var params cf.BigSegmentStoreGetMembershipParams
+	if err := readParams.Decode(&params); err != nil {
+		return nil, err
+	}
+
+	var membership map[string]bool
+	var err error
+	if m.getUserMembershipFn != nil {
+		membership, err = m.getUserMembershipFn(params.UserHash)
+	}
+
+	if err != nil {
+		return nil, err
+	}
+
+	return cf.BigSegmentStoreGetMembershipResponse{Values: membership}, nil
+}

--- a/mockld/callback_helpers.go
+++ b/mockld/callback_helpers.go
@@ -1,0 +1,60 @@
+package mockld
+
+import (
+	"bytes"
+	"encoding/json"
+	"io/ioutil"
+	"net/http"
+
+	"github.com/launchdarkly/sdk-test-harness/framework"
+
+	"github.com/gorilla/mux"
+)
+
+type callbackService struct {
+	router *mux.Router
+	logger framework.Logger
+	name   string
+}
+
+func newCallbackService(logger framework.Logger, name string) *callbackService {
+	router := mux.NewRouter()
+	c := &callbackService{router: router, logger: logger, name: name}
+	router.HandleFunc("/", c.close).Methods("DELETE")
+	return c
+}
+
+func (c *callbackService) addPath(path string, handler func(*json.Decoder) (interface{}, error)) {
+	c.router.HandleFunc(path, func(w http.ResponseWriter, r *http.Request) {
+		var requestDecoder *json.Decoder
+		var body []byte
+		if r.Body != nil {
+			body, _ = ioutil.ReadAll(r.Body)
+			_ = r.Body.Close()
+			requestDecoder = json.NewDecoder(bytes.NewBuffer(body))
+		}
+		c.logger.Printf("[%s] got POST %s %s", c.name, path, string(body))
+
+		responseValue, err := handler(requestDecoder)
+		if err != nil {
+			w.Header().Set("content-type", "text/plain")
+			w.WriteHeader(http.StatusInternalServerError)
+			_, _ = w.Write([]byte(err.Error()))
+			c.logger.Printf("[%s] responded with 500 - %s", c.name, err.Error())
+		} else {
+			w.Header().Set("content-type", "application/json")
+			var respBody []byte
+			w.WriteHeader(http.StatusOK)
+			if responseValue != nil {
+				respBody, _ = json.Marshal(responseValue)
+				_, _ = w.Write(respBody)
+			}
+			c.logger.Printf("[%s] responded with 200 %s", c.name, string(respBody))
+		}
+	})
+}
+
+func (c *callbackService) close(w http.ResponseWriter, r *http.Request) {
+	c.logger.Printf("[%s] got DELETE - closing fixture", c.name)
+	w.WriteHeader(http.StatusNoContent)
+}

--- a/mockld/callback_helpers.go
+++ b/mockld/callback_helpers.go
@@ -11,6 +11,11 @@ import (
 	"github.com/gorilla/mux"
 )
 
+// callbackService provides support infrastructure for callback services that simulate an SDK
+// component with multiple methods. The test service will call one of several predefined subpaths
+// for each component method. For simplicity, and to make it clear that these calls should never
+// be cached, the method is always POST, except for a DELETE method to the base path which means
+// the SDK has stopped using the component. The parameters and responses, if any, are always JSON.
 type callbackService struct {
 	router *mux.Router
 	logger framework.Logger

--- a/sdktests/helpers.go
+++ b/sdktests/helpers.go
@@ -38,6 +38,22 @@ func basicEvaluateFlag(
 	return result.Value
 }
 
+func evaluateFlagDetail(
+	t *ldtest.T,
+	client *SDKClient,
+	flagKey string,
+	user lduser.User,
+	defaultValue ldvalue.Value,
+) servicedef.EvaluateFlagResponse {
+	return client.EvaluateFlag(t, servicedef.EvaluateFlagParams{
+		FlagKey:      flagKey,
+		User:         &user,
+		ValueType:    servicedef.ValueTypeAny,
+		DefaultValue: defaultValue,
+		Detail:       true,
+	})
+}
+
 func expectNoMoreRequests(t *ldtest.T, endpoint *harness.MockEndpoint) {
 	_, err := endpoint.AwaitConnection(time.Millisecond * 100)
 	require.Error(t, err, "did not expect another request, but got one")
@@ -96,7 +112,7 @@ func makeFlagToCheckSegmentMatch(
 ) ldmodel.FeatureFlag {
 	return ldbuilders.NewFlagBuilder(flagKey).Version(1).
 		On(true).FallthroughVariation(0).Variations(valueIfNotIncluded, valueIfIncluded).
-		AddRule(ldbuilders.NewRuleBuilder().Variation(1).Clauses(
+		AddRule(ldbuilders.NewRuleBuilder().ID("ruleid").Variation(1).Clauses(
 			ldbuilders.Clause("", ldmodel.OperatorSegmentMatch, ldvalue.String(segmentKey)),
 		)).
 		Build()

--- a/sdktests/server_side_big_segments.go
+++ b/sdktests/server_side_big_segments.go
@@ -1,0 +1,502 @@
+package sdktests
+
+import (
+	"errors"
+	"fmt"
+	"time"
+
+	"github.com/launchdarkly/sdk-test-harness/framework/ldtest"
+	"github.com/launchdarkly/sdk-test-harness/mockld"
+	"github.com/launchdarkly/sdk-test-harness/servicedef"
+
+	m "github.com/launchdarkly/go-test-helpers/v2/matchers"
+	"gopkg.in/launchdarkly/go-sdk-common.v2/ldreason"
+	"gopkg.in/launchdarkly/go-sdk-common.v2/ldtime"
+	"gopkg.in/launchdarkly/go-sdk-common.v2/lduser"
+	"gopkg.in/launchdarkly/go-sdk-common.v2/ldvalue"
+	"gopkg.in/launchdarkly/go-server-sdk-evaluation.v1/ldbuilders"
+	"gopkg.in/launchdarkly/go-server-sdk-evaluation.v1/ldmodel"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+var bigSegmentsUser = lduser.NewUser("user-key")                                 //nolint:gochecknoglobals
+var bigSegmentsExpectedUserHash = "CEXjZY7cHJG/ydFy7q4+YEFwVrG3/pkJwA4FAjrbfx0=" //nolint:gochecknoglobals
+
+func doBigSegmentsEvaluateSegment(t *ldtest.T) {
+	otherUser := lduser.NewUser("other-user-key")
+
+	basicSegment := ldbuilders.NewSegmentBuilder("segment1").Version(1).
+		Included(otherUser.GetKey()). // for "regular included list is ignored for big segment" test
+		Unbounded(true).Generation(100).Build()
+	basicSegmentRef := fmt.Sprintf("%s.g%d", basicSegment.Key, basicSegment.Generation.IntValue())
+
+	segmentWithRule := ldbuilders.NewSegmentBuilder("segment2").Version(1).
+		Unbounded(true).Generation(100).
+		AddRule(ldbuilders.NewSegmentRuleBuilder().Clauses(
+			ldbuilders.Clause(lduser.KeyAttribute, ldmodel.OperatorIn, ldvalue.String(bigSegmentsUser.GetKey())),
+		)).
+		Build()
+	segmentWithRuleRef := fmt.Sprintf("%s.g%d", segmentWithRule.Key, segmentWithRule.Generation.IntValue())
+
+	basicFlag := makeFlagToCheckSegmentMatch("flagkey1", basicSegment.Key, ldvalue.Bool(false), ldvalue.Bool(true))
+	flagForSegmentWithRule := makeFlagToCheckSegmentMatch(
+		"flagkey2", segmentWithRule.Key, ldvalue.Bool(false), ldvalue.Bool(true))
+	data := mockld.NewServerSDKDataBuilder().
+		Flag(basicFlag, flagForSegmentWithRule).
+		Segment(basicSegment, segmentWithRule).
+		Build()
+	dataSource := NewSDKDataSource(t, data)
+
+	for _, status := range []ldreason.BigSegmentsStatus{ldreason.BigSegmentsHealthy, ldreason.BigSegmentsStale} {
+		t.Run(fmt.Sprintf("user not found, status %s", status), func(t *ldtest.T) {
+			bigSegmentStore := NewBigSegmentStore(t, status)
+			client := NewSDKClient(t, dataSource, bigSegmentStore)
+
+			result := evaluateFlagDetail(t, client, basicFlag.Key, bigSegmentsUser, ldvalue.Null())
+			m.In(t).Assert(result, expectBigSegmentsResult(false, basicFlag, status))
+
+			assert.Equal(t, []string{bigSegmentsExpectedUserHash}, bigSegmentStore.GetMembershipQueries())
+		})
+
+		t.Run(fmt.Sprintf("user not included nor excluded (empty membership), status %s", status), func(t *ldtest.T) {
+			bigSegmentStore := NewBigSegmentStore(t, status)
+			bigSegmentStore.SetupMemberships(t, map[string]map[string]bool{bigSegmentsExpectedUserHash: {}})
+			client := NewSDKClient(t, dataSource, bigSegmentStore)
+
+			result := evaluateFlagDetail(t, client, basicFlag.Key, bigSegmentsUser, ldvalue.Null())
+			m.In(t).Assert(result, expectBigSegmentsResult(false, basicFlag, status))
+
+			assert.Equal(t, []string{bigSegmentsExpectedUserHash}, bigSegmentStore.GetMembershipQueries())
+		})
+
+		t.Run(fmt.Sprintf("user not included nor excluded (null membership), status %s", status), func(t *ldtest.T) {
+			bigSegmentStore := NewBigSegmentStore(t, status)
+			bigSegmentStore.SetupMemberships(t, map[string]map[string]bool{bigSegmentsExpectedUserHash: nil})
+			client := NewSDKClient(t, dataSource, bigSegmentStore)
+
+			result := evaluateFlagDetail(t, client, basicFlag.Key, bigSegmentsUser, ldvalue.Null())
+			m.In(t).Assert(result, expectBigSegmentsResult(false, basicFlag, status))
+
+			assert.Equal(t, []string{bigSegmentsExpectedUserHash}, bigSegmentStore.GetMembershipQueries())
+		})
+
+		t.Run(fmt.Sprintf("user not included nor excluded, matched by segment rule, status %s", status), func(t *ldtest.T) {
+			bigSegmentStore := NewBigSegmentStore(t, status)
+			bigSegmentStore.SetupMemberships(t, map[string]map[string]bool{bigSegmentsExpectedUserHash: {}})
+			client := NewSDKClient(t, dataSource, bigSegmentStore)
+
+			result := evaluateFlagDetail(t, client, flagForSegmentWithRule.Key, bigSegmentsUser, ldvalue.Null())
+			m.In(t).Assert(result, expectBigSegmentsResult(true, flagForSegmentWithRule, status))
+
+			assert.Equal(t, []string{bigSegmentsExpectedUserHash}, bigSegmentStore.GetMembershipQueries())
+		})
+
+		t.Run(fmt.Sprintf("user included, status is %s", status), func(t *ldtest.T) {
+			bigSegmentStore := NewBigSegmentStore(t, status)
+			bigSegmentStore.SetupMemberships(t, map[string]map[string]bool{
+				bigSegmentsExpectedUserHash: {basicSegmentRef: true}})
+			client := NewSDKClient(t, dataSource, bigSegmentStore)
+
+			result := evaluateFlagDetail(t, client, basicFlag.Key, bigSegmentsUser, ldvalue.Null())
+			m.In(t).Assert(result, expectBigSegmentsResult(true, basicFlag, status))
+
+			assert.Equal(t, []string{bigSegmentsExpectedUserHash}, bigSegmentStore.GetMembershipQueries())
+		})
+
+		t.Run(fmt.Sprintf("user excluded, no rules, status is %s", status), func(t *ldtest.T) {
+			bigSegmentStore := NewBigSegmentStore(t, status)
+			bigSegmentStore.SetupMemberships(t, map[string]map[string]bool{
+				bigSegmentsExpectedUserHash: {basicSegmentRef: false}})
+			client := NewSDKClient(t, dataSource, bigSegmentStore)
+
+			result := evaluateFlagDetail(t, client, basicFlag.Key, bigSegmentsUser, ldvalue.Null())
+			m.In(t).Assert(result, expectBigSegmentsResult(false, basicFlag, status))
+
+			assert.Equal(t, []string{bigSegmentsExpectedUserHash}, bigSegmentStore.GetMembershipQueries())
+		})
+
+		t.Run(fmt.Sprintf("user excluded, matched by segment rule, status is %s", status), func(t *ldtest.T) {
+			bigSegmentStore := NewBigSegmentStore(t, status)
+			bigSegmentStore.SetupMemberships(t, map[string]map[string]bool{
+				bigSegmentsExpectedUserHash: {segmentWithRuleRef: false}})
+			client := NewSDKClient(t, dataSource, bigSegmentStore)
+
+			result := evaluateFlagDetail(t, client, flagForSegmentWithRule.Key, bigSegmentsUser, ldvalue.Null())
+			m.In(t).Assert(result, expectBigSegmentsResult(false, basicFlag, status))
+
+			assert.Equal(t, []string{bigSegmentsExpectedUserHash}, bigSegmentStore.GetMembershipQueries())
+		})
+	}
+
+	t.Run("regular include list is ignored for big segment", func(t *ldtest.T) {
+		bigSegmentStore := NewBigSegmentStore(t, ldreason.BigSegmentsHealthy)
+		client := NewSDKClient(t, dataSource, bigSegmentStore)
+
+		result := evaluateFlagDetail(t, client, basicFlag.Key, otherUser, ldvalue.Null())
+		m.In(t).Assert(result, expectBigSegmentsResult(false, basicFlag, ldreason.BigSegmentsHealthy))
+	})
+}
+
+func doBigSegmentsMembershipCachingTests(t *ldtest.T) {
+	user1, user2, user3 := lduser.NewUser("user1"), lduser.NewUser("user2"), lduser.NewUser("user3")
+	expectedUserHash1, expectedUserHash2, expectedUserHash3 := "CgQblGLKpKMbrDVn4Lbm/ZEAeH2yq0M9lvbReMq/zpA=",
+		"YCXRj+SKvUUWhSjxioLiZd2Y1CGnCEqgn2GzQXA5AaM=", "WGD68CtrxiIrpaylI1YPDjZMzYtnvuSG/ov3wB1JLMs="
+
+	segment1 := ldbuilders.NewSegmentBuilder("segment1").Version(1).
+		Unbounded(true).Generation(100).Build()
+	segmentRef1 := fmt.Sprintf("%s.g%d", segment1.Key, segment1.Generation.IntValue())
+	segment2 := ldbuilders.NewSegmentBuilder("segment2").Version(1).
+		Unbounded(true).Generation(101).Build()
+	segmentRef2 := fmt.Sprintf("%s.g%d", segment2.Key, segment2.Generation.IntValue())
+	flag := ldbuilders.NewFlagBuilder("flag-key").Version(1).
+		On(true).FallthroughVariation(1).Variations(ldvalue.Bool(true), ldvalue.Bool(false)).
+		AddRule(
+			ldbuilders.NewRuleBuilder().ID("rule1").Variation(0).Clauses(
+				ldbuilders.Clause("", ldmodel.OperatorSegmentMatch, ldvalue.String(segment1.Key)),
+			)).
+		AddRule(
+			ldbuilders.NewRuleBuilder().ID("rule2").Variation(0).Clauses(
+				ldbuilders.Clause("", ldmodel.OperatorSegmentMatch, ldvalue.String(segment2.Key)),
+			),
+		).
+		Build()
+	data := mockld.NewServerSDKDataBuilder().Flag(flag).Segment(segment1, segment2).Build()
+	dataSource := NewSDKDataSource(t, data)
+
+	t.Run("membership query is cached for multiple tests in one evaluation", func(t *ldtest.T) {
+		// Set up membership so the user is included in segment2, and not included in segment1.
+		// Due to the order of the flag rules, the SDK will check segment1 first, find no match,
+		// and then check segment2. We should only see one membership query for the user.
+
+		bigSegmentStore := NewBigSegmentStore(t, ldreason.BigSegmentsHealthy)
+		bigSegmentStore.SetupMemberships(t, map[string]map[string]bool{
+			expectedUserHash1: {segmentRef1: false, segmentRef2: true}})
+		client := NewSDKClient(t, dataSource, bigSegmentStore)
+
+		value := basicEvaluateFlag(t, client, flag.Key, user1, ldvalue.Null())
+		m.In(t).Assert(value, m.JSONEqual(true))
+
+		assert.Equal(t, []string{expectedUserHash1}, bigSegmentStore.GetMembershipQueries())
+	})
+
+	t.Run("membership query is cached across evaluations for same user", func(t *ldtest.T) {
+		bigSegmentStore := NewBigSegmentStore(t, ldreason.BigSegmentsHealthy)
+		client := NewSDKClient(t, dataSource, bigSegmentStore)
+
+		bigSegmentStore.SetupMemberships(t, map[string]map[string]bool{
+			expectedUserHash1: {segmentRef1: true}})
+
+		value := basicEvaluateFlag(t, client, flag.Key, user1, ldvalue.Null())
+		m.In(t).Assert(value, m.JSONEqual(true))
+
+		bigSegmentStore.SetupMemberships(t, map[string]map[string]bool{
+			expectedUserHash1: {segmentRef1: false}}) // the SDK will not query this value
+
+		value = basicEvaluateFlag(t, client, flag.Key, user1, ldvalue.Null())
+		m.In(t).Assert(value, m.JSONEqual(true))
+
+		assert.Equal(t, []string{expectedUserHash1}, bigSegmentStore.GetMembershipQueries())
+	})
+
+	t.Run("membership query is cached separately per user", func(t *ldtest.T) {
+		bigSegmentStore := NewBigSegmentStore(t, ldreason.BigSegmentsHealthy)
+		client := NewSDKClient(t, dataSource, bigSegmentStore)
+
+		bigSegmentStore.SetupMemberships(t, map[string]map[string]bool{
+			expectedUserHash1: {segmentRef1: true},
+			expectedUserHash2: {segmentRef1: true}})
+
+		// evaluate for user1
+		value := basicEvaluateFlag(t, client, flag.Key, user1, ldvalue.Null())
+		m.In(t).Assert(value, m.JSONEqual(true))
+
+		assert.Equal(t, []string{expectedUserHash1}, bigSegmentStore.GetMembershipQueries())
+
+		// modify the stored data for user1
+		bigSegmentStore.SetupMemberships(t, map[string]map[string]bool{
+			expectedUserHash1: {segmentRef1: false},
+			expectedUserHash2: {segmentRef1: false}})
+
+		// re-evaluate for user1 - should use the cached state, not the value from the store
+		value = basicEvaluateFlag(t, client, flag.Key, user1, ldvalue.Null())
+		m.In(t).Assert(value, m.JSONEqual(true))
+
+		assert.Equal(t, []string{expectedUserHash1},
+			bigSegmentStore.GetMembershipQueries()) // didn't do a 2nd query
+
+		// now evaluate for user2 - its state is not yet cached, so it does a query
+		value = basicEvaluateFlag(t, client, flag.Key, user2, ldvalue.Null())
+		m.In(t).Assert(value, m.JSONEqual(false))
+
+		assert.Equal(t, []string{expectedUserHash1, expectedUserHash2},
+			bigSegmentStore.GetMembershipQueries())
+
+		// re-evaluate for user1 - should still use the cache
+		value = basicEvaluateFlag(t, client, flag.Key, user1, ldvalue.Null())
+		m.In(t).Assert(value, m.JSONEqual(true))
+
+		assert.Equal(t, []string{expectedUserHash1, expectedUserHash2},
+			bigSegmentStore.GetMembershipQueries())
+	})
+
+	t.Run("user cache expiration (cache time)", func(t *ldtest.T) {
+		bigSegmentStore := NewBigSegmentStore(t, ldreason.BigSegmentsHealthy)
+		client := NewSDKClient(t, WithConfig(servicedef.SDKConfigParams{
+			BigSegments: &servicedef.SDKConfigBigSegmentsParams{
+				UserCacheTimeMS: 10,
+			},
+		}), dataSource, bigSegmentStore)
+
+		bigSegmentStore.SetupMemberships(t, map[string]map[string]bool{
+			expectedUserHash1: {segmentRef1: true}})
+
+		value := basicEvaluateFlag(t, client, flag.Key, user1, ldvalue.Null())
+		m.In(t).Assert(value, m.JSONEqual(true))
+
+		assert.Equal(t, []string{expectedUserHash1}, bigSegmentStore.GetMembershipQueries())
+
+		bigSegmentStore.SetupMemberships(t, map[string]map[string]bool{
+			expectedUserHash1: {segmentRef1: false}})
+
+		assert.Eventually(
+			t,
+			func() bool {
+				value := basicEvaluateFlag(t, client, flag.Key, user1, ldvalue.Null())
+				return value.Equal(ldvalue.Bool(false))
+			},
+			time.Second,
+			time.Millisecond*20,
+			"timed out waiting for user membership to be re-queried",
+		)
+
+		assert.Equal(t, []string{expectedUserHash1, expectedUserHash1},
+			bigSegmentStore.GetMembershipQueries())
+	})
+
+	t.Run("user cache eviction (cache size)", func(t *ldtest.T) {
+		bigSegmentStore := NewBigSegmentStore(t, ldreason.BigSegmentsHealthy)
+		client := NewSDKClient(t, WithConfig(servicedef.SDKConfigParams{
+			BigSegments: &servicedef.SDKConfigBigSegmentsParams{
+				UserCacheSize: ldvalue.NewOptionalInt(2),
+			},
+		}), dataSource, bigSegmentStore)
+
+		bigSegmentStore.SetupMemberships(t, map[string]map[string]bool{
+			expectedUserHash1: {segmentRef1: true},
+			expectedUserHash2: {segmentRef2: true},
+			expectedUserHash3: nil})
+
+		value1a := basicEvaluateFlag(t, client, flag.Key, user1, ldvalue.Null())
+		m.In(t).Assert(value1a, m.JSONEqual(true))
+		value2a := basicEvaluateFlag(t, client, flag.Key, user2, ldvalue.Null())
+		m.In(t).Assert(value2a, m.JSONEqual(true))
+
+		assert.Equal(t, []string{expectedUserHash1, expectedUserHash2},
+			bigSegmentStore.GetMembershipQueries())
+
+		value2b := basicEvaluateFlag(t, client, flag.Key, user2, ldvalue.Null())
+		m.In(t).Assert(value2b, m.JSONEqual(true))
+
+		assert.Equal(t, []string{expectedUserHash1, expectedUserHash2},
+			bigSegmentStore.GetMembershipQueries())
+
+		value3 := basicEvaluateFlag(t, client, flag.Key, user3, ldvalue.Null())
+		m.In(t).Assert(value3, m.JSONEqual(false))
+
+		assert.Equal(t, []string{expectedUserHash1, expectedUserHash2, expectedUserHash3},
+			bigSegmentStore.GetMembershipQueries())
+
+		value1b := basicEvaluateFlag(t, client, flag.Key, user1, ldvalue.Null())
+		m.In(t).Assert(value1b, m.JSONEqual(true))
+
+		assert.Equal(t, []string{expectedUserHash1, expectedUserHash2, expectedUserHash3, expectedUserHash1},
+			bigSegmentStore.GetMembershipQueries())
+	})
+}
+
+func doBigSegmentsStatusPollingTests(t *ldtest.T) {
+	dataSource := NewSDKDataSource(t, mockld.EmptyServerSDKData())
+
+	t.Run("polling can be set to a short interval", func(t *ldtest.T) {
+		bigSegmentStore := NewBigSegmentStore(t, ldreason.BigSegmentsHealthy)
+
+		_ = NewSDKClient(t, WithConfig(servicedef.SDKConfigParams{
+			BigSegments: &servicedef.SDKConfigBigSegmentsParams{
+				StatusPollIntervalMS: ldtime.UnixMillisecondTime(10),
+			},
+		}), dataSource, bigSegmentStore)
+
+		for i := 0; i < 3; i++ {
+			// Using a long timeout here just so we're not sensitive to random fluctuations in host speed.
+			// We don't really care if it's greater than the configured interval, as long as it's nowhere
+			// near the default interval of 5 seconds.
+			bigSegmentStore.ExpectMetadataQuery(t, time.Millisecond*500)
+		}
+	})
+
+	t.Run("polling can be set to a long interval", func(t *ldtest.T) {
+		bigSegmentStore := NewBigSegmentStore(t, ldreason.BigSegmentsHealthy)
+
+		client := NewSDKClient(t, WithConfig(servicedef.SDKConfigParams{
+			BigSegments: &servicedef.SDKConfigBigSegmentsParams{
+				StatusPollIntervalMS: ldtime.UnixMillisecondTime(10000),
+			},
+		}), dataSource, bigSegmentStore)
+
+		initialStatus := client.GetBigSegmentStoreStatus(t)
+		assert.Equal(t, servicedef.BigSegmentStoreStatusResponse{Available: true, Stale: false}, initialStatus)
+
+		bigSegmentStore.ExpectMetadataQuery(t, time.Millisecond*500)
+		bigSegmentStore.ExpectNoMoreMetadataQueries(t, time.Millisecond*200)
+	})
+
+	doStatusChangeTest := func(oldStatus, newStatus ldreason.BigSegmentsStatus) {
+		t.Run(fmt.Sprintf("polling detects change from %s to %s", oldStatus, newStatus), func(t *ldtest.T) {
+			bigSegmentStore := NewBigSegmentStore(t, oldStatus)
+
+			client := NewSDKClient(t, WithConfig(servicedef.SDKConfigParams{
+				BigSegments: &servicedef.SDKConfigBigSegmentsParams{
+					StatusPollIntervalMS: ldtime.UnixMillisecondTime(10),
+				},
+			}), dataSource, bigSegmentStore)
+
+			initialStatus := client.GetBigSegmentStoreStatus(t)
+			initialExpected := servicedef.BigSegmentStoreStatusResponse{
+				Available: oldStatus != ldreason.BigSegmentsStoreError,
+				Stale:     oldStatus == ldreason.BigSegmentsStale,
+			}
+			require.Equal(t, initialExpected, initialStatus)
+
+			bigSegmentStore.SetupMetadataForStatus(newStatus)
+
+			newExpected := servicedef.BigSegmentStoreStatusResponse{
+				Available: newStatus != ldreason.BigSegmentsStoreError,
+				Stale:     newStatus == ldreason.BigSegmentsStale,
+			}
+			assert.Eventually(
+				t,
+				func() bool {
+					status := client.GetBigSegmentStoreStatus(t)
+					return status == newExpected
+				},
+				time.Second,
+				time.Millisecond*20,
+				"timed out waiting for status to change",
+			)
+		})
+	}
+	doStatusChangeTest(ldreason.BigSegmentsHealthy, ldreason.BigSegmentsStoreError)
+	doStatusChangeTest(ldreason.BigSegmentsStoreError, ldreason.BigSegmentsHealthy)
+	doStatusChangeTest(ldreason.BigSegmentsHealthy, ldreason.BigSegmentsStale)
+	doStatusChangeTest(ldreason.BigSegmentsStale, ldreason.BigSegmentsHealthy)
+
+	t.Run("multiple evaluations don't cause another status poll before next interval", func(t *ldtest.T) {
+		segment := ldbuilders.NewSegmentBuilder("segment-key").Version(1).
+			Included(bigSegmentsUser.GetKey()). // regular include list should be ignored if unbounded=true
+			Unbounded(true).Generation(100).Build()
+		flag := makeFlagToCheckSegmentMatch("flag-key", segment.Key, ldvalue.Bool(false), ldvalue.Bool(true))
+		data := mockld.NewServerSDKDataBuilder().Flag(flag).Segment(segment).Build()
+
+		dataSource := NewSDKDataSource(t, data)
+		bigSegmentStore := NewBigSegmentStore(t, ldreason.BigSegmentsHealthy)
+
+		client := NewSDKClient(t, WithConfig(servicedef.SDKConfigParams{
+			BigSegments: &servicedef.SDKConfigBigSegmentsParams{
+				StatusPollIntervalMS: ldtime.UnixMillisecondTime(10000),
+			},
+		}), dataSource, bigSegmentStore)
+
+		initialStatus := client.GetBigSegmentStoreStatus(t)
+		require.Equal(t, servicedef.BigSegmentStoreStatusResponse{Available: true, Stale: false}, initialStatus)
+		bigSegmentStore.ExpectMetadataQuery(t, time.Millisecond*500)
+
+		for i := 0; i < 10; i++ {
+			basicEvaluateFlag(t, client, flag.Key, lduser.NewUser(fmt.Sprintf("user-%d", i)), ldvalue.Null())
+		}
+
+		bigSegmentStore.ExpectNoMoreMetadataQueries(t, time.Millisecond*50)
+	})
+}
+
+func doBigSegmentsErrorHandlingTests(t *ldtest.T) {
+	t.Run("big segment store was not configured", func(t *ldtest.T) {
+		segment := ldbuilders.NewSegmentBuilder("segment-key").Version(1).
+			Included(bigSegmentsUser.GetKey()). // regular include list should be ignored if unbounded=true
+			Unbounded(true).Generation(100).Build()
+		flag := makeFlagToCheckSegmentMatch("flag-key", segment.Key, ldvalue.Bool(false), ldvalue.Bool(true))
+		data := mockld.NewServerSDKDataBuilder().Flag(flag).Segment(segment).Build()
+
+		dataSource := NewSDKDataSource(t, data)
+		client := NewSDKClient(t, dataSource)
+
+		result := evaluateFlagDetail(t, client, flag.Key, bigSegmentsUser, ldvalue.Null())
+		m.In(t).Assert(result.Value, m.JSONEqual(false))
+		m.In(t).Assert(result.Reason, m.JSONEqual(
+			ldreason.NewEvalReasonFromReasonWithBigSegmentsStatus(ldreason.NewEvalReasonFallthrough(),
+				ldreason.BigSegmentsNotConfigured)))
+	})
+
+	t.Run("big segment with no generation is invalid", func(t *ldtest.T) {
+		// This is an unexpected data inconsistency condition, so even though the problem might
+		// not be in the configuration or the big segment store itself, we have to assume none
+		// of the big segments results are really valid. Therefore the status should be reported
+		// as NOT_CONFIGURED.
+
+		segment := ldbuilders.NewSegmentBuilder("segment-key").Version(1).
+			Unbounded(true).Build()
+		segmentRef0 := fmt.Sprintf("%s.g0", segment.Key)
+		flag := makeFlagToCheckSegmentMatch("flag-key", segment.Key, ldvalue.Bool(false), ldvalue.Bool(true))
+		data := mockld.NewServerSDKDataBuilder().Flag(flag).Segment(segment).Build()
+
+		dataSource := NewSDKDataSource(t, data)
+		bigSegmentStore := NewBigSegmentStore(t, ldreason.BigSegmentsHealthy)
+		client := NewSDKClient(t, dataSource, bigSegmentStore)
+
+		bigSegmentStore.SetupMemberships(t, map[string]map[string]bool{
+			bigSegmentsExpectedUserHash: {segmentRef0: true}})
+
+		result := evaluateFlagDetail(t, client, flag.Key, bigSegmentsUser, ldvalue.Null())
+		m.In(t).Assert(result.Value, m.JSONEqual(false))
+		m.In(t).Assert(result.Reason, m.JSONEqual(
+			ldreason.NewEvalReasonFromReasonWithBigSegmentsStatus(ldreason.NewEvalReasonFallthrough(),
+				ldreason.BigSegmentsNotConfigured)))
+		assert.Len(t, bigSegmentStore.GetMembershipQueries(), 0)
+	})
+
+	t.Run("store error on user membership query", func(t *ldtest.T) {
+		segment := ldbuilders.NewSegmentBuilder("segment-key").Version(1).
+			Unbounded(true).Generation(100).Build()
+		flag := makeFlagToCheckSegmentMatch("flag-key", segment.Key, ldvalue.Bool(false), ldvalue.Bool(true))
+		data := mockld.NewServerSDKDataBuilder().Flag(flag).Segment(segment).Build()
+
+		dataSource := NewSDKDataSource(t, data)
+		bigSegmentStore := NewBigSegmentStore(t, ldreason.BigSegmentsHealthy)
+		client := NewSDKClient(t, dataSource, bigSegmentStore)
+
+		bigSegmentStore.SetupGetUserMembership(func(string) (map[string]bool, error) {
+			return nil, errors.New("THIS IS A DELIBERATE ERROR")
+		})
+
+		result := evaluateFlagDetail(t, client, flag.Key, bigSegmentsUser, ldvalue.Null())
+		m.In(t).Assert(result.Value, m.JSONEqual(false))
+		m.In(t).Assert(result.Reason, m.JSONEqual(
+			ldreason.NewEvalReasonFromReasonWithBigSegmentsStatus(ldreason.NewEvalReasonFallthrough(),
+				ldreason.BigSegmentsStoreError)))
+
+		assert.Equal(t, []string{bigSegmentsExpectedUserHash}, bigSegmentStore.GetMembershipQueries())
+	})
+}
+
+func expectBigSegmentsResult(isMatch bool, flag ldmodel.FeatureFlag, status ldreason.BigSegmentsStatus) m.Matcher {
+	baseReason := ldreason.NewEvalReasonFallthrough()
+	if isMatch {
+		baseReason = ldreason.NewEvalReasonRuleMatch(0, flag.Rules[0].ID)
+	}
+	return m.AllOf(
+		EvalResponseValue().Should(m.JSONEqual(ldvalue.Bool(isMatch))),
+		EvalResponseReason().Should(m.JSONEqual(
+			ldreason.NewEvalReasonFromReasonWithBigSegmentsStatus(baseReason, status))),
+	)
+}

--- a/sdktests/testapi_sdk_big_segments.go
+++ b/sdktests/testapi_sdk_big_segments.go
@@ -1,0 +1,146 @@
+package sdktests
+
+import (
+	"errors"
+	"sort"
+	"sync"
+	"time"
+
+	"github.com/launchdarkly/sdk-test-harness/framework/harness"
+	"github.com/launchdarkly/sdk-test-harness/framework/ldtest"
+	"github.com/launchdarkly/sdk-test-harness/mockld"
+	"github.com/launchdarkly/sdk-test-harness/servicedef"
+
+	"gopkg.in/launchdarkly/go-sdk-common.v2/ldreason"
+	"gopkg.in/launchdarkly/go-sdk-common.v2/ldtime"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+type BigSegmentStore struct {
+	service           *mockld.MockBigSegmentStoreService
+	endpoint          *harness.MockEndpoint
+	getMetadata       func() (ldtime.UnixMillisecondTime, error)
+	getUserMembership func(string) (map[string]bool, error)
+	metadataQueries   chan struct{}
+	membershipQueries []string
+	lock              sync.Mutex
+}
+
+func NewBigSegmentStore(t *ldtest.T, initialStatus ldreason.BigSegmentsStatus) *BigSegmentStore {
+	b := &BigSegmentStore{}
+	b.service = mockld.NewMockBigSegmentStoreService(
+		b.doGetMetadata,
+		b.doGetUserMembership,
+		t.DebugLogger(),
+	)
+	b.endpoint = requireContext(t).harness.NewMockEndpoint(b.service, nil, t.DebugLogger())
+	t.Defer(b.endpoint.Close)
+
+	b.metadataQueries = make(chan struct{}, 20) // arbitrary capacity that's more than our tests care about
+
+	b.SetupMetadataForStatus(initialStatus)
+
+	return b
+}
+
+// ApplyConfiguration updates the SDK client configuration for NewSDKClient, causing the SDK
+// to connect to the appropriate base URI for the big segments test fixture.
+func (b *BigSegmentStore) ApplyConfiguration(config *servicedef.SDKConfigParams) {
+	if config.BigSegments == nil {
+		config.BigSegments = &servicedef.SDKConfigBigSegmentsParams{}
+	} else {
+		bc := *config.BigSegments
+		config.BigSegments = &bc // copy to avoid side effects
+	}
+	config.BigSegments.CallbackURI = b.endpoint.BaseURL()
+}
+
+func (b *BigSegmentStore) SetupGetMetadata(fn func() (ldtime.UnixMillisecondTime, error)) {
+	b.lock.Lock()
+	b.getMetadata = fn
+	b.lock.Unlock()
+}
+
+func (b *BigSegmentStore) SetupMetadataForStatus(status ldreason.BigSegmentsStatus) {
+	b.SetupGetMetadata(func() (ldtime.UnixMillisecondTime, error) {
+		switch status {
+		case ldreason.BigSegmentsStoreError, ldreason.BigSegmentsNotConfigured:
+			return 0, errors.New("THIS IS A DELIBERATE ERROR")
+		case ldreason.BigSegmentsStale:
+			return ldtime.UnixMillisecondTime(1), nil
+		default:
+			return ldtime.UnixMillisNow(), nil
+		}
+	})
+}
+
+func (b *BigSegmentStore) SetupGetUserMembership(fn func(string) (map[string]bool, error)) {
+	b.lock.Lock()
+	b.getUserMembership = fn
+	b.lock.Unlock()
+}
+
+func (b *BigSegmentStore) SetupMemberships(t *ldtest.T, memberships map[string]map[string]bool) {
+	b.SetupGetUserMembership(func(userHash string) (map[string]bool, error) {
+		if membership, ok := memberships[userHash]; ok {
+			return membership, nil
+		}
+		expectedKeys := make([]string, len(memberships))
+		for k := range memberships {
+			expectedKeys = append(expectedKeys, k)
+		}
+		sort.Strings(expectedKeys)
+		assert.Fail(t, "got membership query with unexpected user hash value",
+			"actual: %s, expected: %v", userHash, expectedKeys)
+		return nil, nil
+	})
+}
+
+func (b *BigSegmentStore) ExpectMetadataQuery(t *ldtest.T, timeout time.Duration) {
+	select {
+	case <-b.metadataQueries:
+		return
+	case <-time.After(timeout):
+		require.Fail(t, "timed out waiting for big segments metadata query")
+	}
+}
+
+func (b *BigSegmentStore) ExpectNoMoreMetadataQueries(t *ldtest.T, timeout time.Duration) {
+	select {
+	case <-b.metadataQueries:
+		require.Fail(t, "got an unexpected big segments metadata query")
+	case <-time.After(timeout):
+	}
+}
+
+func (b *BigSegmentStore) GetMembershipQueries() []string {
+	b.lock.Lock()
+	defer b.lock.Unlock()
+	return append([]string(nil), b.membershipQueries...)
+}
+
+func (b *BigSegmentStore) doGetMetadata() (ldtime.UnixMillisecondTime, error) {
+	b.lock.Lock()
+	defer b.lock.Unlock()
+	select {
+	case b.metadataQueries <- struct{}{}: // non-blocking send
+		break
+	default:
+	}
+	if b.getMetadata != nil {
+		return b.getMetadata()
+	}
+	return 0, nil
+}
+
+func (b *BigSegmentStore) doGetUserMembership(userHash string) (map[string]bool, error) {
+	b.lock.Lock()
+	defer b.lock.Unlock()
+	b.membershipQueries = append(b.membershipQueries, userHash)
+	if b.getUserMembership != nil {
+		return b.getUserMembership(userHash)
+	}
+	return nil, nil
+}

--- a/sdktests/testapi_sdk_client.go
+++ b/sdktests/testapi_sdk_client.go
@@ -183,3 +183,12 @@ func (c *SDKClient) SendAliasEvent(t *ldtest.T, params servicedef.AliasEventPara
 func (c *SDKClient) FlushEvents(t *ldtest.T) {
 	require.NoError(t, c.sdkClientEntity.SendCommand(servicedef.CommandFlushEvents, t.DebugLogger(), nil))
 }
+
+// GetBigSegmentStoreStatus queries the big segment store status from the SDK client. The test
+// harness will only call this method if the test service has the "big-segments" capability.
+func (c *SDKClient) GetBigSegmentStoreStatus(t *ldtest.T) servicedef.BigSegmentStoreStatusResponse {
+	var resp servicedef.BigSegmentStoreStatusResponse
+	require.NoError(t, c.sdkClientEntity.SendCommand(servicedef.CommandGetBigSegmentStoreStatus,
+		t.DebugLogger(), &resp))
+	return resp
+}

--- a/sdktests/testsuite_server_side.go
+++ b/sdktests/testsuite_server_side.go
@@ -17,6 +17,7 @@ func AllImportantServerSideCapabilities() framework.Capabilities {
 		servicedef.CapabilityAllFlagsClientSideOnly,
 		servicedef.CapabilityAllFlagsDetailsOnlyForTrackedFlags,
 		servicedef.CapabilityAllFlagsWithReasons,
+		servicedef.CapabilityBigSegments,
 	}
 	// We don't include the "strongly-typed" capability here because it's not unusual for an SDK
 	// to not have it - that's just an inherent characteristic of the SDK, not a missing feature
@@ -42,7 +43,17 @@ func RunServerSideTestSuite(
 		t.Run("evaluation", DoServerSideEvalTests)
 		t.Run("events", doServerSideEventTests)
 		t.Run("streaming", doServerSideStreamTests)
+		t.Run("big segments", doServerSideBigSegmentsTests)
 	})
+}
+
+func doServerSideBigSegmentsTests(t *ldtest.T) {
+	t.RequireCapability(servicedef.CapabilityBigSegments)
+
+	t.Run("evaluation", doBigSegmentsEvaluateSegment)
+	t.Run("membership caching", doBigSegmentsMembershipCachingTests)
+	t.Run("status polling", doBigSegmentsStatusPollingTests)
+	t.Run("error handling", doBigSegmentsErrorHandlingTests)
 }
 
 func doServerSideDataStoreTests(t *ldtest.T) {

--- a/servicedef/callbackfixtures/big_segment_store.go
+++ b/servicedef/callbackfixtures/big_segment_store.go
@@ -1,0 +1,20 @@
+package callbackfixtures
+
+import "gopkg.in/launchdarkly/go-sdk-common.v2/ldtime"
+
+const (
+	BigSegmentStorePathGetMetadata   = "/getMetadata"
+	BigSegmentStorePathGetMembership = "/getMembership"
+)
+
+type BigSegmentStoreGetMetadataResponse struct {
+	LastUpToDate ldtime.UnixMillisecondTime `json:"lastUpToDate"`
+}
+
+type BigSegmentStoreGetMembershipParams struct {
+	UserHash string `json:"userHash"`
+}
+
+type BigSegmentStoreGetMembershipResponse struct {
+	Values map[string]bool `json:"values,omitempty"`
+}

--- a/servicedef/callbackfixtures/package_info.go
+++ b/servicedef/callbackfixtures/package_info.go
@@ -1,0 +1,7 @@
+// Package callbackfixtures contains definitions for the REST protocol that test services must
+// implement, specifically for callback requests from the test service to the test harness.
+// See the top-level README.md for more details.
+//
+// The package is used by the test harness, but can also be imported by any test service
+// code that is Go-based.
+package callbackfixtures

--- a/servicedef/command_params.go
+++ b/servicedef/command_params.go
@@ -7,12 +7,13 @@ import (
 )
 
 const (
-	CommandEvaluateFlag     = "evaluate"
-	CommandEvaluateAllFlags = "evaluateAll"
-	CommandIdentifyEvent    = "identifyEvent"
-	CommandCustomEvent      = "customEvent"
-	CommandAliasEvent       = "aliasEvent"
-	CommandFlushEvents      = "flushEvents"
+	CommandEvaluateFlag             = "evaluate"
+	CommandEvaluateAllFlags         = "evaluateAll"
+	CommandIdentifyEvent            = "identifyEvent"
+	CommandCustomEvent              = "customEvent"
+	CommandAliasEvent               = "aliasEvent"
+	CommandFlushEvents              = "flushEvents"
+	CommandGetBigSegmentStoreStatus = "getBigSegmentStoreStatus"
 )
 
 type ValueType string
@@ -74,4 +75,9 @@ type IdentifyEventParams struct {
 type AliasEventParams struct {
 	User         lduser.User `json:"user"`
 	PreviousUser lduser.User `json:"previousUser"`
+}
+
+type BigSegmentStoreStatusResponse struct {
+	Available bool `json:"available"`
+	Stale     bool `json:"stale"`
 }

--- a/servicedef/sdk_config.go
+++ b/servicedef/sdk_config.go
@@ -7,11 +7,13 @@ import (
 )
 
 type SDKConfigParams struct {
-	Credential      string                     `json:"credential"`
-	StartWaitTimeMS ldtime.UnixMillisecondTime `json:"startWaitTimeMs,omitempty"`
-	InitCanFail     bool                       `json:"initCanFail,omitempty"`
-	Streaming       *SDKConfigStreamingParams  `json:"streaming,omitempty"`
-	Events          *SDKConfigEventParams      `json:"events,omitempty"`
+	Credential          string                              `json:"credential"`
+	StartWaitTimeMS     ldtime.UnixMillisecondTime          `json:"startWaitTimeMs,omitempty"`
+	InitCanFail         bool                                `json:"initCanFail,omitempty"`
+	Streaming           *SDKConfigStreamingParams           `json:"streaming,omitempty"`
+	Events              *SDKConfigEventParams               `json:"events,omitempty"`
+	PersistentDataStore *SDKConfigPersistentDataStoreParams `json:"persistentDataStore,omitempty"`
+	BigSegments         *SDKConfigBigSegmentsParams         `json:"bigSegments,omitempty"`
 }
 
 type SDKConfigStreamingParams struct {
@@ -27,4 +29,16 @@ type SDKConfigEventParams struct {
 	GlobalPrivateAttributes []lduser.UserAttribute     `json:"globalPrivateAttributes,omitempty"`
 	FlushIntervalMS         ldtime.UnixMillisecondTime `json:"flushIntervalMs,omitempty"`
 	InlineUsers             bool                       `json:"inlineUsers,omitempty"`
+}
+
+type SDKConfigPersistentDataStoreParams struct {
+	CallbackURI string `json:"callbackURI"`
+}
+
+type SDKConfigBigSegmentsParams struct {
+	CallbackURI          string                     `json:"callbackUri"`
+	UserCacheSize        ldvalue.OptionalInt        `json:"userCacheSize,omitempty"`
+	UserCacheTimeMS      ldtime.UnixMillisecondTime `json:"userCacheTimeMs,omitempty"`
+	StatusPollIntervalMS ldtime.UnixMillisecondTime `json:"statusPollIntervalMs,omitempty"`
+	StaleAfterMS         ldtime.UnixMillisecondTime `json:"staleAfterMs,omitempty"`
 }

--- a/servicedef/service_params.go
+++ b/servicedef/service_params.go
@@ -10,6 +10,9 @@ const (
 	CapabilityAllFlagsWithReasons                = "all-flags-with-reasons"
 	CapabilityAllFlagsClientSideOnly             = "all-flags-client-side-only"
 	CapabilityAllFlagsDetailsOnlyForTrackedFlags = "all-flags-details-only-for-tracked-flags"
+
+	CapabilityPersistentDataStore = "persistent-data-store"
+	CapabilityBigSegments         = "big-segments"
 )
 
 type StatusRep struct {


### PR DESCRIPTION
This PR adds a test suite for the non-database-specific components of Big Segments, for SDKs that have that feature.

There are two parts to Big Segment support in a server-side SDK:
* The Big Segment store, which is an integration with a specific database, implementing a standard query API with two methods, "get metadata" and "get user membership" (as defined in the internal spec "Big (Unbounded) Segments (SDK team focused) Spec"). It is normally implemented in the same place as the persistent feature store integration for the same database. The SDK test harness cannot test this, because testing it requires a real database.
* The core logic, which is all the Big Segments-related logic in the SDK that is _not_ specific to a database. This is described in two internal specs: the one mentioned above, and also the parts of the "Feature flag evaluation algorithm" spec that deal with Big Segments.

The new contract tests test the core logic. The test harness creates a simulation of a Big Segment store, implemented as a simple REST service. It provides the base URI of this service as part of the test service configuration. The test service is responsible for creating its own implementation of the Big Segment store API, and for each method in that API, it makes a corresponding call to the simulated big segment store callback service, passing whatever test data (or error) was provided by the test harness back to the SDK. The test harness then verifies that the SDK behaves the way we would expect it to if a real database returned those results, in terms of using the results in evaluations, caching the results, reporting errors, etc.

The test coverage is nearly equivalent to the unit tests that we currently have for this feature in the Go and .NET SDKs. It is testing at a higher level than the unit tests, in that it operates only through the public SDK API rather than testing the underlying lower-level components, but given the fairly simple nature of the interactions between the SDK and the store component, that should be adequate.

One thing that's currently missing is the ability to test the _status listener_ mechanism that the SDKs generally provide— a push notification system for detecting changes in the store status. It should be possible to add tests for this with a similar callback system, but I'll save that for another PR. Once we have that, I believe we will have fully replicated the current test coverage in a cross-platform way, and we can consider simplifying the per-SDK unit tests in this area in the future.