### PR TITLE
fix context build params to correspond to the spec

### DIFF
--- a/sdktests/sdk_context_type.go
+++ b/sdktests/sdk_context_type.go
@@ -90,8 +90,7 @@ func doSDKContextBuildTests(t *ldtest.T) {
 			testCases = append(testCases, testCase{servicedef.ContextBuildParams{Single: &params}, c.expected})
 		}
 		for _, c := range multiKindTestCases {
-			testCases = append(testCases, testCase{servicedef.ContextBuildParams{
-				Multi: &servicedef.ContextBuildMultiParams{Kinds: c.kinds}}, c.expected})
+			testCases = append(testCases, testCase{servicedef.ContextBuildParams{Multi: c.kinds}, c.expected})
 		}
 
 		for _, p := range testCases {

--- a/servicedef/command_params.go
+++ b/servicedef/command_params.go
@@ -81,8 +81,8 @@ type BigSegmentStoreStatusResponse struct {
 }
 
 type ContextBuildParams struct {
-	Single *ContextBuildSingleParams `json:"single,omitempty"`
-	Multi  *ContextBuildMultiParams  `json:"multi,omitempty"`
+	Single *ContextBuildSingleParams  `json:"single,omitempty"`
+	Multi  []ContextBuildSingleParams `json:"multi,omitempty"`
 }
 
 type ContextBuildSingleParams struct {
@@ -93,10 +93,6 @@ type ContextBuildSingleParams struct {
 	Secondary *string                  `json:"secondary,omitempty"`
 	Private   []string                 `json:"private,omitempty"`
 	Custom    map[string]ldvalue.Value `json:"custom,omitempty"`
-}
-
-type ContextBuildMultiParams struct {
-	Kinds []ContextBuildSingleParams `json:"kinds,omitempty"`
 }
 
 type ContextBuildResponse struct {


### PR DESCRIPTION
The struct it was sending had an extra `Kinds` container that wasn't necessary.