### PR TITLE
fix validation of feature & debug events regarding nullable properties

### DIFF
--- a/mockld/event_data.go
+++ b/mockld/event_data.go
@@ -48,8 +48,8 @@ func (e Event) CanonicalizedJSONString() string {
 	}
 	var nullableProps []string
 	switch e.Kind() {
-	case "feature":
-		nullableProps = []string{"userKey", "user", "version", "variation", "reason", "default"}
+	case "feature", "debug":
+		nullableProps = []string{"userKey", "user", "version", "variation", "reason", "default", "prereqOf"}
 	case "custom":
 		nullableProps = []string{"userKey", "user", "data", "metricValue"}
 	}

--- a/sdktests/custom_matchers.go
+++ b/sdktests/custom_matchers.go
@@ -142,6 +142,8 @@ func EventIsFeatureEvent(
 	}
 	if prereqOfFlagKey != "" {
 		o.Set("prereqOf", ldvalue.String(prereqOfFlagKey))
+	} else {
+		o.Set("prereqOf", ldvalue.Null())
 	}
 	return CanonicalizedEventJSON().Should(m.JSONEqual(o.Build()))
 }


### PR DESCRIPTION
Currently, our event JSON spec is agnostic as to whether properties with null values should be entirely omitted or not; event-recorder doesn't care. There is logic in sdk-test-harness to adjust for this, so SDKs are allowed to do it either way for properties that might be null in the data we're verifying.

However, I forgot about the `prereqOf` property, so the tests were pickier about that one than the rest. Also, I forgot to apply the same logic to `debug` events... which made me realize that I completely forgot to write any tests for debug events. I'll do those in a separate PR.

We may at some point decide that we want to strictly enforce dropping null properties so that the SDK output is as compact as possible, but that is not currently a requirement.