### PR TITLE
Add description when not filtering user properties

### DIFF
--- a/sdktests/server_side_events_users.go
+++ b/sdktests/server_side_events_users.go
@@ -47,6 +47,10 @@ func (s eventUserTestScenario) Description() string {
 	if len(s.userPrivateAttrs) != 0 {
 		parts = append(parts, fmt.Sprintf("user-private=%v", s.userPrivateAttrs))
 	}
+	if len(parts) == 0 {
+		parts = append(parts, "no-attributes-filtered")
+	}
+
 	return strings.Join(parts, ", ")
 }
 


### PR DESCRIPTION
When running a test for user properties, if we aren't providing any
private attribute configurations (global or otherwise), the generated
description is empty. This fixes that by providing a default description
which better describes the scenario under test.