### PR TITLE
set valueType to "any" by default

### DIFF
--- a/sdktests/testapi_sdk_client.go
+++ b/sdktests/testapi_sdk_client.go
@@ -117,6 +117,9 @@ func validateSDKConfig(config servicedef.SDKConfigParams) error {
 //
 // Any error from the test service causes the test to terminate immediately.
 func (c *SDKClient) EvaluateFlag(t *ldtest.T, params servicedef.EvaluateFlagParams) servicedef.EvaluateFlagResponse {
+	if params.ValueType == "" {
+		params.ValueType = servicedef.ValueTypeAny // it'd be easy for a test to forget to set this
+	}
 	var resp servicedef.EvaluateFlagResponse
 	require.NoError(t, c.sdkClientEntity.SendCommandWithParams(
 		servicedef.CommandParams{


### PR DESCRIPTION
@cwaldren-ld ran into an error in the C SDK test service due to sdk-test-harness forgetting to set the `valueType` property in an evaluation request. The other test services I implemented just default to "any" in this case, but I think it's reasonable for the test harness's behavior to be more predictable in this regard, so this PR makes it always send "any" if a particular test didn't specify a type. That makes sense as a default since most tests do not involve strongly typed behavior.