### PR TITLE
avoid trying to trigger early test exit from within an Eventually loop

### DIFF
--- a/sdktests/helpers.go
+++ b/sdktests/helpers.go
@@ -18,6 +18,7 @@ import (
 	"gopkg.in/launchdarkly/go-server-sdk-evaluation.v1/ldbuilders"
 	"gopkg.in/launchdarkly/go-server-sdk-evaluation.v1/ldmodel"
 
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
@@ -151,7 +152,7 @@ func checkForUpdatedValue(
 			return true
 		}
 		if !actualValue.Equal(previousValue) {
-			require.Fail(t, "SDK returned neither previous value nor updated value",
+			assert.Fail(t, "SDK returned neither previous value nor updated value",
 				"previous: %s, updated: %s, actual: %s", previousValue, updatedValue, actualValue)
 		}
 		return false


### PR DESCRIPTION
The symptom of this bug was that if certain tests failed, such as `streaming/retry behavior/retry after stream is closed`, the program would panic and exit. More specifically, a panic would happen if the test called `assert.Eventually` or `require.Eventually`, and the `func() bool` that they passed as a condition tried to cause an early end to a test (by calling `t.FailNow()`, or making a `require` assertion that failed).

The problem is that the implementation of `assert.Eventually` and `require.Eventually` calls the condition function on a separate goroutine (see [here](https://github.com/stretchr/testify/blob/v1.7.0/assert/assertions.go#L1655)). I think the point of that is to allow the timeout to work if the condition function hangs. But, our implementation of `FailNow` works by throwing a `panic`, which is then caught by a `recover` with our framework... and that can only work if the `panic` and the `recover` are on the same goroutine.

The implementation of `FailNow` in Go's `testing.T` is different, and safer, in that it does not rely on a panic but instead uses `runtime.Goexit()` to force an early termination of the current goroutine— which it can do because every test in `testing.T` has its own goroutine. However, that still would not quite work as intended with the `Eventually` functions, because if the goroutine terminates without sending a result value, `Eventually` keeps waiting and times out, defeating the purpose of the early exit.

So, while I could probably rewrite `ldtest.T` to be more panic-proof, it's still the case that there is no way to terminate early within `Eventually` and we shouldn't try to do it.