### PR TITLE
Add square brackets to regex autoescape list

### DIFF
--- a/framework/ldtest/filter.go
+++ b/framework/ldtest/filter.go
@@ -138,7 +138,7 @@ func BriefFilterDescription(filters RegexFilters) string {
 
 func autoEscapeTestRegex(pattern string) string {
 	s := pattern
-	for _, ch := range []string{"(", ")"} {
+	for _, ch := range []string{"(", ")", "[", "]"} {
 		s = strings.ReplaceAll(s, ch, "\\"+ch)
 		s = strings.ReplaceAll(s, "\\\\"+ch, "\\"+ch) // in case they already escaped it
 	}

--- a/framework/ldtest/filter_test.go
+++ b/framework/ldtest/filter_test.go
@@ -94,4 +94,6 @@ func TestRegexFilters(t *testing.T) {
 func TestAutoEscapeTestRegex(t *testing.T) {
 	assert.Equal(t, "hello \\(yes\\)", autoEscapeTestRegex("hello (yes)"))
 	assert.Equal(t, "hello \\(yes\\)", autoEscapeTestRegex("hello \\(yes\\)"))
+	assert.Equal(t, "hello \\[yes\\], a \\[test\\]", autoEscapeTestRegex("hello [yes], a [test]"))
+	assert.Equal(t, "hello \\[yes\\], a \\[test\\]", autoEscapeTestRegex("hello \\[yes\\], a \\[test\\]"))
 }


### PR DESCRIPTION
**Requirements**

- [x] I have added test coverage for new or changed functionality
- [x] I have followed the repository's [pull request submission guidelines](../blob/master/CONTRIBUTING.md#submitting-pull-requests)
- [ ] I have validated my changes against all supported platform versions

**Related issues**

Relates to https://github.com/launchdarkly/sdk-test-harness/pull/30 since many tests containing square brackets may need to be skipped.

**Describe the solution you've provided**

Currently the harness is unable to skip tests that contain square brackets in the ID (e.g. `events/user properties/inlineUsers=true, globally-private=[firstName], user-private=[lastName]/identify event`), because brackets constitute a regex character class.

With this change, the harness is now able to match against these tests.

**Describe alternatives you've considered**

Follows existing pattern established with parenthesis.