### PR TITLE
fix AllFlagsState "detail only for tracked flags" expectation

### DIFF
--- a/sdktests/server_side_eval_all_flags.go
+++ b/sdktests/server_side_eval_all_flags.go
@@ -8,6 +8,7 @@ import (
 	"github.com/launchdarkly/sdk-test-harness/mockld"
 	"github.com/launchdarkly/sdk-test-harness/servicedef"
 
+	m "github.com/launchdarkly/go-test-helpers/v2/matchers"
 	"gopkg.in/launchdarkly/go-sdk-common.v2/ldtime"
 	"gopkg.in/launchdarkly/go-sdk-common.v2/lduser"
 	"gopkg.in/launchdarkly/go-sdk-common.v2/ldvalue"
@@ -234,13 +235,15 @@ func doServerSideAllFlagsClientSideOnlyTest(t *ldtest.T) {
 }
 
 func doServerSideAllFlagsDetailsOnlyForTrackedFlagsTest(t *ldtest.T) {
-	// Note that it's really only the *reason* that is omitted for untracked flags in this mode.
-	// The variation index and flag version always must be included, because they're used in
-	// summary events.
+	// Note that it's only "version" and "reason" that are omitted for untracked flags in this mode.
+	// The variation index always must be included, because it's necessary for summary events. The
+	// point of this option is to save bandwidth for applications that don't care about evaluation
+	// reasons in their front-end code, but still want those to show up in event data when
+	// appropriate.
 
 	t.RequireCapability(servicedef.CapabilityAllFlagsDetailsOnlyForTrackedFlags)
 
-	// flag1 does not get a reason because it's not in any of the other categories below
+	// flag1 will have details removed because it's not in any of the other categories below
 	flag1 := ldbuilders.NewFlagBuilder("flag1").Version(100).
 		Variations(dummyValue0, ldvalue.String("value1")).
 		On(false).OffVariation(1).
@@ -280,7 +283,7 @@ func doServerSideAllFlagsDetailsOnlyForTrackedFlagsTest(t *ldtest.T) {
 		"flag3": "value3",
 		"$flagsState": {
 			"flag1": {
-				"variation": 1, "version": 100
+				"variation": 1
 			},
 			"flag2": {
 				"variation": 2, "version": 200, "reason": { "kind": "OFF" }, "trackEvents": true
@@ -292,7 +295,7 @@ func doServerSideAllFlagsDetailsOnlyForTrackedFlagsTest(t *ldtest.T) {
 		},
 		"$valid": true
 	}`
-	assert.JSONEq(t, expectedJSON, string(resultJSON))
+	m.In(t).Assert(resultJSON, m.JSONStrEqual(expectedJSON))
 }
 
 func doServerSideAllFlagsClientNotReadyTest(t *ldtest.T) {


### PR DESCRIPTION
I incorrectly had this test asserting that, if the "detail only for tracked flags" option was used with AllFlagsState, and a flag did not have event tracking or debugging enabled, then the `reason` property should be omitted but the `version` property should still be sent. Actually the intention was for both `reason` and `version` to be omitted— which is how we implemented it in nearly all of the SDKs, but the Go SDK was an outlier and I had based the test on that.

Specifically the idea behind this option is, if an application is passing bootstrap data from the back end to the JS SDK, and they have a ton of client-side flags, they would like the data to be less huge. As long as the front-end code does not care about evaluation reasons (that is, they're never calling `variationDetail`), the reasons will generally be irrelevant, except that if you're also using experimentation or event tracking/debugging, then you _do_ want to see reasons in the detailed `feature` events that it will produce. But for any flags where those things don't apply, `feature` events aren't produced, just summary events. Summary events do include a `version` property but it's not terribly relevant in most cases, so we decided we could do without it.