### PR TITLE
improve logging for subtests

### DIFF
--- a/mockld/callback_helpers.go
+++ b/mockld/callback_helpers.go
@@ -38,14 +38,14 @@ func (c *callbackService) addPath(path string, handler func(*json.Decoder) (inte
 			_ = r.Body.Close()
 			requestDecoder = json.NewDecoder(bytes.NewBuffer(body))
 		}
-		c.logger.Printf("[%s] got POST %s %s", c.name, path, string(body))
+		c.logger.Printf("[%s] Got POST %s %s", c.name, path, string(body))
 
 		responseValue, err := handler(requestDecoder)
 		if err != nil {
 			w.Header().Set("content-type", "text/plain")
 			w.WriteHeader(http.StatusInternalServerError)
 			_, _ = w.Write([]byte(err.Error()))
-			c.logger.Printf("[%s] responded with 500 - %s", c.name, err.Error())
+			c.logger.Printf("[%s] Responded with 500 - %s", c.name, err.Error())
 		} else {
 			w.Header().Set("content-type", "application/json")
 			var respBody []byte
@@ -54,12 +54,12 @@ func (c *callbackService) addPath(path string, handler func(*json.Decoder) (inte
 				respBody, _ = json.Marshal(responseValue)
 				_, _ = w.Write(respBody)
 			}
-			c.logger.Printf("[%s] responded with 200 %s", c.name, string(respBody))
+			c.logger.Printf("[%s] Responded with 200 %s", c.name, string(respBody))
 		}
 	})
 }
 
 func (c *callbackService) close(w http.ResponseWriter, r *http.Request) {
-	c.logger.Printf("[%s] got DELETE - closing fixture", c.name)
+	c.logger.Printf("[%s] Got DELETE - closing fixture", c.name)
 	w.WriteHeader(http.StatusNoContent)
 }

--- a/mockld/events_service.go
+++ b/mockld/events_service.go
@@ -36,7 +36,7 @@ func NewEventsService(sdkKind SDKKind, credential string, logger framework.Logge
 }
 
 func (s *EventsService) ServeHTTP(w http.ResponseWriter, r *http.Request) {
-	s.logger.Printf("received %s %s", r.Method, r.URL)
+	s.logger.Printf("Received %s %s", r.Method, r.URL)
 	switch r.URL.Path {
 	case "/bulk":
 		s.postEvents(w, r)
@@ -70,7 +70,7 @@ func (s *EventsService) postEvents(w http.ResponseWriter, r *http.Request) {
 	data, err := ioutil.ReadAll(r.Body)
 	if err != nil {
 		w.WriteHeader(http.StatusInternalServerError)
-		s.logger.Printf("unable to read request body")
+		s.logger.Printf("Unable to read request body")
 		return
 	}
 
@@ -84,11 +84,11 @@ func (s *EventsService) postEvents(w http.ResponseWriter, r *http.Request) {
 	var events []Event
 	if err := json.Unmarshal(data, &events); err != nil {
 		w.WriteHeader(http.StatusBadRequest)
-		s.logger.Printf("received bad event data (%s): %s", err, string(data))
+		s.logger.Printf("Received bad event data (%s): %s", err, string(data))
 		return
 	}
 	w.WriteHeader(http.StatusAccepted)
-	s.logger.Printf("received %d events", len(events))
+	s.logger.Printf("Received %d events", len(events))
 	for _, e := range events {
 		s.logger.Printf("    %s", e.JSONString())
 	}

--- a/mockld/streaming_service.go
+++ b/mockld/streaming_service.go
@@ -150,7 +150,7 @@ func (s *StreamingService) Replay(channel, id string) chan eventsource.Event {
 }
 
 func (s *StreamingService) logEvent(e eventsource.Event) {
-	s.debugLogger.Printf("sending %s event with data: %s", e.Event(), e.Data())
+	s.debugLogger.Printf("Sending %s event with data: %s", e.Event(), e.Data())
 }
 
 func (e eventImpl) Event() string { return e.name }


### PR DESCRIPTION
Many of the tests use a pattern where some components (like a data source or an event sink) are set up at the top of the test scope and then reused in subtests. In these cases, the debug log output does not give you a full picture of what happened in the test, because if a subtest fails, we only see the debug output that was specifically sent to the subtest's logger; output from the shared components is only being captured as part of the parent scope that created them.

This PR changes that, so that if you do something like this—

```go
func MyTest(t *ldtest.T) {
    client := NewSDKClient(...)
    t.Run("subtest1", func(t *ldtest.T) {
        ...
    })
    t.Run("subtest2", func(t *ldtest.T) {
        ...
    })
}
```

—and then subtest1 fails, the debug logging will look like it would if the subtest1 logic had been directly included in MyTest. That is, the subtest1 log will include any output that came from `client` before subtest1 started, and then a combination (in chronological order) of any output that was logged from actions in subtest1, and any output that `client` produced on its own while subtest1 was running. Tests don't have to do anything special to make this happen, it just automatically happens now when you use `t.Run`.