### PR TITLE
fix flag data in error test

### DIFF
--- a/testdata/data-files/server-side-eval/errors.yml
+++ b/testdata/data-files/server-side-eval/errors.yml
@@ -32,7 +32,7 @@ sdkData:
   flags:
     off-variation-too-low-<TYPE_NAME>:
       on: false
-      offVariation: 1
+      offVariation: -1
       variations: [ "<TYPE_VALUE>" ]
 
     off-variation-too-high-<TYPE_NAME>:


### PR DESCRIPTION
@cwaldren-ld pointed out that the "variation too low" test cases are supposed to be using -1, not 1.