### PR TITLE
ignore duplicate event payloads by default

### DIFF
--- a/mockld/events_service.go
+++ b/mockld/events_service.go
@@ -16,12 +16,15 @@ import (
 const eventsChannelBufferSize = 100
 
 // EventsService is a simulation of the LaunchDarkly event-recorder service, allowing tests to
-// receive event data from an SDK.
+// receive event data from an SDK. This is a low-level component that tests normally don't need
+// to interact with directly; most tests use the sdktests.SDKEventSink facade.
 type EventsService struct {
 	AnalyticsEventPayloads chan Events
 	sdkKind                SDKKind
 	credential             string
+	ignoreDuplicatePayload bool
 	hostTimeOverride       time.Time
+	payloadIDsSeen         map[string]bool
 	logger                 framework.Logger
 	lock                   sync.Mutex
 }
@@ -31,6 +34,8 @@ func NewEventsService(sdkKind SDKKind, credential string, logger framework.Logge
 		AnalyticsEventPayloads: make(chan Events, eventsChannelBufferSize),
 		sdkKind:                sdkKind,
 		credential:             credential,
+		ignoreDuplicatePayload: true,
+		payloadIDsSeen:         make(map[string]bool),
 		logger:                 logger,
 	}
 }
@@ -62,6 +67,21 @@ func (s *EventsService) SetHostTimeOverride(t time.Time) {
 	s.lock.Unlock()
 }
 
+// SetIgnoreDuplicatePayload sets whether we should keep track of X-LaunchDarkly-Payload-Id header values
+// we have seen at this endpoint and ignore any posts containing the same header value. This is true by
+// default; tests would only set it to false if they want to verify that a failed post was retried.
+//
+// The rationale for this being the default behavior is that an SDK might, due to unpredictable network
+// issues, think an event post had failed when it really succeeded, and retry the post. We don't want
+// that to disrupt tests. The payload ID is always the same in the case of a retry for this very reason--
+// it allows event-recorder to ignore accidental redundant posts. We trust that SDKs will generate
+// reasonably unique payload IDs for posts that are not retries.
+func (s *EventsService) SetIgnoreDuplicatePayload(ignore bool) {
+	s.lock.Lock()
+	s.ignoreDuplicatePayload = ignore
+	s.lock.Unlock()
+}
+
 func (s *EventsService) postEvents(w http.ResponseWriter, r *http.Request) {
 	if r.Method != "POST" {
 		w.WriteHeader(http.StatusMethodNotAllowed)
@@ -74,11 +94,25 @@ func (s *EventsService) postEvents(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	payloadID := r.Header.Get("X-LaunchDarkly-Payload-ID")
+
 	s.lock.Lock()
 	hostTime := s.hostTimeOverride
+	ignoreDuplicatePayload := s.ignoreDuplicatePayload
+	seenPayloadID := s.payloadIDsSeen[payloadID]
+	if payloadID != "" {
+		s.payloadIDsSeen[payloadID] = true
+	}
 	s.lock.Unlock()
+
 	if !hostTime.IsZero() {
 		w.Header().Set("Date", hostTime.UTC().Format(http.TimeFormat))
+	}
+
+	if ignoreDuplicatePayload && payloadID != "" && seenPayloadID {
+		w.WriteHeader(http.StatusAccepted)
+		s.logger.Printf("Received & discarded duplicate payload ID %q: %s", payloadID, string(data))
+		return
 	}
 
 	var events []Event


### PR DESCRIPTION
@keelerm84 ran into a problem in Ruby SDK testing where, when running in JRuby, some tests would fail with weird output that indicated they had received an event from an earlier test. In this case the events endpoint was being reused across tests, but there was no apparent reason why the earlier event would've been sent twice; the earlier test had succeeded.

I think what was going on was this. We've sometimes seen spurious I/O problems in JRuby, and in this case it thought an event post had failed when it really succeeded, so the SDK retried the event post. In such a case, it always sends the same `X-LaunchDarkly-Payload-Id` header as before, instead of generating a unique one; that's what that header is for, so that event-recorder won't record events twice if an SDK does an unnecessary retry. So, this PR makes sdk-test-harness behave the same way by default, ignoring any duplicate Payload-Id that it sees.

That means that these tests won't be able to detect if an SDK is so broken that it's constantly sending duplicate event posts for no reason. We could still write such a test, since it's possible to turn off the "ignore duplicates" behavior for a particular mock events endpoints... although I'm not sure we could write it in a way that wouldn't spuriously fail in cases like this JRuby case. But anyway, in tests whose focus is not that, we don't want inconsequential network glitches to break a whole group of tests.