### PR TITLE
don't worry about ordering of events as long as all expected events are present

### DIFF
--- a/sdktests/server_side_events_buffer.go
+++ b/sdktests/server_side_events_buffer.go
@@ -49,7 +49,7 @@ func doServerSideEventBufferTests(t *ldtest.T) {
 		client.FlushEvents(t)
 		payload := events.ExpectAnalyticsEvents(t, defaultEventTimeout)
 
-		m.In(t).Assert(payload, m.Items(makeIdentifyEventExpectations(capacity)...))
+		m.In(t).Assert(payload, m.ItemsInAnyOrder(makeIdentifyEventExpectations(capacity)...))
 	})
 
 	t.Run("buffer is reset after flush", func(t *ldtest.T) {
@@ -86,6 +86,6 @@ func doServerSideEventBufferTests(t *ldtest.T) {
 
 		expectations := append(makeIdentifyEventExpectations(capacity),
 			IsSummaryEvent())
-		m.In(t).Assert(payload, m.Items(expectations...))
+		m.In(t).Assert(payload, m.ItemsInAnyOrder(expectations...))
 	})
 }

--- a/sdktests/server_side_events_experimentation.go
+++ b/sdktests/server_side_events_experimentation.go
@@ -86,7 +86,7 @@ func doServerSideExperimentationEventTests(t *ldtest.T) {
 				JSONPropertyNullOrAbsent("prereqOf"),
 			)
 
-			m.In(t).Assert(payload, m.Items(
+			m.In(t).Assert(payload, m.ItemsInAnyOrder(
 				IsIndexEventForUserKey(user.GetKey()),
 				matchFeatureEvent,
 				IsSummaryEvent(),

--- a/sdktests/server_side_events_index.go
+++ b/sdktests/server_side_events_index.go
@@ -38,7 +38,7 @@ func doServerSideIndexEventTests(t *ldtest.T) {
 				client.FlushEvents(t)
 				payload := events.ExpectAnalyticsEvents(t, defaultEventTimeout)
 
-				m.In(t).Assert(payload, m.Items(
+				m.In(t).Assert(payload, m.ItemsInAnyOrder(
 					matchIndexEvent(user),
 					IsSummaryEvent(),
 				))

--- a/sdktests/server_side_events_summary.go
+++ b/sdktests/server_side_events_summary.go
@@ -61,7 +61,7 @@ func doServerSideSummaryEventBasicTest(t *ldtest.T) {
 	client.FlushEvents(t)
 	payload := events.ExpectAnalyticsEvents(t, defaultEventTimeout)
 
-	m.In(t).Assert(payload, m.Items(
+	m.In(t).Assert(payload, m.ItemsInAnyOrder(
 		IsIndexEvent(),
 		IsIndexEvent(),
 		IsValidSummaryEventWithFlags(
@@ -100,7 +100,7 @@ func doServerSideSummaryEventUnknownFlagTest(t *ldtest.T) {
 	client.FlushEvents(t)
 	payload := events.ExpectAnalyticsEvents(t, defaultEventTimeout)
 
-	m.In(t).Assert(payload, m.Items(
+	m.In(t).Assert(payload, m.ItemsInAnyOrder(
 		IsIndexEventForUserKey(user.GetKey()),
 		IsValidSummaryEventWithFlags(
 			m.KV(unknownKey, m.MapOf(
@@ -142,7 +142,7 @@ func doServerSideSummaryEventResetTest(t *ldtest.T) {
 	client.FlushEvents(t)
 	payload1 := events.ExpectAnalyticsEvents(t, defaultEventTimeout)
 
-	m.In(t).Assert(payload1, m.Items(
+	m.In(t).Assert(payload1, m.ItemsInAnyOrder(
 		IsIndexEvent(),
 		IsIndexEvent(),
 		IsValidSummaryEventWithFlags(
@@ -213,7 +213,7 @@ func doServerSideSummaryEventPrerequisitesTest(t *ldtest.T) {
 	client.FlushEvents(t)
 	payload := events.ExpectAnalyticsEvents(t, defaultEventTimeout)
 
-	m.In(t).Assert(payload, m.Items(
+	m.In(t).Assert(payload, m.ItemsInAnyOrder(
 		IsIndexEvent(),
 		IsValidSummaryEventWithFlags(
 			m.KV(flag1.Key, m.MapOf(
@@ -271,7 +271,7 @@ func doServerSideSummaryEventVersionTest(t *ldtest.T) {
 	client.FlushEvents(t)
 	payload := events.ExpectAnalyticsEvents(t, defaultEventTimeout)
 
-	m.In(t).Assert(payload, m.Items(
+	m.In(t).Assert(payload, m.ItemsInAnyOrder(
 		IsIndexEvent(),
 		IsValidSummaryEventWithFlags(
 			m.KV(flagKey, m.MapOf(

--- a/sdktests/server_side_events_users.go
+++ b/sdktests/server_side_events_users.go
@@ -155,7 +155,7 @@ func doServerSideEventUserTests(t *ldtest.T) {
 				client.FlushEvents(t)
 
 				payload := events.ExpectAnalyticsEvents(t, defaultEventTimeout)
-				m.In(t).Assert(payload, m.Items(
+				m.In(t).Assert(payload, m.ItemsInAnyOrder(
 					m.AllOf(IsIndexEvent(), scenario.hasExpectedUserObject(user)),
 					IsSummaryEvent(),
 				))


### PR DESCRIPTION
The order in which events appear in a payload isn't significant to LaunchDarkly (if we wanted to look at them in chronological order we would go by the timestamp property) and isn't part of the analytics events spec, so these tests should use the `ItemsInAnyOrder` matcher instead of `Items` whenever they're looking at a list of more than one item.