### PR TITLE
add NonCritical option for tests + make some of the "all flags" assertions non-critical

### DIFF
--- a/docs/running.md
+++ b/docs/running.md
@@ -24,3 +24,34 @@ For `-run` and `-skip`, the rules for pattern matching are as follows:
 * However, `(` and `)` will always be treated as literal characters, not regular expression operators. This is because some tests may have parens in their names. If you want "or" behavior, instead of `-run (a|b)` just use `-run a -run b` (in other words, there is an implied "or" for multiple values).
 * If `-run` specifies a test that has subtests, then all of its subtests are also run.
 * If `-skip` specifies a test that has subtests, then all of its subtests are also skipped.
+
+## Output
+
+While tests are running, when each test starts a line is printed to standard output with the full path of the test in brackets, such as:
+
+```
+[evaluation/all flags state/with reasons]
+```
+
+If the test is skipped, you will see an explanation starting with `SKIPPED:` on the next line. A test could be skipped because of filter parameters like `-run` or `-skip`, or because the test is only for SDKs with a certain capability and the test service did not report having that capability.
+
+If the test failed, you will see `FAILED:` and a failure message, which normally includes both a description of the problem and a stacktrace. The stacktrace refers to the `sdk-test-harness` code and may be helpful in understanding the test logic.
+
+If you see `FAILED (non-critical):`, it means that the test failed but that the author of the test indicated SDKs don't necessarily need to pass it, by calling `t.NonCritical` within the test. This is normally accompanied by an explanatory message to help understand what kind of changes in the SDK's behavior are desirable.
+
+At the end, if all tests passed-- not counting tests that were skipped-- the output is "All tests passed" and the program returns a zero exit code.
+
+If some tests failed, it writes a summary of first the non-critical failures and then the regular failures to standard error. The program returns a non-zero exit code if there were any regular failures.
+
+### JUnit output for CircleCI
+
+When running in CircleCI, you will probably also want to create a JUnit-compatible test results file, since CircleCI knows how to parse the JUnit format. Do this by adding `-junit my_file_name.xml` to the command-line parameters, and make sure your CI job includes a directive like:
+
+```yaml
+      - store_test_results:
+          path: my_file_name.xml
+```
+
+Then you'll be able to see test failures called out individually on the Tests tab for the CI run.
+
+If there are non-critical failures, they will show up as failures in the results file since JUnit does not have a separate category for these. However, they will have "(non-critical)" appended to the name to make this clearer, and since the test harness still returns a zero exit code as long as all the failures were non-critical, the CI job will still pass.

--- a/docs/writing_tests.md
+++ b/docs/writing_tests.md
@@ -61,7 +61,7 @@ There are several ways to do this. When using `testify/assert` or `testify/requi
 
 Also, using the `matchers` API sometimes results in more helpful error messages. For instance, if you want to assert that every element in a slice has a certain property, using `matchers.Items` or `matchers.ItemsInAnyOrder` along with a matcher for the desired property is better than doing an equality test on the whole slice against the entire expected data set, because it won't care about any irrelevant properties, and because the property matcher will automatically give you an appropriate failure message. It's also better than doing a `for` loop over the slice and doing an assertion on each element, because you won't have to construct your own message to explain that the failure is for item 0, item 1, etc.
 
-Values in failure output may be formatted differently in `matchers`versus `testify`: for instance, values of types that have a JSON representation are shown as JSON in `matchers`, rather than using the result of `fmt.Sprintf("%v", value)` as `testify` does in most cases. The easiest way to see which kind of output would be most helpful for a particular test is to cause a deliberate failure in the test and see what you get.
+Values in failure output may be formatted differently in `matchers` versus `testify`: for instance, values of types that have a JSON representation are shown as JSON in `matchers`, rather than using the result of `fmt.Sprintf("%v", value)` as `testify` does in most cases. The easiest way to see which kind of output would be most helpful for a particular test is to cause a deliberate failure in the test and see what you get.
 
 ## Non-critical tests
 

--- a/docs/writing_tests.md
+++ b/docs/writing_tests.md
@@ -49,14 +49,30 @@ See documentation comments for a full description of the available API. Here is 
 
 Since the `ldtest.T` type implements the same basic interface as `testing.T` in terms of reporting failures, you can use any assertion framework that acts on an equivalent interface rather than specifically on `testing.T`.
 
-For instance, the `testify/assert` and `testify/require` packages will work with `ldtest.T` because they are written against an equivalent interface (`assert.TestingT` or `require.TestingT`). So, many of these tests use `assert` and `require` methods for convenience.
+For instance, the `testify/assert` and `testify/require` packages will work with `ldtest.T` because they are written against an equivalent interface (`assert.TestingT` or `require.TestingT`). So, many of these tests use `assert` and `require` methods for convenience. The `github.com/launchdarkly/go-test-helpers/v2/matchers` API is also interoperable with that interface; `matchers` is particularly helpful if you need to make assertions about elements within a slice or map.
 
-If an assertion fails, you may wish to either continue and allow more failures to accumulate, or immediately stop the test. That is up to you based on whether the failure is significant enough that it would make the rest of the test moot. The `ldtest.T` method `Errorf` records a failure without stopping, and `FailNow` makes it immediately terminate. When using the `testify` packages, the `assert` functions will call only `Errorf` whereas the `require` functions will call both `Errorf` and `FailNow`, so `require` always implies "stop here on failure".
-
-There is also a somewhat richer assertion API from `github.com/launchdarkly/go-test-helpers/v2/matchers`. This is similar in design to Java's Hamcrest package, providing self-describing assertions and combinators, which in some cases will provide clearer failure messages.
+If an assertion fails, you may wish to either continue and allow more failures to accumulate, or immediately stop the test. That is up to you based on whether the failure is significant enough that it would make the rest of the test moot. The `ldtest.T` method `Errorf` records a failure without stopping, and `FailNow` makes it immediately terminate. When using the `testify` packages, the `assert` functions will call only `Errorf` whereas the `require` functions will call both `Errorf` and `FailNow`, so `require` always implies "stop here on failure". The `matchers` API follows the same conventions with its `Assert` and `Require` methods.
 
 ## Making test failures clear
 
 If an SDK test fails, someone will have to interpret the test output and find the problem. They should not need to dig through the test harness code to understand the failure message (although the output does include a stacktrace to make that possible). So, if for instance the assertion is that the `variationIndex` property in some event data should have value X, ideally a failed assertion would not just print "expected value X but was Y", but should include some context to clarify that this is a `variationIndex`.
 
-There are several ways to do this. When using `testify/assert` or `testify/require`, the assertion functions have optional parameters for an additional message to be printed on failure. 
+There are several ways to do this. When using `testify/assert` or `testify/require`, the assertion functions have optional parameters for an additional message to be printed on failure.
+
+Also, using the `matchers` API sometimes results in more helpful error messages. For instance, if you want to assert that every element in a slice has a certain property, using `matchers.Items` or `matchers.ItemsInAnyOrder` along with a matcher for the desired property is better than doing an equality test on the whole slice against the entire expected data set, because it won't care about any irrelevant properties, and because the property matcher will automatically give you an appropriate failure message. It's also better than doing a `for` loop over the slice and doing an assertion on each element, because you won't have to construct your own message to explain that the failure is for item 0, item 1, etc.
+
+Values in failure output may be formatted differently in `matchers`versus `testify`: for instance, values of types that have a JSON representation are shown as JSON in `matchers`, rather than using the result of `fmt.Sprintf("%v", value)` as `testify` does in most cases. The easiest way to see which kind of output would be most helpful for a particular test is to cause a deliberate failure in the test and see what you get.
+
+## Non-critical tests
+
+Sometimes we may want to standardize some aspect of SDK behavior, but we know that many of the SDKs don't yet comply with this standard and we don't consider it to be mandatory, just desirable.
+
+In that case, at the top of a test you can call `t.NonCritical()`. This marks it as a "non-critical" test: if it fails, the failure will be reported, but it will be labeled as a non-critical failure and it will _not_ cause the overall test run to fail. `NonCritical` takes a string parameter which is an explanatory message to be included in the failure output, to save the reader trouble in interpreting the failure details. For instance:
+
+```go
+    t.NonCritical("If this test fails but the other evaluation tests passed, it means the SDK"+
+        " considers burnt sienna and puce to be the same color. We would prefer for them to be"+
+        " treated as two different colors.")
+```
+
+When using the `-junit` command-line option to produce a JUnit-compatible results file, non-critical failures are reported as regular failures, since JUnit does not have a separate category for these, but they will have "(non-critical)" appended to the test name.

--- a/framework/ldtest/junit_test_logger.go
+++ b/framework/ldtest/junit_test_logger.go
@@ -101,7 +101,7 @@ func (j *JUnitTestLogger) TestError(id TestID, err error) {
 	j.tests[id.String()] = status
 }
 
-func (j *JUnitTestLogger) TestFinished(id TestID, failed bool, debugOutput framework.CapturedOutput) {
+func (j *JUnitTestLogger) TestFinished(id TestID, result TestResult, debugOutput framework.CapturedOutput) {
 	j.lock.Lock()
 	defer j.lock.Unlock()
 	status := j.tests[id.String()]

--- a/framework/ldtest/result.go
+++ b/framework/ldtest/result.go
@@ -6,13 +6,16 @@ import (
 )
 
 type Results struct {
-	Tests    []TestResult
-	Failures []TestResult
+	Tests               []TestResult
+	Failures            []TestResult
+	NonCriticalFailures []TestResult
 }
 
 type TestResult struct {
-	TestID TestID
-	Errors []error
+	TestID      TestID
+	Errors      []error
+	NonCritical bool
+	Explanation string
 }
 
 func (r Results) OK() bool {
@@ -36,4 +39,8 @@ type TestFailure struct {
 
 func (f TestFailure) Error() string {
 	return fmt.Sprintf("[%s]: %s", f.ID, f.Err)
+}
+
+func (r TestResult) Failed() bool {
+	return len(r.Errors) != 0
 }

--- a/framework/ldtest/test_logger.go
+++ b/framework/ldtest/test_logger.go
@@ -12,6 +12,7 @@ import (
 
 var consoleTestErrorColor = color.New(color.FgYellow)              //nolint:gochecknoglobals
 var consoleTestFailedColor = color.New(color.FgRed)                //nolint:gochecknoglobals
+var consoleTestFailedNonCriticalColor = color.New(color.FgYellow)  //nolint:gochecknoglobals
 var consoleTestSkippedColor = color.New(color.Faint, color.FgBlue) //nolint:gochecknoglobals
 var consoleDebugOutputColor = color.New(color.Faint)               //nolint:gochecknoglobals
 var allTestsPassedColor = color.New(color.FgGreen)                 //nolint:gochecknoglobals
@@ -19,18 +20,18 @@ var allTestsPassedColor = color.New(color.FgGreen)                 //nolint:goch
 type TestLogger interface {
 	TestStarted(id TestID)
 	TestError(id TestID, err error)
-	TestFinished(id TestID, failed bool, debugOutput framework.CapturedOutput)
+	TestFinished(id TestID, result TestResult, debugOutput framework.CapturedOutput)
 	TestSkipped(id TestID, reason string)
 	EndLog(results Results) error
 }
 
 type nullTestLogger struct{}
 
-func (n nullTestLogger) TestStarted(TestID)                                  {}
-func (n nullTestLogger) TestError(TestID, error)                             {}
-func (n nullTestLogger) TestFinished(TestID, bool, framework.CapturedOutput) {}
-func (n nullTestLogger) TestSkipped(TestID, string)                          {}
-func (n nullTestLogger) EndLog(result Results) error                         { return nil }
+func (n nullTestLogger) TestStarted(TestID)                                        {}
+func (n nullTestLogger) TestError(TestID, error)                                   {}
+func (n nullTestLogger) TestFinished(TestID, TestResult, framework.CapturedOutput) {}
+func (n nullTestLogger) TestSkipped(TestID, string)                                {}
+func (n nullTestLogger) EndLog(result Results) error                               { return nil }
 
 type ConsoleTestLogger struct {
 	DebugOutputOnFailure bool
@@ -51,12 +52,17 @@ func (c ConsoleTestLogger) TestError(id TestID, err error) {
 	}
 }
 
-func (c ConsoleTestLogger) TestFinished(id TestID, failed bool, debugOutput framework.CapturedOutput) {
-	if failed {
-		_, _ = consoleTestFailedColor.Printf("  FAILED: %s\n", id)
+func (c ConsoleTestLogger) TestFinished(id TestID, result TestResult, debugOutput framework.CapturedOutput) {
+	if result.Failed() {
+		if result.NonCritical {
+			_, _ = consoleTestFailedNonCriticalColor.Printf("  FAILED (non-critical): %s\n", id)
+			_, _ = consoleTestFailedNonCriticalColor.Printf("  Explanation: %s\n", result.Explanation)
+		} else {
+			_, _ = consoleTestFailedColor.Printf("  FAILED: %s\n", id)
+		}
 	}
 	if len(debugOutput) > 0 &&
-		((failed && c.DebugOutputOnFailure) || (!failed && c.DebugOutputOnSuccess)) {
+		((result.Failed() && c.DebugOutputOnFailure) || (!result.Failed() && c.DebugOutputOnSuccess)) {
 		_, _ = consoleDebugOutputColor.Println(debugOutput.ToString("    DEBUG "))
 	}
 }
@@ -71,8 +77,27 @@ func (c ConsoleTestLogger) TestSkipped(id TestID, reason string) {
 
 func (c ConsoleTestLogger) EndLog(results Results) error {
 	if results.OK() {
-		_, _ = allTestsPassedColor.Println("All tests passed")
+		if len(results.NonCriticalFailures) == 0 {
+			_, _ = allTestsPassedColor.Println("All tests passed")
+		} else {
+			_, _ = allTestsPassedColor.Println("All critical tests passed")
+		}
 	} else {
+		_, _ = consoleTestFailedColor.Fprintln(os.Stderr, "Tests failed")
+	}
+
+	if len(results.NonCriticalFailures) != 0 {
+		fmt.Fprintln(os.Stderr)
+		_, _ = consoleTestFailedNonCriticalColor.Fprintf(os.Stderr,
+			"NON-CRITICAL FAILURES (%d):\n", len(results.NonCriticalFailures))
+		for _, f := range results.NonCriticalFailures {
+			_, _ = consoleTestFailedNonCriticalColor.Fprintf(os.Stderr, "  * %s\n", f.TestID)
+			_, _ = consoleTestFailedNonCriticalColor.Fprintf(os.Stderr, "      %s\n", f.Explanation)
+		}
+	}
+
+	if !results.OK() {
+		fmt.Fprintln(os.Stderr)
 		_, _ = consoleTestFailedColor.Fprintf(os.Stderr, "FAILED TESTS (%d):\n", len(results.Failures))
 		for _, f := range results.Failures {
 			_, _ = consoleTestFailedColor.Fprintf(os.Stderr, "  * %s\n", f.TestID)
@@ -94,9 +119,9 @@ func (m *MultiTestLogger) TestError(id TestID, err error) {
 	}
 }
 
-func (m *MultiTestLogger) TestFinished(id TestID, failed bool, debugOutput framework.CapturedOutput) {
+func (m *MultiTestLogger) TestFinished(id TestID, result TestResult, debugOutput framework.CapturedOutput) {
 	for _, l := range m.Loggers {
-		l.TestFinished(id, failed, debugOutput)
+		l.TestFinished(id, result, debugOutput)
 	}
 }
 


### PR DESCRIPTION
See story, plus the new docs text in this PR.

Along with implementing this feature, I made use of it in a test change as a proof of concept. The tests I added in https://github.com/launchdarkly/sdk-test-harness/pull/5 had strict expectations about the SDK stripping out null-valued properties from the JSON data. That's not something we ever really spec'd, even if it's generally desirable— and, because it was lumped in with the overall equality assertions that the tests were making, if an SDK did not strip the null values it would show up as a whole lot of "all flags" tests being broken, rather than showing more clearly that everything else works except for that. So, I changed the existing tests to be less strict in that regard, and added a separate non-critical test for just the null-stripping behavior. I'll do a follow-up PR that adds something similar for null values in events.