### PR TITLE
Add test to ensure SDKs reject context with kind as empty string

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 .vscode/
 bin/
 dist/
+.idea/
 
 sdk-test-harness

--- a/sdktests/sdk_context_type.go
+++ b/sdktests/sdk_context_type.go
@@ -224,6 +224,7 @@ func doSDKContextConvertTests(t *ldtest.T) {
 
 			// wrong type for built-in property
 			`{"kind": null, "key": "x"}`,
+			`{"kind": "", "key" : "x"}`,
 			`{"kind": true, "key": "x"}`,
 			`{"kind": "org", "key": null}`,
 			`{"kind": "org", "key": 3}`,

--- a/sdktests/sdk_context_type.go
+++ b/sdktests/sdk_context_type.go
@@ -224,7 +224,6 @@ func doSDKContextConvertTests(t *ldtest.T) {
 
 			// wrong type for built-in property
 			`{"kind": null, "key": "x"}`,
-			`{"kind": "", "key" : "x"}`,
 			`{"kind": true, "key": "x"}`,
 			`{"kind": "org", "key": null}`,
 			`{"kind": "org", "key": 3}`,
@@ -237,6 +236,8 @@ func doSDKContextConvertTests(t *ldtest.T) {
 
 			`{"kind": "kind", "key": "x"}`, // kind cannot be "kind"
 			`{"kind": "multi"}`,            // multi-kind with no kinds
+			`{"kind": "", "key" : "x"}`,    // kind cannot be empty string
+
 		}
 		for _, input := range inputs {
 			t.Run(input, func(t *ldtest.T) {


### PR DESCRIPTION
SDKs should reject contexts of the form `{"kind" : "", ...}`.

This is because implicit user format is defined to be "distinguished from the other formats by the absence of a top-level kind attribute", and single-kind format is defined such that kind cannot be an empty string.