### PR TITLE
add event test logic for debug events and contextKind

### DIFF
--- a/mockld/event_data.go
+++ b/mockld/event_data.go
@@ -32,30 +32,21 @@ func (e Event) Kind() string {
 // CanonicalizedJSONString transforms the JSON formatting of the event to make comparisons
 // reliable, as follows: 1. Drop the creationDate property, since its value is unpredictable.
 // 2. Call EventUser.CanonicalizedJSONString on user properties, if any. 3. Ensure that
-// all expected properties, if nullable, do appear in the object when null instead of being
-// omitted.
+// all nullable properties are omitted if their value is null (so we can write more concise
+// test expectations).
 func (e Event) CanonicalizedJSONString() string {
 	b := ldvalue.ObjectBuild()
 	for key, value := range ldvalue.Value(e).AsValueMap().AsMap() {
-		if key == "creationDate" {
+		if value.IsNull() {
+			continue
+		}
+		switch key {
+		case "creationDate":
 			continue // We won't try to make assertions about the timestamp, just omit it
-		}
-		if key == "user" {
+		case "user":
 			b.Set(key, ldvalue.Raw([]byte(EventUser(value).CanonicalizedJSONString())))
-		} else {
+		default:
 			b.Set(key, value)
-		}
-	}
-	var nullableProps []string
-	switch e.Kind() {
-	case "feature", "debug":
-		nullableProps = []string{"userKey", "user", "version", "variation", "reason", "default", "prereqOf"}
-	case "custom":
-		nullableProps = []string{"userKey", "user", "data", "metricValue"}
-	}
-	for _, k := range nullableProps {
-		if !ldvalue.Value(e).GetByKey(k).IsDefined() {
-			b.Set(k, ldvalue.Null())
 		}
 	}
 	return b.Build().JSONString()
@@ -172,3 +163,5 @@ func (u EventUser) CanonicalizedJSONString() string {
 func (u EventUser) AsValue() ldvalue.Value { return ldvalue.Value(u) }
 
 func (u EventUser) GetKey() string { return u.AsValue().GetByKey("key").StringValue() }
+
+func (u EventUser) IsAnonymous() bool { return u.AsValue().GetByKey("anonymous").BoolValue() }

--- a/mockld/event_data.go
+++ b/mockld/event_data.go
@@ -48,8 +48,8 @@ func (e Event) CanonicalizedJSONString() string {
 	}
 	var nullableProps []string
 	switch e.Kind() {
-	case "feature":
-		nullableProps = []string{"userKey", "user", "version", "variation", "reason", "default"}
+	case "feature", "debug":
+		nullableProps = []string{"userKey", "user", "version", "variation", "reason", "default", "prereqOf"}
 	case "custom":
 		nullableProps = []string{"userKey", "user", "data", "metricValue"}
 	}

--- a/sdktests/custom_matchers.go
+++ b/sdktests/custom_matchers.go
@@ -142,6 +142,8 @@ func EventIsFeatureEvent(
 	}
 	if prereqOfFlagKey != "" {
 		o.Set("prereqOf", ldvalue.String(prereqOfFlagKey))
+	} else {
+		o.Set("prereqOf", ldvalue.Null())
 	}
 	return CanonicalizedEventJSON().Should(m.JSONEqual(o.Build()))
 }

--- a/sdktests/custom_matchers.go
+++ b/sdktests/custom_matchers.go
@@ -87,6 +87,7 @@ func EventIsCustomEvent(
 	o.Set("key", ldvalue.String(eventKey))
 	setPropertyConditionally(o, inlineUser, "user", eventUser.AsValue())
 	setPropertyConditionally(o, !inlineUser, "userKey", ldvalue.String(eventUser.GetKey()))
+	setPropertyConditionally(o, eventUser.IsAnonymous(), "contextKind", ldvalue.String("anonymousUser"))
 	setPropertyConditionally(o, !data.IsNull(), "data", data)
 	setPropertyConditionally(o, metricValue != nil, "metricValue", ldvalue.CopyArbitraryValue(metricValue))
 	return CanonicalizedEventJSON().Should(m.JSONEqual(o.Build()))
@@ -173,6 +174,7 @@ func EventIsIdentifyEvent(eventUser mockld.EventUser) m.Matcher {
 			Set("key", ldvalue.String(eventUser.GetKey())).
 			Set("user", eventUser.AsValue()).
 			Build()))
+	// identify events do *not* get a contextKind property for anonymous users
 }
 
 func EventIsIndexEvent(eventUser mockld.EventUser) m.Matcher {
@@ -181,6 +183,7 @@ func EventIsIndexEvent(eventUser mockld.EventUser) m.Matcher {
 			Set("kind", ldvalue.String("index")).
 			Set("user", eventUser.AsValue()).
 			Build()))
+	// index events do *not* get a contextKind property for anonymous users
 }
 
 func EventIsSummaryEvent() m.Matcher {

--- a/sdktests/custom_matchers.go
+++ b/sdktests/custom_matchers.go
@@ -85,15 +85,10 @@ func EventIsCustomEvent(
 	o := ldvalue.ObjectBuild()
 	o.Set("kind", ldvalue.String("custom"))
 	o.Set("key", ldvalue.String(eventKey))
-	if inlineUser {
-		o.Set("user", eventUser.AsValue())
-		o.Set("userKey", ldvalue.Null())
-	} else {
-		o.Set("user", ldvalue.Null())
-		o.Set("userKey", ldvalue.String(eventUser.GetKey()))
-	}
-	o.Set("data", data)
-	o.Set("metricValue", ldvalue.CopyArbitraryValue(metricValue))
+	setPropertyConditionally(o, inlineUser, "user", eventUser.AsValue())
+	setPropertyConditionally(o, !inlineUser, "userKey", ldvalue.String(eventUser.GetKey()))
+	setPropertyConditionally(o, !data.IsNull(), "data", data)
+	setPropertyConditionally(o, metricValue != nil, "metricValue", ldvalue.CopyArbitraryValue(metricValue))
 	return CanonicalizedEventJSON().Should(m.JSONEqual(o.Build()))
 }
 
@@ -121,30 +116,53 @@ func EventIsFeatureEvent(
 	defaultValue ldvalue.Value,
 	prereqOfFlagKey string,
 ) m.Matcher {
+	return eventIsFeatureOrDebugEvent("feature",
+		flagKey, eventUser, inlineUser, flagVersion, value, variation, reason, defaultValue, prereqOfFlagKey)
+}
+
+func EventIsDebugEvent(
+	flagKey string,
+	eventUser mockld.EventUser,
+	inlineUser bool,
+	flagVersion ldvalue.OptionalInt,
+	value ldvalue.Value,
+	variation ldvalue.OptionalInt,
+	reason ldreason.EvaluationReason,
+	defaultValue ldvalue.Value,
+	prereqOfFlagKey string,
+) m.Matcher {
+	return eventIsFeatureOrDebugEvent("debug",
+		flagKey, eventUser, inlineUser, flagVersion, value, variation, reason, defaultValue, prereqOfFlagKey)
+}
+
+func eventIsFeatureOrDebugEvent(
+	kind string,
+	flagKey string,
+	eventUser mockld.EventUser,
+	inlineUser bool,
+	flagVersion ldvalue.OptionalInt,
+	value ldvalue.Value,
+	variation ldvalue.OptionalInt,
+	reason ldreason.EvaluationReason,
+	defaultValue ldvalue.Value,
+	prereqOfFlagKey string,
+) m.Matcher {
 	o := ldvalue.ObjectBuild()
-	o.Set("kind", ldvalue.String("feature"))
+	// For all nullable properties, we deliberately omit the property here if the value would be null,
+	// even though an SDK might or might not do so, because we're comparing against the result of
+	// CanonicalizedEventJSON().
+	o.Set("kind", ldvalue.String(kind))
 	o.Set("key", ldvalue.String(flagKey))
 	o.Set("version", flagVersion.AsValue())
-	if inlineUser {
-		o.Set("user", eventUser.AsValue())
-		o.Set("userKey", ldvalue.Null())
-	} else {
-		o.Set("user", ldvalue.Null())
-		o.Set("userKey", ldvalue.String(eventUser.GetKey()))
-	}
-	o.Set("value", value)
-	o.Set("variation", variation.AsValue())
-	o.Set("default", defaultValue)
-	if reason.IsDefined() {
-		o.Set("reason", ldvalue.Raw(jsonhelpers.ToJSON(reason)))
-	} else {
-		o.Set("reason", ldvalue.Null())
-	}
-	if prereqOfFlagKey != "" {
-		o.Set("prereqOf", ldvalue.String(prereqOfFlagKey))
-	} else {
-		o.Set("prereqOf", ldvalue.Null())
-	}
+	setPropertyConditionally(o, inlineUser, "user", eventUser.AsValue())
+	setPropertyConditionally(o, !inlineUser, "userKey", ldvalue.String(eventUser.GetKey()))
+	setPropertyConditionally(o, eventUser.IsAnonymous(), "contextKind", ldvalue.String("anonymousUser"))
+	// Note that we expect SDKs to omit contextKind in the usual case where its value would have been "user"
+	setPropertyConditionally(o, !value.IsNull(), "value", value)
+	setPropertyConditionally(o, variation.IsDefined(), "variation", variation.AsValue())
+	setPropertyConditionally(o, defaultValue.IsDefined(), "default", defaultValue)
+	setPropertyConditionally(o, reason.IsDefined(), "reason", ldvalue.Raw(jsonhelpers.ToJSON(reason)))
+	setPropertyConditionally(o, prereqOfFlagKey != "", "prereqOf", ldvalue.String(prereqOfFlagKey))
 	return CanonicalizedEventJSON().Should(m.JSONEqual(o.Build()))
 }
 

--- a/sdktests/helpers.go
+++ b/sdktests/helpers.go
@@ -166,17 +166,23 @@ func pollUntilFlagValueUpdated(
 		time.Second, time.Millisecond*50, "timed out without seeing updated flag value")
 }
 
+func selectString(boolValue bool, valueIfTrue, valueIfFalse string) string {
+	if boolValue {
+		return valueIfTrue
+	}
+	return valueIfFalse
+}
+
+func setPropertyConditionally(o ldvalue.ObjectBuilder, condition bool, name string, value ldvalue.Value) {
+	if condition {
+		o.Set(name, value)
+	}
+}
+
 func timeValueAsPointer(value ldtime.UnixMillisecondTime) *ldtime.UnixMillisecondTime {
 	return &value
 }
 
 func testDescFromType(valueType servicedef.ValueType) string {
 	return fmt.Sprintf("type: %s", valueType)
-}
-
-func testDescWithOrWithoutReason(withReason bool) string {
-	if withReason {
-		return "with reason"
-	}
-	return "without reason"
 }

--- a/sdktests/server_side_events_eval.go
+++ b/sdktests/server_side_events_eval.go
@@ -100,10 +100,7 @@ func doServerSideFeatureEventTests(t *ldtest.T) {
 					expectedValue = defaultValues(valueType)
 					expectedVariation = ldvalue.OptionalInt{}
 				}
-				user := users.NextUniqueUser()
-				if isAnonymousUser {
-					user = lduser.NewUserBuilderFromUser(user).Anonymous(true).Build()
-				}
+				user := users.NextUniqueUserMaybeAnonymous(isAnonymousUser)
 				eventUser := mockld.SimpleEventUser(user)
 				resp := client.EvaluateFlag(t, servicedef.EvaluateFlagParams{
 					FlagKey:      flag.Key,

--- a/sdktests/server_side_events_eval.go
+++ b/sdktests/server_side_events_eval.go
@@ -1,12 +1,15 @@
 package sdktests
 
 import (
+	"time"
+
 	"github.com/launchdarkly/sdk-test-harness/framework/ldtest"
 	"github.com/launchdarkly/sdk-test-harness/mockld"
 	"github.com/launchdarkly/sdk-test-harness/servicedef"
 
 	m "github.com/launchdarkly/go-test-helpers/v2/matchers"
 	"gopkg.in/launchdarkly/go-sdk-common.v2/ldreason"
+	"gopkg.in/launchdarkly/go-sdk-common.v2/ldtime"
 	"gopkg.in/launchdarkly/go-sdk-common.v2/lduser"
 	"gopkg.in/launchdarkly/go-sdk-common.v2/ldvalue"
 	"gopkg.in/launchdarkly/go-server-sdk-evaluation.v1/ldbuilders"
@@ -19,11 +22,12 @@ import (
 func doServerSideFeatureEventTests(t *ldtest.T) {
 	flagValues := FlagValueByTypeFactory()
 	defaultValues := DefaultValueByTypeFactory()
-	users := NewUserFactory("doServerSideEvaluationBasicEventTests")
+	users := NewUserFactory("doServerSideFeatureEventTests")
 	expectedReason := ldreason.NewEvalReasonFallthrough()
 	untrackedFlags := FlagFactoryForValueTypes{
 		KeyPrefix:    "untracked-flag-",
 		ValueFactory: flagValues,
+		Reason:       expectedReason,
 	}
 	trackedFlags := FlagFactoryForValueTypes{
 		KeyPrefix:      "tracked-flag-",
@@ -44,143 +48,94 @@ func doServerSideFeatureEventTests(t *ldtest.T) {
 	dataSource := NewSDKDataSource(t, dataBuilder.Build())
 	events := NewSDKEventSink(t)
 
-	makeEvalParams := func(
-		flag ldmodel.FeatureFlag,
-		user lduser.User,
-		valueType servicedef.ValueType,
-		detail bool,
-	) servicedef.EvaluateFlagParams {
-		return servicedef.EvaluateFlagParams{
-			FlagKey:      flag.Key,
-			User:         &user,
-			ValueType:    valueType,
-			DefaultValue: defaultValues(valueType),
-			Detail:       detail,
-		}
-	}
-
 	client := NewSDKClient(t, dataSource, events)
 
 	t.Run("only index + summary event for untracked flag", func(t *ldtest.T) {
-		for _, valueType := range getValueTypesToTest(t) {
-			t.Run(testDescFromType(valueType), func(t *ldtest.T) {
-				flag := untrackedFlags.ForType(valueType)
-				user := users.NextUniqueUser()
-				eventUser := mockld.SimpleEventUser(user)
-				resp := client.EvaluateFlag(t, makeEvalParams(flag, user, valueType, false))
-				// If the evaluation didn't return the expected value, then the rest of the test is moot
-				if !m.In(t).Assert(flag.Variations[0], m.JSONEqual(resp.Value)) {
-					require.Fail(t, "evaluation unexpectedly returned wrong value")
-				}
+		for _, withReason := range []bool{false, true} {
+			t.Run(selectString(withReason, "with reasons", "without reasons"), func(t *ldtest.T) {
+				for _, valueType := range getValueTypesToTest(t) {
+					t.Run(testDescFromType(valueType), func(t *ldtest.T) {
+						flag := untrackedFlags.ForType(valueType)
+						user := users.NextUniqueUser()
+						eventUser := mockld.SimpleEventUser(user)
 
-				client.FlushEvents(t)
-				payload := events.ExpectAnalyticsEvents(t, defaultEventTimeout)
-				m.In(t).Assert(payload, m.ItemsInAnyOrder(
-					EventIsIndexEvent(eventUser),
-					EventHasKind("summary"),
-				))
+						resp := client.EvaluateFlag(t, servicedef.EvaluateFlagParams{
+							FlagKey:      flag.Key,
+							User:         &user,
+							ValueType:    valueType,
+							DefaultValue: defaultValues(valueType),
+							Detail:       withReason,
+						})
+
+						// If the evaluation didn't return the expected value, then the rest of the test is moot
+						if !m.In(t).Assert(flag.Variations[0], m.JSONEqual(resp.Value)) {
+							require.Fail(t, "evaluation unexpectedly returned wrong value")
+						}
+						if withReason {
+							m.In(t).Assert(resp.Reason, m.JSONEqual(expectedReason))
+						} else {
+							m.In(t).Assert(resp.Reason, m.JSONEqual(ldreason.EvaluationReason{}))
+						}
+
+						client.FlushEvents(t)
+						payload := events.ExpectAnalyticsEvents(t, defaultEventTimeout)
+						m.In(t).Assert(payload, m.ItemsInAnyOrder(
+							EventIsIndexEvent(eventUser),
+							EventHasKind("summary"),
+						))
+					})
+				}
 			})
 		}
 	})
 
-	t.Run("full feature event for tracked flag, without reason", func(t *ldtest.T) {
+	doFeatureEventTest := func(t *ldtest.T, withReason, isAnonymousUser, isBadFlag bool) {
 		for _, valueType := range getValueTypesToTest(t) {
 			t.Run(testDescFromType(valueType), func(t *ldtest.T) {
 				flag := trackedFlags.ForType(valueType)
-				user := users.NextUniqueUser()
-				eventUser := mockld.SimpleEventUser(user)
-				resp := client.EvaluateFlag(t, makeEvalParams(flag, user, valueType, false))
-				// If the evaluation didn't return the expected value, then the rest of the test is moot
-				if !m.In(t).Assert(flagValues(valueType), m.JSONEqual(resp.Value)) {
-					require.Fail(t, "evaluation unexpectedly returned wrong value")
+				expectedValue := flagValues(valueType)
+				expectedVariation := ldvalue.NewOptionalInt(0)
+				if isBadFlag {
+					flag = malformedFlag
+					expectedValue = defaultValues(valueType)
+					expectedVariation = ldvalue.OptionalInt{}
 				}
-
-				client.FlushEvents(t)
-
-				matchFeatureEvent := EventIsFeatureEvent(
-					flag.Key,
-					eventUser,
-					false,
-					ldvalue.NewOptionalInt(flag.Version),
-					flagValues(valueType),
-					ldvalue.NewOptionalInt(0),
-					ldreason.EvaluationReason{},
-					defaultValues(valueType),
-					"",
-				)
-
-				payload := events.ExpectAnalyticsEvents(t, defaultEventTimeout)
-				m.In(t).Assert(payload, m.ItemsInAnyOrder(
-					EventIsIndexEvent(eventUser),
-					matchFeatureEvent,
-					EventHasKind("summary"),
-				))
-			})
-		}
-	})
-
-	t.Run("full feature event for tracked flag, with reason", func(t *ldtest.T) {
-		for _, valueType := range getValueTypesToTest(t) {
-			t.Run(testDescFromType(valueType), func(t *ldtest.T) {
-				flag := trackedFlags.ForType(valueType)
 				user := users.NextUniqueUser()
-				eventUser := mockld.SimpleEventUser(user)
-				resp := client.EvaluateFlag(t, makeEvalParams(flag, user, valueType, true))
-				// If the evaluation didn't return the expected value, then the rest of the test is moot
-				if !m.In(t).Assert(flagValues(valueType), m.JSONEqual(resp.Value)) {
-					require.Fail(t, "evaluation unexpectedly returned wrong value")
+				if isAnonymousUser {
+					user = lduser.NewUserBuilderFromUser(user).Anonymous(true).Build()
 				}
-
-				client.FlushEvents(t)
-
-				matchFeatureEvent := EventIsFeatureEvent(
-					flag.Key,
-					eventUser,
-					false,
-					ldvalue.NewOptionalInt(flag.Version),
-					flagValues(valueType),
-					ldvalue.NewOptionalInt(0),
-					expectedReason,
-					defaultValues(valueType),
-					"",
-				)
-
-				payload := events.ExpectAnalyticsEvents(t, defaultEventTimeout)
-				m.In(t).Assert(payload, m.ItemsInAnyOrder(
-					EventIsIndexEvent(eventUser),
-					matchFeatureEvent,
-					EventHasKind("summary"),
-				))
-			})
-		}
-	})
-
-	t.Run("full feature event for failed tracked flag, with reason", func(t *ldtest.T) {
-		for _, valueType := range getValueTypesToTest(t) {
-			t.Run(testDescFromType(valueType), func(t *ldtest.T) {
-				defaultValue := defaultValues(valueType)
-				user := users.NextUniqueUser()
 				eventUser := mockld.SimpleEventUser(user)
 				resp := client.EvaluateFlag(t, servicedef.EvaluateFlagParams{
-					FlagKey:      malformedFlag.Key,
+					FlagKey:      flag.Key,
 					User:         &user,
 					ValueType:    valueType,
-					DefaultValue: defaultValue,
-					Detail:       true,
+					DefaultValue: defaultValues(valueType),
+					Detail:       withReason,
 				})
-				m.In(t).Assert(resp.Value, m.JSONEqual(defaultValue))
+
+				// If the evaluation didn't return the expected value, then the rest of the test is moot
+				if !m.In(t).Assert(expectedValue, m.JSONEqual(resp.Value)) {
+					require.Fail(t, "evaluation unexpectedly returned wrong value")
+				}
 
 				client.FlushEvents(t)
 
+				var reason ldreason.EvaluationReason
+				if withReason {
+					reason = expectedReason
+					if isBadFlag {
+						reason = ldreason.NewEvalReasonError(ldreason.EvalErrorMalformedFlag)
+					}
+				}
 				matchFeatureEvent := EventIsFeatureEvent(
-					malformedFlag.Key,
+					flag.Key,
 					eventUser,
 					false,
-					ldvalue.NewOptionalInt(malformedFlag.Version),
-					defaultValue,
-					ldvalue.OptionalInt{},
-					ldreason.NewEvalReasonError(ldreason.EvalErrorMalformedFlag),
-					defaultValue,
+					ldvalue.NewOptionalInt(flag.Version),
+					expectedValue,
+					expectedVariation,
+					reason,
+					defaultValues(valueType),
 					"",
 				)
 
@@ -192,6 +147,160 @@ func doServerSideFeatureEventTests(t *ldtest.T) {
 				))
 			})
 		}
+	}
+
+	t.Run("full feature event for tracked flag", func(t *ldtest.T) {
+		for _, withReason := range []bool{false, true} {
+			t.Run(selectString(withReason, "with reason", "without reason"), func(t *ldtest.T) {
+				for _, isAnonymousUser := range []bool{false, true} {
+					t.Run(selectString(isAnonymousUser, "anonymous user", "non-anonymous user"), func(t *ldtest.T) {
+						for _, isBadFlag := range []bool{false, true} {
+							t.Run(selectString(isBadFlag, "malformed flag", "valid flag"), func(t *ldtest.T) {
+								doFeatureEventTest(t, withReason, isAnonymousUser, isBadFlag)
+							})
+						}
+					})
+				}
+			})
+		}
+	})
+}
+
+func doServerSideDebugEventTests(t *ldtest.T) {
+	// These tests could misbehave if the system clocks of the host that's running the test harness
+	// and the host that's running the test service are out of sync by at least an hour. However,
+	// in normal usage those are the same host.
+
+	flagValues := FlagValueByTypeFactory()
+	defaultValues := DefaultValueByTypeFactory()
+	users := NewUserFactory("doServerSideDebugEventTests")
+	expectedReason := ldreason.NewEvalReasonFallthrough()
+
+	doDebugTest := func(
+		t *ldtest.T,
+		shouldSeeDebugEvent bool,
+		flagDebugUntil time.Time,
+		lastKnownTimeFromLD time.Time,
+	) {
+		flags := FlagFactoryForValueTypes{
+			KeyPrefix:    "flag",
+			ValueFactory: flagValues,
+			Reason:       expectedReason,
+			BuilderActions: func(b *ldbuilders.FlagBuilder) {
+				b.DebugEventsUntilDate(ldtime.UnixMillisFromTime(flagDebugUntil))
+			},
+		}
+		dataBuilder := mockld.NewServerSDKDataBuilder()
+		for _, valueType := range getValueTypesToTest(t) {
+			dataBuilder.Flag(flags.ForType(valueType))
+		}
+		dataSource := NewSDKDataSource(t, dataBuilder.Build())
+
+		events := NewSDKEventSink(t)
+		if !lastKnownTimeFromLD.IsZero() {
+			events.Service().SetHostTimeOverride(lastKnownTimeFromLD)
+		}
+
+		client := NewSDKClient(t, dataSource, events)
+
+		if !lastKnownTimeFromLD.IsZero() {
+			// In this scenario, we want the SDK to be aware of the LD host's clock because it
+			// has seen a Date header in an event post response. Send an unimportant event so
+			// the SDK will see a response before we do the rest of the test.
+			client.SendIdentifyEvent(t, users.NextUniqueUser())
+			client.FlushEvents(t)
+			_ = events.ExpectAnalyticsEvents(t, defaultEventTimeout)
+		}
+
+		for _, withReasons := range []bool{false, true} {
+			t.Run(selectString(withReasons, "with reasons", "without reasons"), func(t *ldtest.T) {
+				for _, valueType := range getValueTypesToTest(t) {
+					t.Run(testDescFromType(valueType), func(t *ldtest.T) {
+						user := users.NextUniqueUser()
+						eventUser := mockld.SimpleEventUser(user)
+						flag := flags.ForType(valueType)
+						result := client.EvaluateFlag(t, servicedef.EvaluateFlagParams{
+							FlagKey:      flag.Key,
+							User:         &user,
+							ValueType:    valueType,
+							DefaultValue: defaultValues(valueType),
+							Detail:       withReasons,
+						})
+						m.In(t).Assert(result.Value, m.JSONEqual(flagValues(valueType)))
+
+						client.FlushEvents(t)
+						payload := events.ExpectAnalyticsEvents(t, defaultEventTimeout)
+
+						if shouldSeeDebugEvent {
+							reason := ldreason.EvaluationReason{}
+							if withReasons {
+								reason = expectedReason
+							}
+							matchDebugEvent := EventIsDebugEvent(
+								flag.Key,
+								eventUser,
+								true,
+								ldvalue.NewOptionalInt(flag.Version),
+								result.Value,
+								ldvalue.NewOptionalInt(0),
+								reason,
+								defaultValues(valueType),
+								"",
+							)
+							m.In(t).Assert(payload, m.ItemsInAnyOrder(
+								EventIsIndexEvent(eventUser),
+								matchDebugEvent,
+								EventHasKind("summary"),
+							))
+						} else {
+							m.In(t).Assert(payload, m.ItemsInAnyOrder(
+								EventIsIndexEvent(eventUser),
+								EventHasKind("summary"),
+							))
+						}
+					})
+				}
+			})
+		}
+	}
+	shouldSeeDebugEvent := func(t *ldtest.T, debugUntil time.Time, lastKnownTimeFromLD time.Time) {
+		doDebugTest(t, true, debugUntil, lastKnownTimeFromLD)
+	}
+	shouldNotSeeDebugEvent := func(t *ldtest.T, debugUntil time.Time, lastKnownTimeFromLD time.Time) {
+		doDebugTest(t, false, debugUntil, lastKnownTimeFromLD)
+	}
+
+	t.Run("should see debug event", func(t *ldtest.T) {
+		t.Run("debugEventsUntilDate is after SDK time", func(t *ldtest.T) {
+			futureDebugUntil := time.Now().Add(time.Hour)
+			t.Run("SDK does not know LD time", func(t *ldtest.T) {
+				shouldSeeDebugEvent(t, futureDebugUntil, time.Time{})
+			})
+			t.Run("SDK knows LD time is before debugEventsUntilDate", func(t *ldtest.T) {
+				shouldSeeDebugEvent(t, futureDebugUntil, futureDebugUntil.Add(-time.Minute))
+			})
+		})
+	})
+
+	t.Run("should not see debug event", func(t *ldtest.T) {
+		t.Run("debugEventsUntilDate is before SDK time", func(t *ldtest.T) {
+			pastDebugUntil := time.Now().Add(-time.Hour)
+			t.Run("SDK does not know LD time", func(t *ldtest.T) {
+				shouldNotSeeDebugEvent(t, pastDebugUntil, time.Time{})
+			})
+			t.Run("SDK knows LD time is before debugEventsUntilDate", func(t *ldtest.T) {
+				shouldNotSeeDebugEvent(t, pastDebugUntil, pastDebugUntil.Add(-time.Minute))
+			})
+			t.Run("SDK knows LD time is after debugEventsUntilDate", func(t *ldtest.T) {
+				shouldNotSeeDebugEvent(t, pastDebugUntil, pastDebugUntil.Add(time.Minute))
+			})
+		})
+		t.Run("debugEventsUntilDate is after SDK time", func(t *ldtest.T) {
+			futureDebugUntil := time.Now().Add(time.Hour)
+			t.Run("SDK knows LD time is after debugEventsUntilDate", func(t *ldtest.T) {
+				shouldNotSeeDebugEvent(t, futureDebugUntil, futureDebugUntil.Add(time.Minute))
+			})
+		})
 	})
 }
 
@@ -225,7 +334,7 @@ func doServerSideFeaturePrerequisiteEventTests(t *ldtest.T) {
 		Build()
 
 	for _, withReason := range []bool{false, true} {
-		t.Run(testDescWithOrWithoutReason(withReason), func(t *ldtest.T) {
+		t.Run(selectString(withReason, "with reasons", "without reasons"), func(t *ldtest.T) {
 			dataBuilder := mockld.NewServerSDKDataBuilder()
 			dataBuilder.Flag(flag1, flag2, flag3)
 

--- a/sdktests/testapi_sdk_events.go
+++ b/sdktests/testapi_sdk_events.go
@@ -55,6 +55,9 @@ func (e *SDKEventSink) ApplyConfiguration(config *servicedef.SDKConfigParams) {
 	config.Events.BaseURI = e.eventsEndpoint.BaseURL()
 }
 
+// Service returns the underlying mock events service component, for access to special options.
+func (e *SDKEventSink) Service() *mockld.EventsService { return e.eventsService }
+
 // ExpectAnalyticsEvents waits for event data to be posted to the endpoint, and then calls
 // matchers.ItemsInAnyOrder with the specified eventMatchers, verifying that the payload contains
 // one event matching each of the matchers regardless of ordering.

--- a/sdktests/testdata_factories.go
+++ b/sdktests/testdata_factories.go
@@ -35,6 +35,14 @@ func (f *UserFactory) NextUniqueUser() lduser.User {
 	return builder.Build()
 }
 
+func (f *UserFactory) NextUniqueUserMaybeAnonymous(shouldBeAnonymous bool) lduser.User {
+	user := f.NextUniqueUser()
+	if shouldBeAnonymous {
+		return lduser.NewUserBuilderFromUser(user).Anonymous(true).Build()
+	}
+	return user
+}
+
 type FlagFactory interface {
 	MakeFlag(param interface{}) ldmodel.FeatureFlag
 }

--- a/sdktests/testsuite_server_side.go
+++ b/sdktests/testsuite_server_side.go
@@ -63,6 +63,7 @@ func doServerSideDataStoreTests(t *ldtest.T) {
 func doServerSideEventTests(t *ldtest.T) {
 	t.Run("summary events", doServerSideSummaryEventTests)
 	t.Run("feature events", doServerSideFeatureEventTests)
+	t.Run("debug events", doServerSideDebugEventTests)
 	t.Run("feature prerequisite events", doServerSideFeaturePrerequisiteEventTests)
 	t.Run("experimentation", doServerSideExperimentationEventTests)
 	t.Run("identify events", doServerSideIdentifyEventTests)


### PR DESCRIPTION
This improves test coverage for SDK event behavior as follows:

* Add tests to verify that `debug` events are generated if and only if they should be generated. This includes testing the somewhat convoluted logic that the SDKs use to check the debug expiration time against both their own current time and the last `Date` header they got from an LD event post, if any (which can't be tested with integration-harness, and is not always possible to test well in the SDK unit tests either).
* For `feature`, `debug`, and `custom` events, we now verify that the SDK puts `"contextKind":"anonymousUser"` in the event for anonymous users.

We expect that all current SDK versions will pass these tests.

This also addresses [sc-139541](https://app.shortcut.com/launchdarkly/story/139541/minor-bugs-in-sdk-test-harness-prerequisite-event-tests).