### PR TITLE
Rename -suppress-failures to -skip-from

### DIFF
--- a/docs/running.md
+++ b/docs/running.md
@@ -16,17 +16,17 @@ Options besides `-url`:
 * `-junit <FILEPATH>` - writes test results in JUnit XML format to the specified file
 * `-debug` - enables verbose logging of test actions for failed tests
 * `-debug-all` - enables verbose logging of test actions for all tests
-* `-record-failures` - record test failures to the given file. Test failures recorded can be skipped by the next run of 
-the test harness via -suppress-failures.
-* `-suppress-failures` - path to test failures recorded by `-record-failures`. The test harness will automatically skip any tests contained in the file.
+* `-record-failures` - record failed test IDs to the given file. Recorded tests can be skipped by the next run of 
+the harness via `-skip-from`.
+* `-skip-from` - skips any test IDs recorded in the specified file. May be used in conjunction with `-record-failures`
 
-For `-run` and `-skip`, the rules for pattern matching are as follows:
+For `-run`, `-skip`, and tests referenced via `-skip-from`, the rules for pattern matching are as follows:
 
 * The match is done against the full path of the test. The full path is the string that appears between brackets in the test output. It may include slash-delimited subtests, such as `parent test name/subtest name/sub-subtest name`.
 * In the pattern, each slash-delimited segment is treated as a separate regular expression. So, for instance, you can write `^evaluation$/a.c` to match `evaluation/abc` and `evaluation/xaxcx` but not match `xevaluationx/abc`.
 * However, `(` and `)` will always be treated as literal characters, not regular expression operators. This is because some tests may have parens in their names. If you want "or" behavior, instead of `-run (a|b)` just use `-run a -run b` (in other words, there is an implied "or" for multiple values).
 * If `-run` specifies a test that has subtests, then all of its subtests are also run.
-* If `-skip` specifies a test that has subtests, then all of its subtests are also skipped.
+* If `-skip`/`-skip-from` specifies a test that has subtests, then all of its subtests are also skipped.
 
 ## Output
 
@@ -36,7 +36,7 @@ While tests are running, when each test starts a line is printed to standard out
 [evaluation/all flags state/with reasons]
 ```
 
-If the test is skipped, you will see an explanation starting with `SKIPPED:` on the next line. A test could be skipped because of filter parameters like `-run` or `-skip`, or due to `-suppress-failures`, or because the test is only for SDKs with a certain capability and the test service did not report having that capability.
+If the test is skipped, you will see an explanation starting with `SKIPPED:` on the next line. A test could be skipped because of filter parameters like `-run`, `-skip`, or `-skip-from`, or because the test is only for SDKs with a certain capability and the test service did not report having that capability.
 
 If the test failed, you will see `FAILED:` and a failure message, which normally includes both a description of the problem and a stacktrace. The stacktrace refers to the `sdk-test-harness` code and may be helpful in understanding the test logic.
 

--- a/main.go
+++ b/main.go
@@ -44,7 +44,7 @@ func main() {
 }
 
 func run(params commandParams) (*ldtest.Results, error) {
-	if params.suppressFailures != "" {
+	if params.skipFile != "" {
 		if err := loadSuppressions(&params); err != nil {
 			return nil, err
 		}
@@ -128,7 +128,7 @@ func run(params commandParams) (*ldtest.Results, error) {
 }
 
 func loadSuppressions(params *commandParams) error {
-	file, err := os.Open(params.suppressFailures)
+	file, err := os.Open(params.skipFile)
 	if err != nil {
 		return fmt.Errorf("cannot open provided suppression file: %v", err)
 	}

--- a/params.go
+++ b/params.go
@@ -18,7 +18,7 @@ type commandParams struct {
 	debugAll         bool
 	jUnitFile        string
 	recordFailures   string
-	suppressFailures string
+	skipFile         string
 }
 
 func (c *commandParams) Read(args []string) bool {
@@ -32,10 +32,10 @@ func (c *commandParams) Read(args []string) bool {
 	fs.BoolVar(&c.debug, "debug", false, "enable debug logging for failed tests")
 	fs.BoolVar(&c.debugAll, "debug-all", false, "enable debug logging for all tests")
 	fs.StringVar(&c.jUnitFile, "junit", "", "write JUnit XML output to the specified path")
-	fs.StringVar(&c.recordFailures, "record-failures", "", "record test failures to the specified file path.\n"+
-		"Recorded failures can be skipped by the next run of the test harness via -suppress-failures")
-	fs.StringVar(&c.suppressFailures, "suppress-failures", "", "path to recorded test failures generated "+
-		"by -record-failures.\nThe test harness will automatically skip tests contained in the specified file")
+	fs.StringVar(&c.recordFailures, "record-failures", "", "record failed test IDs to the given file.\n"+
+		"recorded tests can be skipped by the next run of the harness via -skip-from")
+	fs.StringVar(&c.skipFile, "skip-from", "", "skips any test IDs recorded in the specified file.\n"+
+		"may be used in conjunction with -record-failures")
 
 	if err := fs.Parse(args[1:]); err != nil {
 		fmt.Fprintln(os.Stderr, err)


### PR DESCRIPTION
Eli brought up the good point that the use-case for `-suppress-failures` is both more general, and different, than the name implies.

More general:
- You might be skipping tests not due to failure, but for other reasons (for example flakiness)

Different:
- It's not that the tests referenced by `-suppress-failures` are run and then the results suppressed; they are skipped entirely.

To head-off confusion, I've renamed the argument to `-skip-from` & updated associated documentation.