### PR TITLE
Do not use filepath.join with embedded paths because embedded paths must always use forward slash.

### DIFF
--- a/testdata/loader.go
+++ b/testdata/loader.go
@@ -52,7 +52,7 @@ func (s SourceInfo) ParamsString() string {
 // The path parameter is relative to testdata/data-files.
 func LoadDataFile(path string) ([]SourceInfo, error) {
 	ret := make([]SourceInfo, 0, 10) // preallocate a little because it's likely there will be multiple results
-	data, err := dataFilesRoot.ReadFile(filepath.Join(dataBasePath, path))
+	data, err := dataFilesRoot.ReadFile(dataBasePath + "/" + path)
 	if err != nil {
 		return nil, fmt.Errorf("failed to read %q: %w", path, err)
 	}
@@ -75,13 +75,13 @@ func LoadDataFile(path string) ([]SourceInfo, error) {
 //
 // The path parameter is relative to testdata/data-files.
 func LoadAllDataFiles(path string) ([]SourceInfo, error) {
-	files, err := dataFilesRoot.ReadDir(filepath.Join(dataBasePath, path))
+	files, err := dataFilesRoot.ReadDir(dataBasePath + "/" + path)
 	if err != nil {
 		return nil, err
 	}
 	var ret []SourceInfo
 	for _, file := range files {
-		filePath := filepath.Join(path, file.Name())
+		filePath := path + "/" + file.Name()
 		sources, err := LoadDataFile(filePath)
 		if err != nil {
 			return nil, err


### PR DESCRIPTION
…

Embedded files could not be loaded on windows because `filepath.join` will use `\` and the embedded paths always use `/`.

**Requirements**

~- [ ] I have added test coverage for new or changed functionality~
- [x] I have followed the repository's [pull request submission guidelines](../blob/master/CONTRIBUTING.md#submitting-pull-requests)
- [x] I have validated my changes against all supported platform versions

**Related issues**

Provide links to any issues in this repository or elsewhere relating to this pull request.

**Describe the solution you've provided**

Removed usages of filepath.join and instead just concatenate the path.

**Describe alternatives you've considered**

Provide a clear and concise description of any alternative solutions or features you've considered.

**Additional context**

Add any other context about the pull request here.
