### PR TITLE
add contract tests for tags

### DIFF
--- a/docs/service_spec.md
+++ b/docs/service_spec.md
@@ -80,7 +80,9 @@ A `POST` request indicates that the test harness wants to start an instance of t
   * `bigSegments` (object, optional): Enables and configures Big Segments. Properties are:
     * `callbackUri` (string, required): The base URI for the big segments store callback fixture. See [Callback fixtures](#callback-fixtures).
     * `userCacheSize`, `userCacheTimeMs`, `statusPollIntervalMS`, `staleAfterMs`: These correspond to the standard optional configuration parameters for every SDK that supports Big Segments.
-  * `tags` (object, optional): If specified, this is an object where each key is a tag key, and each value is an array of strings that are the tag values for that key (always an array even if there is only one value).
+  * `tags` (object, optional): If specified, this has options for metadata/tags (that is, values that are translated into an `X-LaunchDarkly-Tags` header):
+    * `applicationId` (string, optional): If present and non-null, the SDK should set the "application ID" property to this string.
+    * `applicationVersion` (string, optional): If present and non-null, the SDK should set the "application version" property to this string.
 
 The response to a valid request is any HTTP `2xx` status, with a `Location` header whose value is the URL of the test service resource representing this SDK client instance (that is, the one that would be used for "Close client" or "Send command" as described below).
 

--- a/docs/service_spec.md
+++ b/docs/service_spec.md
@@ -47,6 +47,12 @@ This means that the SDK supports Big Segments and can be configured with a custo
 
 For tests that involve Big Segments, the test harness will provide parameters in the `bigSegments` property of the configuration object, including a `callbackUri` that points to one of the test harness's callback services (see [Callback endpoints](#callback-endpoints)). The test service should configure the SDK with its own implementation of a Big Segment store, where every method of the store delegates to a corresponding endpoint in the callback service.
 
+#### Capability `"tags"`
+
+This means that the SDK supports the "tags" configuration option and will send the `X-LaunchDarkly-Tags` header in HTTP requests if tags are defined.
+
+For tests that involve tags, the test harness will set the `tags` property of the configuration object.
+
 ### Stop test service: `DELETE /`
 
 The test harness sends this request at the end of a test run if you have specified `--stop-service-at-end` on the [command line](./running.md). The test service should simply quit. This is a convenience so CI scripts can simply start the test service in the background and assume it will be stopped for them.
@@ -74,6 +80,7 @@ A `POST` request indicates that the test harness wants to start an instance of t
   * `bigSegments` (object, optional): Enables and configures Big Segments. Properties are:
     * `callbackUri` (string, required): The base URI for the big segments store callback fixture. See [Callback fixtures](#callback-fixtures).
     * `userCacheSize`, `userCacheTimeMs`, `statusPollIntervalMS`, `staleAfterMs`: These correspond to the standard optional configuration parameters for every SDK that supports Big Segments.
+  * `tags` (object, optional): If specified, this is an object where each key is a tag key, and each value is an array of strings that are the tag values for that key (always an array even if there is only one value).
 
 The response to a valid request is any HTTP `2xx` status, with a `Location` header whose value is the URL of the test service resource representing this SDK client instance (that is, the one that would be used for "Close client" or "Send command" as described below).
 

--- a/sdktests/constants.go
+++ b/sdktests/constants.go
@@ -1,0 +1,7 @@
+package sdktests
+
+const (
+	allAllowedTagChars = "._-abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789"
+	tagNameAppID       = "application-id"
+	tagNameAppVersion  = "application-version"
+)

--- a/sdktests/helpers.go
+++ b/sdktests/helpers.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"sort"
+	"strings"
 	"time"
 
 	m "github.com/launchdarkly/go-test-helpers/v2/matchers"
@@ -113,6 +114,20 @@ func inferDefaultFromFlag(sdkData mockld.ServerSDKData, flagKey string) ldvalue.
 	default:
 		return ldvalue.Null()
 	}
+}
+
+func makeCharactersNotInAllowedCharsetString(allowed string) []rune {
+	var badChars []rune
+	badChars = append(badChars, '\t', '\n', '\r') // don't bother including every control character
+	for ch := 32; ch <= 127; ch++ {
+		if strings.ContainsRune(allowed, rune(ch)) {
+			continue
+		}
+		badChars = append(badChars, rune(ch))
+	}
+	// Don't try to cover the whole Unicode space, just pick a couple of multi-byte characters
+	badChars = append(badChars, 'é', '😀')
+	return badChars
 }
 
 func makeFlagToCheckSegmentMatch(

--- a/sdktests/server_side_tags.go
+++ b/sdktests/server_side_tags.go
@@ -104,7 +104,10 @@ func doServerSideTagsTests(t *ldtest.T) {
 func makeValidTagsTestParams() []tagsTestParams {
 	ret := make([]tagsTestParams, 0)
 	values := []ldvalue.OptionalString{
-		{},
+		// Note that on *some* platforms, there's a distinction between "undefined" and "empty string".
+		// We test both, to ensure that empty strings are correctly ignored in terms of the header.
+		{},                            // "undefined"
+		ldvalue.NewOptionalString(""), // empty string
 		ldvalue.NewOptionalString(allAllowedTagChars),
 	}
 	for _, appID := range values {

--- a/sdktests/server_side_tags.go
+++ b/sdktests/server_side_tags.go
@@ -1,0 +1,172 @@
+package sdktests
+
+import (
+	"time"
+
+	"github.com/launchdarkly/go-test-helpers/v2/jsonhelpers"
+	"github.com/launchdarkly/sdk-test-harness/framework/harness"
+	"github.com/launchdarkly/sdk-test-harness/framework/ldtest"
+	"github.com/launchdarkly/sdk-test-harness/mockld"
+	"github.com/launchdarkly/sdk-test-harness/servicedef"
+
+	"gopkg.in/launchdarkly/go-sdk-common.v2/lduser"
+
+	"github.com/stretchr/testify/assert"
+)
+
+type tagsTestParams struct {
+	description         string
+	tags                map[string][]string
+	expectedHeaderValue string
+}
+
+func doServerSideTagsTests(t *ldtest.T) {
+	t.RequireCapability(servicedef.CapabilityTags)
+
+	verifyRequestHeader := func(t *ldtest.T, p tagsTestParams, endpoint *harness.MockEndpoint) {
+		request := expectRequest(t, endpoint, time.Second)
+
+		if p.expectedHeaderValue == "" {
+			assert.NotContains(t, request.Headers, "X-LaunchDarkly-Tags")
+		} else {
+			assert.Equal(t, p.expectedHeaderValue, request.Headers.Get("X-LaunchDarkly-Tags"))
+		}
+	}
+
+	t.Run("stream requests", func(t *ldtest.T) {
+		for _, p := range makeTagsTestParams() {
+			t.Run(p.description, func(t *ldtest.T) {
+				dataSource := NewSDKDataSource(t, mockld.EmptyServerSDKData())
+				_ = NewSDKClient(t, WithConfig(servicedef.SDKConfigParams{
+					Tags: p.tags,
+				}), dataSource)
+				verifyRequestHeader(t, p, dataSource.Endpoint())
+			})
+		}
+	})
+
+	t.Run("event posts", func(t *ldtest.T) {
+		for _, p := range makeTagsTestParams() {
+			t.Run(p.description, func(t *ldtest.T) {
+				dataSource := NewSDKDataSource(t, mockld.EmptyServerSDKData())
+				events := NewSDKEventSink(t)
+				client := NewSDKClient(t, WithConfig(servicedef.SDKConfigParams{
+					Tags: p.tags,
+				}), dataSource, events)
+
+				client.SendIdentifyEvent(t, lduser.NewUser("user-key"))
+				client.FlushEvents(t)
+
+				verifyRequestHeader(t, p, events.Endpoint())
+			})
+		}
+	})
+
+	t.Run("disallowed characters", func(t *ldtest.T) {
+		dataSource := NewSDKDataSource(t, mockld.EmptyServerSDKData())
+
+		type scenario struct {
+			tags map[string][]string
+		}
+		var scenarios []scenario
+		badStrings := makeTagStringsWithDisallowedCharacters()
+		for _, badString := range badStrings {
+			scenarios = append(scenarios, scenario{
+				tags: map[string][]string{
+					"goodkey": {"goodvalue"},
+					badString: {"badvalue"},
+				},
+			})
+			scenarios = append(scenarios, scenario{
+				tags: map[string][]string{
+					"goodkey": {badString, "goodvalue"},
+				},
+			})
+		}
+		expectedHeader := "goodkey/goodvalue"
+		for _, scenario := range scenarios {
+			// We're not using t.Run to make a subtest here because there would be so many. We'll
+			// just print details of any failures we see.
+			config := servicedef.SDKConfigParams{
+				Tags: scenario.tags,
+			}
+			_ = NewSDKClient(t, WithConfig(config), dataSource)
+			request := expectRequest(t, dataSource.Endpoint(), time.Second)
+			headerTags := request.Headers.Get("X-LaunchDarkly-Tags")
+			assert.Equal(t, expectedHeader, headerTags, "for input tags: %s", jsonhelpers.ToJSONString(scenario.tags))
+		}
+	})
+}
+
+func makeTagsTestParams() []tagsTestParams {
+	return []tagsTestParams{
+		{
+			description:         "no tags",
+			tags:                nil,
+			expectedHeaderValue: "",
+		},
+		{
+			description: "single key-value pair",
+			tags: map[string][]string{
+				"tagname": {"tagvalue"},
+			},
+			expectedHeaderValue: "tagname/tagvalue",
+		},
+		{
+			description: "multiple keys, one value each",
+			tags: map[string][]string{
+				"tagname1": {"tagvalue1"},
+				"tagname2": {"tagvalue2"},
+			},
+			expectedHeaderValue: "tagname1/tagvalue1:tagname2/tagvalue2",
+		},
+		{
+			description: "multiple values per key",
+			tags: map[string][]string{
+				"tagname1": {"tagvalue1a", "tagvalue1b"},
+			},
+			expectedHeaderValue: "tagname1/tagvalue1a:tagname1/tagvalue1b",
+		},
+		{
+			description: "tags are sorted by key and then value",
+			tags: map[string][]string{
+				"tagname2": {"tagvalue2b", "tagvalue2a"},
+				"tagname4": {"tagvalue4a", "tagvalue4c", "tagvalue4b"},
+				"tagname1": {"tagvalue1"},
+				"tagname3": {"tagvalue3"},
+			},
+			expectedHeaderValue: "tagname1/tagvalue1:tagname2/tagvalue2a:tagname2/tagvalue2b" +
+				":tagname3/tagvalue3:tagname4/tagvalue4a:tagname4/tagvalue4b:tagname4/tagvalue4c",
+		},
+		{
+			description: "all allowable characters",
+			tags: map[string][]string{
+				"._-abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789": {
+					"abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789._-",
+				},
+			},
+			expectedHeaderValue: "._-abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789" +
+				"/abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789._-",
+		},
+	}
+}
+
+func makeTagStringsWithDisallowedCharacters() []string {
+	var badChars []rune
+	badChars = append(badChars, '\t', '\n', '\r') // don't bother including every control character
+	for ch := 1; ch <= 127; ch++ {
+		if (ch >= '0' && ch <= '9') || (ch >= 'a' && ch <= 'z') || (ch >= 'A' && ch <= 'Z') ||
+			ch == '.' || ch == '-' || ch == '_' {
+			continue
+		}
+		badChars = append(badChars, rune(ch))
+	}
+	// Don't try to cover the whole Unicode space, just pick a couple of multi-byte characters
+	badChars = append(badChars, 'é', '😀')
+
+	ret := make([]string, 0, len(badChars))
+	for _, ch := range badChars {
+		ret = append(ret, "bad-"+string(ch))
+	}
+	return ret
+}

--- a/sdktests/server_side_tags.go
+++ b/sdktests/server_side_tags.go
@@ -88,8 +88,10 @@ func doServerSideTagsTests(t *ldtest.T) {
 			// just print details of any failures we see.
 			tags := p.tags
 			dataSource := NewSDKDataSource(t, mockld.EmptyServerSDKData())
-			if _, err := TryNewSDKClient(t, WithConfig(servicedef.SDKConfigParams{Tags: &tags}), dataSource); err != nil {
+			client, err := TryNewSDKClient(t, WithConfig(servicedef.SDKConfigParams{Tags: &tags}), dataSource)
+			if err != nil {
 				assert.Fail(t, "error initializing client", "for input tags: %s\nerror: %s", jsonhelpers.ToJSONString(tags), err)
+				continue
 			}
 			if request, err := dataSource.Endpoint().AwaitConnection(time.Second); err == nil {
 				headerTags := request.Headers.Get("X-LaunchDarkly-Tags")
@@ -97,6 +99,7 @@ func doServerSideTagsTests(t *ldtest.T) {
 			} else {
 				assert.Fail(t, "timed out waiting for request", "for input tags: %s", jsonhelpers.ToJSONString(tags))
 			}
+			_ = client.Close()
 		}
 	})
 }

--- a/sdktests/testapi_sdk_client.go
+++ b/sdktests/testapi_sdk_client.go
@@ -101,14 +101,14 @@ func TryNewSDKClient(t *ldtest.T, configurer SDKConfigurer, moreConfigurers ...S
 		return nil, err
 	}
 
-	t.Defer(func() {
-		_ = sdkClient.Close()
-	})
-
-	return &SDKClient{
+	c := &SDKClient{
 		sdkClientEntity: sdkClient,
 		sdkConfig:       config,
-	}, nil
+	}
+	t.Defer(func() {
+		_ = c.Close()
+	})
+	return c, nil
 }
 
 func validateSDKConfig(config servicedef.SDKConfigParams) error {
@@ -120,6 +120,12 @@ func validateSDKConfig(config servicedef.SDKConfigParams) error {
 			" did you forget to include the SDKEventSink as a parameter?")
 	}
 	return nil
+}
+
+// Close tells the test service to shut down the client instance. Normally this happens automatically at
+// the end of a test.
+func (c *SDKClient) Close() error {
+	return c.sdkClientEntity.Close()
 }
 
 // EvaluateFlag tells the SDK client to evaluate a feature flag. This corresponds to calling one of the SDK's

--- a/sdktests/testapi_sdk_events.go
+++ b/sdktests/testapi_sdk_events.go
@@ -55,6 +55,9 @@ func (e *SDKEventSink) ApplyConfiguration(config *servicedef.SDKConfigParams) {
 	config.Events.BaseURI = e.eventsEndpoint.BaseURL()
 }
 
+// Endpoint returns the low-level object that manages incoming requests.
+func (e *SDKEventSink) Endpoint() *harness.MockEndpoint { return e.eventsEndpoint }
+
 // Service returns the underlying mock events service component, for access to special options.
 func (e *SDKEventSink) Service() *mockld.EventsService { return e.eventsService }
 

--- a/sdktests/testsuite_server_side.go
+++ b/sdktests/testsuite_server_side.go
@@ -44,6 +44,7 @@ func RunServerSideTestSuite(
 		t.Run("events", doServerSideEventTests)
 		t.Run("streaming", doServerSideStreamTests)
 		t.Run("big segments", doServerSideBigSegmentsTests)
+		t.Run("tags", doServerSideTagsTests)
 	})
 }
 

--- a/servicedef/sdk_config.go
+++ b/servicedef/sdk_config.go
@@ -14,6 +14,7 @@ type SDKConfigParams struct {
 	Events              *SDKConfigEventParams               `json:"events,omitempty"`
 	PersistentDataStore *SDKConfigPersistentDataStoreParams `json:"persistentDataStore,omitempty"`
 	BigSegments         *SDKConfigBigSegmentsParams         `json:"bigSegments,omitempty"`
+	Tags                map[string][]string                 `json:"tags,omitempty"`
 }
 
 type SDKConfigStreamingParams struct {

--- a/servicedef/sdk_config.go
+++ b/servicedef/sdk_config.go
@@ -14,7 +14,7 @@ type SDKConfigParams struct {
 	Events              *SDKConfigEventParams               `json:"events,omitempty"`
 	PersistentDataStore *SDKConfigPersistentDataStoreParams `json:"persistentDataStore,omitempty"`
 	BigSegments         *SDKConfigBigSegmentsParams         `json:"bigSegments,omitempty"`
-	Tags                map[string][]string                 `json:"tags,omitempty"`
+	Tags                *SDKConfigTagsParams                `json:"tags,omitempty"`
 }
 
 type SDKConfigStreamingParams struct {
@@ -42,4 +42,9 @@ type SDKConfigBigSegmentsParams struct {
 	UserCacheTimeMS      ldtime.UnixMillisecondTime `json:"userCacheTimeMs,omitempty"`
 	StatusPollIntervalMS ldtime.UnixMillisecondTime `json:"statusPollIntervalMs,omitempty"`
 	StaleAfterMS         ldtime.UnixMillisecondTime `json:"staleAfterMs,omitempty"`
+}
+
+type SDKConfigTagsParams struct {
+	ApplicationID      ldvalue.OptionalString `json:"applicationID,omitempty"`
+	ApplicationVersion ldvalue.OptionalString `json:"applicationVersion,omitempty"`
 }

--- a/servicedef/sdk_config.go
+++ b/servicedef/sdk_config.go
@@ -45,6 +45,6 @@ type SDKConfigBigSegmentsParams struct {
 }
 
 type SDKConfigTagsParams struct {
-	ApplicationID      ldvalue.OptionalString `json:"applicationID,omitempty"`
+	ApplicationID      ldvalue.OptionalString `json:"applicationId,omitempty"`
 	ApplicationVersion ldvalue.OptionalString `json:"applicationVersion,omitempty"`
 }

--- a/servicedef/service_params.go
+++ b/servicedef/service_params.go
@@ -13,6 +13,7 @@ const (
 
 	CapabilityPersistentDataStore = "persistent-data-store"
 	CapabilityBigSegments         = "big-segments"
+	CapabilityTags                = "tags"
 )
 
 type StatusRep struct {


### PR DESCRIPTION
This adds some new tests which will only be done if the test service includes `"tags"` in its capability list.

The tests cover the formatting of the X-LaunchDarkly-Tags header and the validation rules. Although in principle the SDK should always be using the same set of computed default headers (Authorization, User-Agent, X-LaunchDarkly-Wrapper, etc.) in HTTP requests from every component, the tests check this by looking at both stream requests and event posts— this would also apply to polling requests, but the test harness doesn't currently have the ability to test polling mode.

The tests do not verify that the SDK logs a warning message for bad tags. Currently the test harness doesn't have the ability to query log output; we may want to add that at some point, but in any case we haven't standardized what the log messages would be.