### PR TITLE
Allow passing -skip parameters to run.sh

### DIFF
--- a/downloader/run.sh
+++ b/downloader/run.sh
@@ -51,4 +51,4 @@ if [ ! -x "${EXECUTABLE}" ]; then
   tar -xf "${TEMP_DIR}/archive.tar.gz" -C "${TEMP_DIR}"
 fi
 
-bash -c "${EXECUTABLE} $PARAMS"
+sh -c "${EXECUTABLE} $PARAMS"

--- a/downloader/run.sh
+++ b/downloader/run.sh
@@ -51,4 +51,4 @@ if [ ! -x "${EXECUTABLE}" ]; then
   tar -xf "${TEMP_DIR}/archive.tar.gz" -C "${TEMP_DIR}"
 fi
 
-"${EXECUTABLE}" $PARAMS
+bash -c "${EXECUTABLE} $PARAMS"


### PR DESCRIPTION
Using the standard Makefile setup, if I try to pass multiple -skip options to the run script, it fails to recognize them all.