### PR TITLE
bump major version to 2

### DIFF
--- a/docs/deploying.md
+++ b/docs/deploying.md
@@ -3,10 +3,10 @@
 In a CI job for an SDK, the most convenient way to run the test suite is by invoking the `downloader/run.sh` script, which downloads the compiled executable and runs it. You can download this script directly from GitHub and pipe it to `bash` or `sh`. This is similar to how tools such as Goreleaser are normally run. You must set `VERSION` to the desired version of the tool, and `PARAMS` to the command-line parameters.
 
 ```shell
-curl -s https://raw.githubusercontent.com/launchdarkly/sdk-test-harness/master/downloader/run.sh \
-  | VERSION=v1 PARAMS="--url http://localhost:8000" sh
+curl -s https://raw.githubusercontent.com/launchdarkly/sdk-test-harness/v2.0.0/downloader/run.sh \
+  | VERSION=v2 PARAMS="--url http://localhost:8000" sh
 ```
 
-In this example, `v1.0.0` is the version of the `run.sh` script to use. If there are any significant changes to the script, there will be a new major version, to ensure that CI jobs pinned to previous versions will not fail.
+In this example, `v2.0.0` in the URL is the version of the `run.sh` script to use. If there are any significant changes to the script, there will be a new major version, to ensure that CI jobs pinned to previous versions will not fail.
 
-The `VERSION=v1` setting is what determines what version of the actual tests to use. It's best to specify only a major version so that you will automatically get any backward-compatible improvements in the test harness-- as long as you keep in mind that this might cause a build to fail that previously passed, if a more sensitive test is added (that is, if the test harness now detects a kind of noncompliance with the existing SDK specification that it did not previously check for). If you want to make sure your builds will never break due to such an improvement in the tests, you can instead pin to a specific version string such as `VERSION=v1.0.0`, but be aware that this could mean a bug is overlooked.
+The `VERSION=v2` setting is what determines what version of the actual tests to use. It's best to specify only a major version so that you will automatically get any backward-compatible improvements in the test harness-- as long as you keep in mind that this might cause a build to fail that previously passed, if a more sensitive test is added (that is, if the test harness now detects a kind of noncompliance with the existing SDK specification that it did not previously check for). If you want to make sure your builds will never break due to such an improvement in the tests, you can instead pin to a specific version string such as `VERSION=v2.0.0`, but be aware that this could mean a bug is overlooked.

--- a/framework/harness/harness.go
+++ b/framework/harness/harness.go
@@ -7,7 +7,7 @@ import (
 	"net/http"
 	"time"
 
-	"github.com/launchdarkly/sdk-test-harness/framework"
+	"github.com/launchdarkly/sdk-test-harness/v2/framework"
 )
 
 const httpListenerTimeout = time.Second * 10

--- a/framework/harness/mock_endpoints.go
+++ b/framework/harness/mock_endpoints.go
@@ -12,7 +12,7 @@ import (
 	"sync"
 	"time"
 
-	"github.com/launchdarkly/sdk-test-harness/framework"
+	"github.com/launchdarkly/sdk-test-harness/v2/framework"
 )
 
 const endpointPathPrefix = "/endpoints/"

--- a/framework/harness/mock_endpoints_test.go
+++ b/framework/harness/mock_endpoints_test.go
@@ -7,7 +7,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/launchdarkly/sdk-test-harness/framework"
+	"github.com/launchdarkly/sdk-test-harness/v2/framework"
 
 	"github.com/launchdarkly/go-test-helpers/v2/httphelpers"
 

--- a/framework/harness/test_service.go
+++ b/framework/harness/test_service.go
@@ -11,7 +11,7 @@ import (
 	"strings"
 	"time"
 
-	"github.com/launchdarkly/sdk-test-harness/framework"
+	"github.com/launchdarkly/sdk-test-harness/v2/framework"
 )
 
 // TestServiceInfo is status information returned by the test service from the initial status query.

--- a/framework/ldtest/errors_test.go
+++ b/framework/ldtest/errors_test.go
@@ -3,7 +3,7 @@ package ldtest
 import (
 	"testing"
 
-	"github.com/launchdarkly/sdk-test-harness/framework/ldtest/internal"
+	"github.com/launchdarkly/sdk-test-harness/v2/framework/ldtest/internal"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )

--- a/framework/ldtest/junit_test_logger.go
+++ b/framework/ldtest/junit_test_logger.go
@@ -8,8 +8,8 @@ import (
 	"sync"
 	"time"
 
-	"github.com/launchdarkly/sdk-test-harness/framework"
-	"github.com/launchdarkly/sdk-test-harness/framework/harness"
+	"github.com/launchdarkly/sdk-test-harness/v2/framework"
+	"github.com/launchdarkly/sdk-test-harness/v2/framework/harness"
 
 	"gopkg.in/launchdarkly/go-sdk-common.v2/ldvalue"
 )

--- a/framework/ldtest/test_logger.go
+++ b/framework/ldtest/test_logger.go
@@ -5,7 +5,7 @@ import (
 	"os"
 	"strings"
 
-	"github.com/launchdarkly/sdk-test-harness/framework"
+	"github.com/launchdarkly/sdk-test-harness/v2/framework"
 
 	"github.com/fatih/color"
 )

--- a/framework/ldtest/test_scope.go
+++ b/framework/ldtest/test_scope.go
@@ -6,7 +6,7 @@ import (
 	"runtime"
 	"runtime/debug"
 
-	"github.com/launchdarkly/sdk-test-harness/framework"
+	"github.com/launchdarkly/sdk-test-harness/v2/framework"
 )
 
 type environment struct {

--- a/framework/ldtest/test_scope_test.go
+++ b/framework/ldtest/test_scope_test.go
@@ -3,8 +3,8 @@ package ldtest
 import (
 	"testing"
 
-	"github.com/launchdarkly/sdk-test-harness/framework"
-	"github.com/launchdarkly/sdk-test-harness/framework/ldtest/internal"
+	"github.com/launchdarkly/sdk-test-harness/v2/framework"
+	"github.com/launchdarkly/sdk-test-harness/v2/framework/ldtest/internal"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/launchdarkly/sdk-test-harness
+module github.com/launchdarkly/sdk-test-harness/v2
 
 go 1.17
 

--- a/main.go
+++ b/main.go
@@ -11,11 +11,11 @@ import (
 	"strings"
 	"time"
 
-	"github.com/launchdarkly/sdk-test-harness/framework"
-	"github.com/launchdarkly/sdk-test-harness/framework/harness"
-	"github.com/launchdarkly/sdk-test-harness/framework/ldtest"
-	"github.com/launchdarkly/sdk-test-harness/sdktests"
-	"github.com/launchdarkly/sdk-test-harness/servicedef"
+	"github.com/launchdarkly/sdk-test-harness/v2/framework"
+	"github.com/launchdarkly/sdk-test-harness/v2/framework/harness"
+	"github.com/launchdarkly/sdk-test-harness/v2/framework/ldtest"
+	"github.com/launchdarkly/sdk-test-harness/v2/sdktests"
+	"github.com/launchdarkly/sdk-test-harness/v2/servicedef"
 )
 
 const defaultPort = 8111

--- a/mockld/big_segment_store.go
+++ b/mockld/big_segment_store.go
@@ -4,8 +4,8 @@ import (
 	"encoding/json"
 	"net/http"
 
-	"github.com/launchdarkly/sdk-test-harness/framework"
-	cf "github.com/launchdarkly/sdk-test-harness/servicedef/callbackfixtures"
+	"github.com/launchdarkly/sdk-test-harness/v2/framework"
+	cf "github.com/launchdarkly/sdk-test-harness/v2/servicedef/callbackfixtures"
 
 	"gopkg.in/launchdarkly/go-sdk-common.v2/ldtime"
 )

--- a/mockld/callback_helpers.go
+++ b/mockld/callback_helpers.go
@@ -6,7 +6,7 @@ import (
 	"io/ioutil"
 	"net/http"
 
-	"github.com/launchdarkly/sdk-test-harness/framework"
+	"github.com/launchdarkly/sdk-test-harness/v2/framework"
 
 	"github.com/gorilla/mux"
 )

--- a/mockld/events_service.go
+++ b/mockld/events_service.go
@@ -7,7 +7,7 @@ import (
 	"sync"
 	"time"
 
-	"github.com/launchdarkly/sdk-test-harness/framework"
+	"github.com/launchdarkly/sdk-test-harness/v2/framework"
 )
 
 // Somewhat arbitrary buffer size for the channel that we use as a queue for received events. We

--- a/mockld/streaming_service.go
+++ b/mockld/streaming_service.go
@@ -6,7 +6,7 @@ import (
 	"net/http"
 	"sync"
 
-	"github.com/launchdarkly/sdk-test-harness/framework"
+	"github.com/launchdarkly/sdk-test-harness/v2/framework"
 
 	"github.com/launchdarkly/eventsource"
 )

--- a/params.go
+++ b/params.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 	"os"
 
-	"github.com/launchdarkly/sdk-test-harness/framework/ldtest"
+	"github.com/launchdarkly/sdk-test-harness/v2/framework/ldtest"
 )
 
 type commandParams struct {

--- a/sdktests/custom_matchers_general.go
+++ b/sdktests/custom_matchers_general.go
@@ -5,7 +5,7 @@ import (
 	"sort"
 	"strings"
 
-	"github.com/launchdarkly/sdk-test-harness/servicedef"
+	"github.com/launchdarkly/sdk-test-harness/v2/servicedef"
 
 	"github.com/launchdarkly/go-test-helpers/v2/jsonhelpers"
 	m "github.com/launchdarkly/go-test-helpers/v2/matchers"

--- a/sdktests/helpers.go
+++ b/sdktests/helpers.go
@@ -7,10 +7,10 @@ import (
 	"time"
 
 	m "github.com/launchdarkly/go-test-helpers/v2/matchers"
-	"github.com/launchdarkly/sdk-test-harness/framework/harness"
-	"github.com/launchdarkly/sdk-test-harness/framework/ldtest"
-	"github.com/launchdarkly/sdk-test-harness/mockld"
-	"github.com/launchdarkly/sdk-test-harness/servicedef"
+	"github.com/launchdarkly/sdk-test-harness/v2/framework/harness"
+	"github.com/launchdarkly/sdk-test-harness/v2/framework/ldtest"
+	"github.com/launchdarkly/sdk-test-harness/v2/mockld"
+	"github.com/launchdarkly/sdk-test-harness/v2/servicedef"
 
 	"gopkg.in/launchdarkly/go-sdk-common.v2/ldtime"
 	"gopkg.in/launchdarkly/go-sdk-common.v2/lduser"

--- a/sdktests/server_side_big_segments.go
+++ b/sdktests/server_side_big_segments.go
@@ -5,9 +5,9 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/launchdarkly/sdk-test-harness/framework/ldtest"
-	"github.com/launchdarkly/sdk-test-harness/mockld"
-	"github.com/launchdarkly/sdk-test-harness/servicedef"
+	"github.com/launchdarkly/sdk-test-harness/v2/framework/ldtest"
+	"github.com/launchdarkly/sdk-test-harness/v2/mockld"
+	"github.com/launchdarkly/sdk-test-harness/v2/servicedef"
 
 	m "github.com/launchdarkly/go-test-helpers/v2/matchers"
 	"gopkg.in/launchdarkly/go-sdk-common.v2/ldreason"

--- a/sdktests/server_side_data_store_updates.go
+++ b/sdktests/server_side_data_store_updates.go
@@ -6,9 +6,9 @@ import (
 
 	"github.com/launchdarkly/go-test-helpers/v2/jsonhelpers"
 	m "github.com/launchdarkly/go-test-helpers/v2/matchers"
-	"github.com/launchdarkly/sdk-test-harness/framework/ldtest"
-	"github.com/launchdarkly/sdk-test-harness/mockld"
-	"github.com/launchdarkly/sdk-test-harness/servicedef"
+	"github.com/launchdarkly/sdk-test-harness/v2/framework/ldtest"
+	"github.com/launchdarkly/sdk-test-harness/v2/mockld"
+	"github.com/launchdarkly/sdk-test-harness/v2/servicedef"
 
 	"gopkg.in/launchdarkly/go-sdk-common.v2/lduser"
 	"gopkg.in/launchdarkly/go-sdk-common.v2/ldvalue"

--- a/sdktests/server_side_eval.go
+++ b/sdktests/server_side_eval.go
@@ -3,11 +3,11 @@ package sdktests
 import (
 	"fmt"
 
-	"github.com/launchdarkly/sdk-test-harness/framework/ldtest"
-	"github.com/launchdarkly/sdk-test-harness/mockld"
-	"github.com/launchdarkly/sdk-test-harness/servicedef"
-	"github.com/launchdarkly/sdk-test-harness/testdata"
-	"github.com/launchdarkly/sdk-test-harness/testdata/testmodel"
+	"github.com/launchdarkly/sdk-test-harness/v2/framework/ldtest"
+	"github.com/launchdarkly/sdk-test-harness/v2/mockld"
+	"github.com/launchdarkly/sdk-test-harness/v2/servicedef"
+	"github.com/launchdarkly/sdk-test-harness/v2/testdata"
+	"github.com/launchdarkly/sdk-test-harness/v2/testdata/testmodel"
 
 	m "github.com/launchdarkly/go-test-helpers/v2/matchers"
 	"gopkg.in/launchdarkly/go-sdk-common.v2/ldreason"

--- a/sdktests/server_side_eval_all_flags.go
+++ b/sdktests/server_side_eval_all_flags.go
@@ -4,9 +4,9 @@ import (
 	"encoding/json"
 	"fmt"
 
-	"github.com/launchdarkly/sdk-test-harness/framework/ldtest"
-	"github.com/launchdarkly/sdk-test-harness/mockld"
-	"github.com/launchdarkly/sdk-test-harness/servicedef"
+	"github.com/launchdarkly/sdk-test-harness/v2/framework/ldtest"
+	"github.com/launchdarkly/sdk-test-harness/v2/mockld"
+	"github.com/launchdarkly/sdk-test-harness/v2/servicedef"
 
 	m "github.com/launchdarkly/go-test-helpers/v2/matchers"
 	"gopkg.in/launchdarkly/go-sdk-common.v2/ldtime"

--- a/sdktests/server_side_events_alias.go
+++ b/sdktests/server_side_events_alias.go
@@ -3,9 +3,9 @@ package sdktests
 import (
 	"fmt"
 
-	"github.com/launchdarkly/sdk-test-harness/framework/ldtest"
-	"github.com/launchdarkly/sdk-test-harness/mockld"
-	"github.com/launchdarkly/sdk-test-harness/servicedef"
+	"github.com/launchdarkly/sdk-test-harness/v2/framework/ldtest"
+	"github.com/launchdarkly/sdk-test-harness/v2/mockld"
+	"github.com/launchdarkly/sdk-test-harness/v2/servicedef"
 
 	m "github.com/launchdarkly/go-test-helpers/v2/matchers"
 	"gopkg.in/launchdarkly/go-sdk-common.v2/lduser"

--- a/sdktests/server_side_events_buffer.go
+++ b/sdktests/server_side_events_buffer.go
@@ -1,9 +1,9 @@
 package sdktests
 
 import (
-	"github.com/launchdarkly/sdk-test-harness/framework/ldtest"
-	"github.com/launchdarkly/sdk-test-harness/mockld"
-	"github.com/launchdarkly/sdk-test-harness/servicedef"
+	"github.com/launchdarkly/sdk-test-harness/v2/framework/ldtest"
+	"github.com/launchdarkly/sdk-test-harness/v2/mockld"
+	"github.com/launchdarkly/sdk-test-harness/v2/servicedef"
 
 	m "github.com/launchdarkly/go-test-helpers/v2/matchers"
 	"gopkg.in/launchdarkly/go-sdk-common.v2/lduser"

--- a/sdktests/server_side_events_custom.go
+++ b/sdktests/server_side_events_custom.go
@@ -3,9 +3,9 @@ package sdktests
 import (
 	"fmt"
 
-	"github.com/launchdarkly/sdk-test-harness/framework/ldtest"
-	"github.com/launchdarkly/sdk-test-harness/mockld"
-	"github.com/launchdarkly/sdk-test-harness/servicedef"
+	"github.com/launchdarkly/sdk-test-harness/v2/framework/ldtest"
+	"github.com/launchdarkly/sdk-test-harness/v2/mockld"
+	"github.com/launchdarkly/sdk-test-harness/v2/servicedef"
 
 	m "github.com/launchdarkly/go-test-helpers/v2/matchers"
 	"gopkg.in/launchdarkly/go-sdk-common.v2/ldvalue"

--- a/sdktests/server_side_events_eval.go
+++ b/sdktests/server_side_events_eval.go
@@ -3,9 +3,9 @@ package sdktests
 import (
 	"time"
 
-	"github.com/launchdarkly/sdk-test-harness/framework/ldtest"
-	"github.com/launchdarkly/sdk-test-harness/mockld"
-	"github.com/launchdarkly/sdk-test-harness/servicedef"
+	"github.com/launchdarkly/sdk-test-harness/v2/framework/ldtest"
+	"github.com/launchdarkly/sdk-test-harness/v2/mockld"
+	"github.com/launchdarkly/sdk-test-harness/v2/servicedef"
 
 	m "github.com/launchdarkly/go-test-helpers/v2/matchers"
 	"gopkg.in/launchdarkly/go-sdk-common.v2/ldreason"

--- a/sdktests/server_side_events_experimentation.go
+++ b/sdktests/server_side_events_experimentation.go
@@ -3,8 +3,8 @@ package sdktests
 import (
 	"time"
 
-	"github.com/launchdarkly/sdk-test-harness/framework/ldtest"
-	"github.com/launchdarkly/sdk-test-harness/mockld"
+	"github.com/launchdarkly/sdk-test-harness/v2/framework/ldtest"
+	"github.com/launchdarkly/sdk-test-harness/v2/mockld"
 
 	m "github.com/launchdarkly/go-test-helpers/v2/matchers"
 	"gopkg.in/launchdarkly/go-sdk-common.v2/ldreason"

--- a/sdktests/server_side_events_identify.go
+++ b/sdktests/server_side_events_identify.go
@@ -3,9 +3,9 @@ package sdktests
 import (
 	"time"
 
-	"github.com/launchdarkly/sdk-test-harness/framework/ldtest"
-	"github.com/launchdarkly/sdk-test-harness/mockld"
-	"github.com/launchdarkly/sdk-test-harness/servicedef"
+	"github.com/launchdarkly/sdk-test-harness/v2/framework/ldtest"
+	"github.com/launchdarkly/sdk-test-harness/v2/mockld"
+	"github.com/launchdarkly/sdk-test-harness/v2/servicedef"
 
 	m "github.com/launchdarkly/go-test-helpers/v2/matchers"
 	"gopkg.in/launchdarkly/go-sdk-common.v2/lduser"

--- a/sdktests/server_side_events_index.go
+++ b/sdktests/server_side_events_index.go
@@ -1,9 +1,9 @@
 package sdktests
 
 import (
-	"github.com/launchdarkly/sdk-test-harness/framework/ldtest"
-	"github.com/launchdarkly/sdk-test-harness/mockld"
-	"github.com/launchdarkly/sdk-test-harness/servicedef"
+	"github.com/launchdarkly/sdk-test-harness/v2/framework/ldtest"
+	"github.com/launchdarkly/sdk-test-harness/v2/mockld"
+	"github.com/launchdarkly/sdk-test-harness/v2/servicedef"
 
 	m "github.com/launchdarkly/go-test-helpers/v2/matchers"
 	"gopkg.in/launchdarkly/go-sdk-common.v2/lduser"

--- a/sdktests/server_side_events_summary.go
+++ b/sdktests/server_side_events_summary.go
@@ -3,9 +3,9 @@ package sdktests
 import (
 	"time"
 
-	"github.com/launchdarkly/sdk-test-harness/framework/ldtest"
-	"github.com/launchdarkly/sdk-test-harness/mockld"
-	"github.com/launchdarkly/sdk-test-harness/servicedef"
+	"github.com/launchdarkly/sdk-test-harness/v2/framework/ldtest"
+	"github.com/launchdarkly/sdk-test-harness/v2/mockld"
+	"github.com/launchdarkly/sdk-test-harness/v2/servicedef"
 
 	"github.com/launchdarkly/go-test-helpers/v2/jsonhelpers"
 	m "github.com/launchdarkly/go-test-helpers/v2/matchers"

--- a/sdktests/server_side_events_users.go
+++ b/sdktests/server_side_events_users.go
@@ -5,9 +5,9 @@ import (
 	"sort"
 	"strings"
 
-	"github.com/launchdarkly/sdk-test-harness/framework/ldtest"
-	"github.com/launchdarkly/sdk-test-harness/mockld"
-	"github.com/launchdarkly/sdk-test-harness/servicedef"
+	"github.com/launchdarkly/sdk-test-harness/v2/framework/ldtest"
+	"github.com/launchdarkly/sdk-test-harness/v2/mockld"
+	"github.com/launchdarkly/sdk-test-harness/v2/servicedef"
 
 	"github.com/launchdarkly/go-test-helpers/v2/jsonhelpers"
 	m "github.com/launchdarkly/go-test-helpers/v2/matchers"

--- a/sdktests/server_side_stream_request.go
+++ b/sdktests/server_side_stream_request.go
@@ -4,9 +4,9 @@ import (
 	"strings"
 	"time"
 
-	"github.com/launchdarkly/sdk-test-harness/framework/ldtest"
-	"github.com/launchdarkly/sdk-test-harness/mockld"
-	"github.com/launchdarkly/sdk-test-harness/servicedef"
+	"github.com/launchdarkly/sdk-test-harness/v2/framework/ldtest"
+	"github.com/launchdarkly/sdk-test-harness/v2/mockld"
+	"github.com/launchdarkly/sdk-test-harness/v2/servicedef"
 
 	"github.com/stretchr/testify/assert"
 )

--- a/sdktests/server_side_stream_retry.go
+++ b/sdktests/server_side_stream_retry.go
@@ -5,10 +5,10 @@ import (
 	"net/http"
 	"time"
 
-	"github.com/launchdarkly/sdk-test-harness/framework/harness"
-	"github.com/launchdarkly/sdk-test-harness/framework/ldtest"
-	"github.com/launchdarkly/sdk-test-harness/mockld"
-	"github.com/launchdarkly/sdk-test-harness/servicedef"
+	"github.com/launchdarkly/sdk-test-harness/v2/framework/harness"
+	"github.com/launchdarkly/sdk-test-harness/v2/framework/ldtest"
+	"github.com/launchdarkly/sdk-test-harness/v2/mockld"
+	"github.com/launchdarkly/sdk-test-harness/v2/servicedef"
 
 	"github.com/launchdarkly/go-test-helpers/v2/httphelpers"
 	m "github.com/launchdarkly/go-test-helpers/v2/matchers"

--- a/sdktests/server_side_stream_validation.go
+++ b/sdktests/server_side_stream_validation.go
@@ -7,9 +7,9 @@ import (
 	"github.com/launchdarkly/go-test-helpers/v2/httphelpers"
 	"github.com/launchdarkly/go-test-helpers/v2/jsonhelpers"
 	m "github.com/launchdarkly/go-test-helpers/v2/matchers"
-	"github.com/launchdarkly/sdk-test-harness/framework/ldtest"
-	"github.com/launchdarkly/sdk-test-harness/mockld"
-	"github.com/launchdarkly/sdk-test-harness/servicedef"
+	"github.com/launchdarkly/sdk-test-harness/v2/framework/ldtest"
+	"github.com/launchdarkly/sdk-test-harness/v2/mockld"
+	"github.com/launchdarkly/sdk-test-harness/v2/servicedef"
 	"gopkg.in/launchdarkly/go-sdk-common.v2/lduser"
 	"gopkg.in/launchdarkly/go-sdk-common.v2/ldvalue"
 )

--- a/sdktests/testapi_context.go
+++ b/sdktests/testapi_context.go
@@ -1,9 +1,9 @@
 package sdktests
 
 import (
-	"github.com/launchdarkly/sdk-test-harness/framework/harness"
-	"github.com/launchdarkly/sdk-test-harness/framework/ldtest"
-	"github.com/launchdarkly/sdk-test-harness/mockld"
+	"github.com/launchdarkly/sdk-test-harness/v2/framework/harness"
+	"github.com/launchdarkly/sdk-test-harness/v2/framework/ldtest"
+	"github.com/launchdarkly/sdk-test-harness/v2/mockld"
 )
 
 const defaultSDKKey = "test-sdk-key"

--- a/sdktests/testapi_sdk_big_segments.go
+++ b/sdktests/testapi_sdk_big_segments.go
@@ -5,10 +5,10 @@ import (
 	"sync"
 	"time"
 
-	"github.com/launchdarkly/sdk-test-harness/framework/harness"
-	"github.com/launchdarkly/sdk-test-harness/framework/ldtest"
-	"github.com/launchdarkly/sdk-test-harness/mockld"
-	"github.com/launchdarkly/sdk-test-harness/servicedef"
+	"github.com/launchdarkly/sdk-test-harness/v2/framework/harness"
+	"github.com/launchdarkly/sdk-test-harness/v2/framework/ldtest"
+	"github.com/launchdarkly/sdk-test-harness/v2/mockld"
+	"github.com/launchdarkly/sdk-test-harness/v2/servicedef"
 
 	"gopkg.in/launchdarkly/go-sdk-common.v2/ldreason"
 	"gopkg.in/launchdarkly/go-sdk-common.v2/ldtime"

--- a/sdktests/testapi_sdk_client.go
+++ b/sdktests/testapi_sdk_client.go
@@ -3,9 +3,9 @@ package sdktests
 import (
 	"errors"
 
-	"github.com/launchdarkly/sdk-test-harness/framework/harness"
-	"github.com/launchdarkly/sdk-test-harness/framework/ldtest"
-	"github.com/launchdarkly/sdk-test-harness/servicedef"
+	"github.com/launchdarkly/sdk-test-harness/v2/framework/harness"
+	"github.com/launchdarkly/sdk-test-harness/v2/framework/ldtest"
+	"github.com/launchdarkly/sdk-test-harness/v2/servicedef"
 
 	"gopkg.in/launchdarkly/go-sdk-common.v2/lduser"
 

--- a/sdktests/testapi_sdk_data.go
+++ b/sdktests/testapi_sdk_data.go
@@ -3,10 +3,10 @@ package sdktests
 import (
 	"net/http"
 
-	"github.com/launchdarkly/sdk-test-harness/framework/harness"
-	"github.com/launchdarkly/sdk-test-harness/framework/ldtest"
-	"github.com/launchdarkly/sdk-test-harness/mockld"
-	"github.com/launchdarkly/sdk-test-harness/servicedef"
+	"github.com/launchdarkly/sdk-test-harness/v2/framework/harness"
+	"github.com/launchdarkly/sdk-test-harness/v2/framework/ldtest"
+	"github.com/launchdarkly/sdk-test-harness/v2/mockld"
+	"github.com/launchdarkly/sdk-test-harness/v2/servicedef"
 )
 
 // SDKDataSource is a test fixture that provides a callback endpoint for SDK clients to connect to,

--- a/sdktests/testapi_sdk_events.go
+++ b/sdktests/testapi_sdk_events.go
@@ -3,10 +3,10 @@ package sdktests
 import (
 	"time"
 
-	"github.com/launchdarkly/sdk-test-harness/framework/harness"
-	"github.com/launchdarkly/sdk-test-harness/framework/ldtest"
-	"github.com/launchdarkly/sdk-test-harness/mockld"
-	"github.com/launchdarkly/sdk-test-harness/servicedef"
+	"github.com/launchdarkly/sdk-test-harness/v2/framework/harness"
+	"github.com/launchdarkly/sdk-test-harness/v2/framework/ldtest"
+	"github.com/launchdarkly/sdk-test-harness/v2/mockld"
+	"github.com/launchdarkly/sdk-test-harness/v2/servicedef"
 
 	"github.com/stretchr/testify/require"
 )

--- a/sdktests/testdata_factories.go
+++ b/sdktests/testdata_factories.go
@@ -3,7 +3,7 @@ package sdktests
 import (
 	"fmt"
 
-	"github.com/launchdarkly/sdk-test-harness/servicedef"
+	"github.com/launchdarkly/sdk-test-harness/v2/servicedef"
 	"gopkg.in/launchdarkly/go-sdk-common.v2/ldreason"
 	"gopkg.in/launchdarkly/go-sdk-common.v2/ldtime"
 	"gopkg.in/launchdarkly/go-sdk-common.v2/lduser"

--- a/sdktests/testsuite_server_side.go
+++ b/sdktests/testsuite_server_side.go
@@ -3,11 +3,11 @@ package sdktests
 import (
 	"time"
 
-	"github.com/launchdarkly/sdk-test-harness/framework"
-	"github.com/launchdarkly/sdk-test-harness/framework/harness"
-	"github.com/launchdarkly/sdk-test-harness/framework/ldtest"
-	"github.com/launchdarkly/sdk-test-harness/mockld"
-	"github.com/launchdarkly/sdk-test-harness/servicedef"
+	"github.com/launchdarkly/sdk-test-harness/v2/framework"
+	"github.com/launchdarkly/sdk-test-harness/v2/framework/harness"
+	"github.com/launchdarkly/sdk-test-harness/v2/framework/ldtest"
+	"github.com/launchdarkly/sdk-test-harness/v2/mockld"
+	"github.com/launchdarkly/sdk-test-harness/v2/servicedef"
 )
 
 const defaultEventTimeout = time.Second * 5

--- a/servicedef/service_params.go
+++ b/servicedef/service_params.go
@@ -1,6 +1,6 @@
 package servicedef
 
-import "github.com/launchdarkly/sdk-test-harness/framework/harness"
+import "github.com/launchdarkly/sdk-test-harness/v2/framework/harness"
 
 const (
 	CapabilityClientSide    = "client-side"

--- a/testdata/testmodel/eval.go
+++ b/testdata/testmodel/eval.go
@@ -1,8 +1,8 @@
 package testmodel
 
 import (
-	"github.com/launchdarkly/sdk-test-harness/mockld"
-	"github.com/launchdarkly/sdk-test-harness/servicedef"
+	"github.com/launchdarkly/sdk-test-harness/v2/mockld"
+	"github.com/launchdarkly/sdk-test-harness/v2/servicedef"
 
 	"gopkg.in/launchdarkly/go-sdk-common.v2/ldreason"
 	"gopkg.in/launchdarkly/go-sdk-common.v2/lduser"


### PR DESCRIPTION
The current major feature work will result in SDKs with different enough behavior (features are being both added and removed) that it's best to go to a new major version of sdk-test-harness, rather than try to make all of that behavior conditional on the SDKs' reported capabilities.

The other, more incremental feature work that's currently ongoing (tags) will go into the existing v1.