### PR TITLE
Allow gradual compliance with Test Harness via test failure suppression file

### DIFF
--- a/docs/running.md
+++ b/docs/running.md
@@ -11,15 +11,18 @@ Options besides `-url`:
 * `-host <NAME>` - sets the hostname to use in callback URLs, if not the same as the host the test service is running on (default: localhost)
 * `-port <PORT>` - sets the callback port that test services will connect to (default: 8111)
 * `-run <PATTERN>` - skips any tests whose names do not match the specified pattern (can specify more than one)
-* `-skip <PATTERN>` - skips any tests whose names match the specified pattern (can specify more than one)
+* `-skip <PATTERN>` - skips any tests whose names match the specified pattern (can specify more than one) 
 * `-stop-service-at-end` - tells the test service to exit after the test run
 * `-junit <FILEPATH>` - writes test results in JUnit XML format to the specified file
 * `-debug` - enables verbose logging of test actions for failed tests
 * `-debug-all` - enables verbose logging of test actions for all tests
+* `-record-failures` - record test failures to the given file. Test failures recorded can be skipped by the next run of 
+the test harness via -suppress-failures.
+* `-suppress-failures` - path to test failures recorded by `-record-failures`. The test harness will automatically skip any tests contained in the file.
 
 For `-run` and `-skip`, the rules for pattern matching are as follows:
 
-* The match is done againt the full path of the test. The full path is the string that appears between brackets in the test output. It may include slash-delimited subtests, such as `parent test name/subtest name/sub-subtest name`.
+* The match is done against the full path of the test. The full path is the string that appears between brackets in the test output. It may include slash-delimited subtests, such as `parent test name/subtest name/sub-subtest name`.
 * In the pattern, each slash-delimited segment is treated as a separate regular expression. So, for instance, you can write `^evaluation$/a.c` to match `evaluation/abc` and `evaluation/xaxcx` but not match `xevaluationx/abc`.
 * However, `(` and `)` will always be treated as literal characters, not regular expression operators. This is because some tests may have parens in their names. If you want "or" behavior, instead of `-run (a|b)` just use `-run a -run b` (in other words, there is an implied "or" for multiple values).
 * If `-run` specifies a test that has subtests, then all of its subtests are also run.
@@ -33,7 +36,7 @@ While tests are running, when each test starts a line is printed to standard out
 [evaluation/all flags state/with reasons]
 ```
 
-If the test is skipped, you will see an explanation starting with `SKIPPED:` on the next line. A test could be skipped because of filter parameters like `-run` or `-skip`, or because the test is only for SDKs with a certain capability and the test service did not report having that capability.
+If the test is skipped, you will see an explanation starting with `SKIPPED:` on the next line. A test could be skipped because of filter parameters like `-run` or `-skip`, or due to `-suppress-failures`, or because the test is only for SDKs with a certain capability and the test service did not report having that capability.
 
 If the test failed, you will see `FAILED:` and a failure message, which normally includes both a description of the problem and a stacktrace. The stacktrace refers to the `sdk-test-harness` code and may be helpful in understanding the test logic.
 

--- a/docs/running.md
+++ b/docs/running.md
@@ -11,7 +11,7 @@ Options besides `-url`:
 * `-host <NAME>` - sets the hostname to use in callback URLs, if not the same as the host the test service is running on (default: localhost)
 * `-port <PORT>` - sets the callback port that test services will connect to (default: 8111)
 * `-run <PATTERN>` - skips any tests whose names do not match the specified pattern (can specify more than one)
-* `-skip <PATTERN>` - skips any tests whose names match the specified pattern (can specify more than one) 
+* `-skip <PATTERN>` - skips any tests whose names match the specified pattern (can specify more than one)
 * `-stop-service-at-end` - tells the test service to exit after the test run
 * `-junit <FILEPATH>` - writes test results in JUnit XML format to the specified file
 * `-debug` - enables verbose logging of test actions for failed tests

--- a/main.go
+++ b/main.go
@@ -43,8 +43,8 @@ func main() {
 }
 
 func run(params commandParams) (*ldtest.Results, error) {
-	if params.suppressions != "" {
-		file, err := os.Open(params.suppressions)
+	if params.suppressFailures != "" {
+		file, err := os.Open(params.suppressFailures)
 		if err != nil {
 			return nil, fmt.Errorf("cannot open provided suppression file: %v", err)
 		}
@@ -123,8 +123,8 @@ func run(params commandParams) (*ldtest.Results, error) {
 		return nil, fmt.Errorf("error writing log: %v", logErr)
 	}
 
-	if params.genSuppressions != "" {
-		f, err := os.Create(params.genSuppressions)
+	if params.recordFailures != "" {
+		f, err := os.Create(params.recordFailures)
 		if err != nil {
 			return nil, fmt.Errorf("cannot create suppression file: %v", err)
 		}
@@ -136,4 +136,3 @@ func run(params commandParams) (*ldtest.Results, error) {
 
 	return &results, nil
 }
-

--- a/main.go
+++ b/main.go
@@ -49,6 +49,7 @@ func run(params commandParams) (*ldtest.Results, error) {
 		if err != nil {
 			return nil, fmt.Errorf("cannot open provided suppression file: %v", err)
 		}
+		defer file.Close()
 		scanner := bufio.NewScanner(file)
 		for scanner.Scan() {
 			escaped := regexp.QuoteMeta(scanner.Text())

--- a/main.go
+++ b/main.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"log"
 	"os"
+	"regexp"
 	"strings"
 	"time"
 
@@ -50,7 +51,8 @@ func run(params commandParams) (*ldtest.Results, error) {
 		}
 		scanner := bufio.NewScanner(file)
 		for scanner.Scan() {
-			if err := params.filters.MustNotMatch.Set(scanner.Text()); err != nil {
+			escaped := regexp.QuoteMeta(scanner.Text())
+			if err := params.filters.MustNotMatch.Set(escaped); err != nil {
 				return nil, fmt.Errorf("cannot parse suppression: %v", err)
 			}
 		}

--- a/main.go
+++ b/main.go
@@ -34,7 +34,7 @@ func main() {
 
 	results, err := run(params)
 	if err != nil {
-		fmt.Fprintf(os.Stderr, "Test Service Error: %v\n", err)
+		fmt.Fprintf(os.Stderr, "Error: %v\n", err)
 		os.Exit(1)
 	}
 

--- a/params.go
+++ b/params.go
@@ -17,8 +17,8 @@ type commandParams struct {
 	debug            bool
 	debugAll         bool
 	jUnitFile        string
-	genSuppressions  string
-	suppressions     string
+	recordFailures   string
+	suppressFailures string
 }
 
 func (c *commandParams) Read(args []string) bool {
@@ -32,8 +32,10 @@ func (c *commandParams) Read(args []string) bool {
 	fs.BoolVar(&c.debug, "debug", false, "enable debug logging for failed tests")
 	fs.BoolVar(&c.debugAll, "debug-all", false, "enable debug logging for all tests")
 	fs.StringVar(&c.jUnitFile, "junit", "", "write JUnit XML output to the specified path")
-	fs.StringVar(&c.genSuppressions, "gen-suppressions", "", "output suppression file")
-	fs.StringVar(&c.suppressions, "suppressions", "", "input suppression file")
+	fs.StringVar(&c.recordFailures, "record-failures", "", "record test failures to the specified file path.\n"+
+		"Recorded failures can be skipped by the next run of the test harness via -suppress-failures")
+	fs.StringVar(&c.suppressFailures, "suppress-failures", "", "path to recorded test failures generated "+
+		"by -record-failures.\nThe test harness will automatically skip tests contained in the specified file")
 
 	if err := fs.Parse(args[1:]); err != nil {
 		fmt.Fprintln(os.Stderr, err)

--- a/params.go
+++ b/params.go
@@ -17,6 +17,8 @@ type commandParams struct {
 	debug            bool
 	debugAll         bool
 	jUnitFile        string
+	genSuppressions  string
+	suppressions     string
 }
 
 func (c *commandParams) Read(args []string) bool {
@@ -30,6 +32,8 @@ func (c *commandParams) Read(args []string) bool {
 	fs.BoolVar(&c.debug, "debug", false, "enable debug logging for failed tests")
 	fs.BoolVar(&c.debugAll, "debug-all", false, "enable debug logging for all tests")
 	fs.StringVar(&c.jUnitFile, "junit", "", "write JUnit XML output to the specified path")
+	fs.StringVar(&c.genSuppressions, "gen-suppressions", "", "output suppression file")
+	fs.StringVar(&c.suppressions, "suppressions", "", "input suppression file")
 
 	if err := fs.Parse(args[1:]); err != nil {
 		fmt.Fprintln(os.Stderr, err)

--- a/sdktests/server_side_stream_retry.go
+++ b/sdktests/server_side_stream_retry.go
@@ -122,7 +122,7 @@ func doServerSideStreamRetryTests(t *ldtest.T) {
 		expectNoMoreRequests(t, streamEndpoint)
 	}
 
-	t.Run("retry after I/O error on initial connect", func(t *ldtest.T) {
+	t.Run("retry after IO error on initial connect", func(t *ldtest.T) {
 		shouldRetryAfterErrorOnInitialConnect(t, httphelpers.BrokenConnectionHandler())
 	})
 
@@ -169,7 +169,7 @@ func doServerSideStreamRetryTests(t *ldtest.T) {
 		pollUntilFlagValueUpdated(t, client, flagKey, user, expectedValueV1, expectedValueV2, ldvalue.Null())
 	}
 
-	t.Run("retry after I/O error on reconnect", func(t *ldtest.T) {
+	t.Run("retry after IO error on reconnect", func(t *ldtest.T) {
 		shouldRetryAfterErrorOnReconnect(t, httphelpers.BrokenConnectionHandler())
 	})
 


### PR DESCRIPTION
This PR introduces a simple method to mass-skip tests, allowing an SDK to incrementally comply with the contract test suite.

If the `-record-failures [file-path]` argument is supplied, the Test Harness will record the test IDs of all failures encountered to the specified file.

If `-suppress-failures [file-path]` is supplied, the Test Harness will skip any test that literally matches the string found on each line of the file. 

A common use-case might look like:
```shell
./sdk-test-harness [other args] -record-failures failures.txt
# Now failures.txt contains the name of each failing test.

./sdk-test-harness [other args] -suppress-failures failures.txt
# Now all tests recorded in failures.txt will be skipped.
```
