### PR TITLE
Refactor loading of suppression file into method

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@
 GORELEASER_VERSION=v0.141.0
 GORELEASER_CMD=curl -sL https://git.io/goreleaser | GOPATH=$(mktemp -d) VERSION=$(GORELEASER_VERSION) bash -s -- --rm-dist
 
-GOLANGCI_LINT_VERSION=v1.43.0
+GOLANGCI_LINT_VERSION=v1.44.0
 
 LINTER=./bin/golangci-lint
 LINTER_VERSION_FILE=./bin/.golangci-lint-version-$(GOLANGCI_LINT_VERSION)

--- a/main.go
+++ b/main.go
@@ -132,6 +132,8 @@ func loadSuppressions(params *commandParams) error {
 	if err != nil {
 		return fmt.Errorf("cannot open provided suppression file: %v", err)
 	}
+	// #nosec G307 -- This is a read-only file so Close failing will not result in data loss.
+	// Additionally, this is a false positive since we are checking the error code.
 	defer func() {
 		if err := file.Close(); err != nil {
 			fmt.Fprintf(os.Stderr, "Failed to close suppressions file: %v\n", err)

--- a/main.go
+++ b/main.go
@@ -45,7 +45,7 @@ func main() {
 
 func run(params commandParams) (*ldtest.Results, error) {
 	if params.suppressFailures != "" {
-		if err := loadSuppressions(params); err != nil {
+		if err := loadSuppressions(&params); err != nil {
 			return nil, err
 		}
 	}
@@ -127,7 +127,7 @@ func run(params commandParams) (*ldtest.Results, error) {
 	return &results, nil
 }
 
-func loadSuppressions(params commandParams) error {
+func loadSuppressions(params *commandParams) error {
 	file, err := os.Open(params.suppressFailures)
 	if err != nil {
 		return fmt.Errorf("cannot open provided suppression file: %v", err)

--- a/main.go
+++ b/main.go
@@ -132,8 +132,6 @@ func loadSuppressions(params *commandParams) error {
 	if err != nil {
 		return fmt.Errorf("cannot open provided suppression file: %v", err)
 	}
-	// #nosec G307 -- This is a read-only file so Close failing will not result in data loss.
-	// Additionally, this is a false positive since we are checking the error code.
 	defer func() {
 		if err := file.Close(); err != nil {
 			fmt.Fprintf(os.Stderr, "Failed to close suppressions file: %v\n", err)

--- a/main.go
+++ b/main.go
@@ -132,11 +132,7 @@ func loadSuppressions(params *commandParams) error {
 	if err != nil {
 		return fmt.Errorf("cannot open provided suppression file: %v", err)
 	}
-	defer func() {
-		if err := file.Close(); err != nil {
-			fmt.Fprintf(os.Stderr, "Failed to close suppressions file: %v\n", err)
-		}
-	}()
+	defer func() { _ = file.Close() }()
 	scanner := bufio.NewScanner(file)
 	for scanner.Scan() {
 		escaped := regexp.QuoteMeta(scanner.Text())


### PR DESCRIPTION
I jumped the gun slightly on merging https://github.com/launchdarkly/sdk-test-harness/pull/30. 

When I modified the PR to defer the suppression file close operation, I didn't realize that it would output an error (because there's also an explicit close.)

In this PR I've implemented the defer correctly by refactoring into a method, so all exit points will execute `Close` once and only once. This is cleaner overall.

The linter gave me an error:
```
main.go:135:2: G307: Deferring unsafe method "Close" on type "*os.File" (gosec)
```
Which led me down a rabbit hole: https://giters.com/securego/gosec/issues/453
To: https://github.com/securego/gosec/issues/579

False positive was fixed upstream here: https://github.com/securego/gosec/releases/tag/v2.9.3
Golang-ci fixed here: https://github.com/golangci/golangci-lint/releases/tag/v1.44.0

So I've upgraded `golang-ci` to v1.44.0.