### PR TITLE
Remove usage of square brackets in test IDs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,5 @@
 .vscode/
 bin/
 dist/
-
+.idea
 sdk-test-harness

--- a/sdktests/helpers.go
+++ b/sdktests/helpers.go
@@ -1,8 +1,10 @@
 package sdktests
 
 import (
+	"bytes"
 	"encoding/json"
 	"fmt"
+	"reflect"
 	"sort"
 	"time"
 
@@ -204,4 +206,22 @@ func timeValueAsPointer(value ldtime.UnixMillisecondTime) *ldtime.UnixMillisecon
 
 func testDescFromType(valueType servicedef.ValueType) string {
 	return fmt.Sprintf("type: %s", valueType)
+}
+
+func formatSlice(a interface{}) string {
+	kind := reflect.TypeOf(a).Kind()
+	if kind != reflect.Slice {
+		panic("formatSlice expects slice argument")
+	}
+	var out bytes.Buffer
+	arr := reflect.ValueOf(a)
+	if arr.Len() == 0 {
+		return ""
+	}
+	for i := 0; i < arr.Len()-1; i++ {
+		out.Write([]byte(fmt.Sprint(arr.Index(i).Interface())))
+		out.Write([]byte(", "))
+	}
+	out.Write([]byte(fmt.Sprint(arr.Index(arr.Len() - 1).Interface())))
+	return out.String()
 }

--- a/sdktests/helpers_test.go
+++ b/sdktests/helpers_test.go
@@ -1,0 +1,30 @@
+package sdktests
+
+import (
+	"github.com/stretchr/testify/assert"
+	"testing"
+)
+
+func TestFormatList(t *testing.T) {
+	t.Run("array/slice arguments", func(t *testing.T) {
+		assert.Equal(t, "a, b, c", formatSlice([]string{"a", "b", "c"}))
+		assert.Equal(t, "just a", formatSlice([]string{"just a"}))
+		assert.Equal(t, "a, b", formatSlice([]string{"a, b"}))
+		assert.Equal(t, "", formatSlice([]string{}))
+
+		type stringAlias string
+		assert.Equal(t, "a, b, c", formatSlice([]stringAlias{"a", "b", "c"}))
+
+		type intAlias int
+		assert.Equal(t, "1, 2, 3", formatSlice([]intAlias{1, 2, 3}))
+	})
+
+	t.Run("non array/slice argument", func(t *testing.T) {
+		defer func() {
+			if err := recover(); err == nil {
+				t.Fatal("expected panic")
+			}
+		}()
+		formatSlice("not a slice")
+	})
+}

--- a/sdktests/server_side_events_users.go
+++ b/sdktests/server_side_events_users.go
@@ -44,10 +44,10 @@ func (s eventUserTestScenario) Description() string {
 		parts = append(parts, "allAttributesPrivate=true")
 	}
 	if len(s.config.GlobalPrivateAttributes) != 0 {
-		parts = append(parts, fmt.Sprintf("globally-private=%v", s.config.GlobalPrivateAttributes))
+		parts = append(parts, fmt.Sprintf("globally-private=(%s)", formatSlice(s.config.GlobalPrivateAttributes)))
 	}
 	if len(s.userPrivateAttrs) != 0 {
-		parts = append(parts, fmt.Sprintf("user-private=%v", s.userPrivateAttrs))
+		parts = append(parts, fmt.Sprintf("user-private=(%s)", formatSlice(s.userPrivateAttrs)))
 	}
 	return strings.Join(parts, ", ")
 }


### PR DESCRIPTION
**Requirements**

- [x] I have added test coverage for new or changed functionality
- [x] I have followed the repository's [pull request submission guidelines](../blob/master/CONTRIBUTING.md#submitting-pull-requests)
- [ ] I have validated my changes against all supported platform versions

**Related issues**

See https://github.com/launchdarkly/sdk-test-harness/pull/31.

**Describe the solution you've provided**

Some test IDs are dynamically generated at runtime based on a number of properties of the objects under test.
In these cases, the test ID might contain a square-bracket delimited array, such as:

`propValues=[a b]`

These brackets interfere with regex matching when using `-skip` and `-run` command line parameters, since brackets are reserved regex for character classes.

This commit provides a new `formatSlice` helper which formats slices without the brackets, and includes commas for
readability.

Before:
```
events/user properties/inlineUsers=true, globally-private=[firstName], user-private=[lastName]/index event
```
After:
```
events/user properties/inlineUsers=true, globally-private=(firstName), user-private=(lastName)/index event
```

**Describe alternatives you've considered**

Escape `[]` using the existing auto-escape method. See See https://github.com/launchdarkly/sdk-test-harness/pull/31.

**Additional context**

The implemented method feels unclean - for example, the panic, and the lack of handling of arguments that contain `,` themselves. Let me know if you have ideas on how to improve it.
