### PR TITLE
tolerate variants of redacted attribute name in events

### DIFF
--- a/sdktests/custom_matchers_events.go
+++ b/sdktests/custom_matchers_events.go
@@ -1,6 +1,8 @@
 package sdktests
 
 import (
+	"strings"
+
 	"github.com/launchdarkly/go-sdk-common/v3/ldcontext"
 	m "github.com/launchdarkly/go-test-helpers/v2/matchers"
 )
@@ -104,4 +106,21 @@ func IsValidSummaryEventWithFlags(keyValueMatchers ...m.KeyValueMatcher) m.Match
 		JSONPropertyKeysCanOnlyBe("kind", "startDate", "endDate", "features"),
 		m.JSONProperty("features").Should(m.MapOf(keyValueMatchers...)),
 	)
+}
+
+// RedactedAttributesAre is a matcher for the value of an event context's redactedAttributes property,
+// verifying that it has the specified attribute names/references and no others. This is not just a
+// plain slice match, because 1. they can be in any order and 2. for simple attribute names, the SDK
+// is allowed to send either "name" or "/name" (with any slashes or tildes escaped in the latter case).
+func RedactedAttributesAre(attrStrings ...string) m.Matcher {
+	matchers := make([]m.Matcher, 0, len(attrStrings))
+	for _, s := range attrStrings {
+		if strings.HasPrefix(s, "/") {
+			matchers = append(matchers, m.Equal(s))
+		} else {
+			escapedName := strings.ReplaceAll(strings.ReplaceAll(s, "~", "~0"), "/", "~1")
+			matchers = append(matchers, m.AnyOf(m.Equal(s), m.Equal("/"+escapedName)))
+		}
+	}
+	return m.ItemsInAnyOrder(matchers...)
 }

--- a/sdktests/server_side_events_contexts.go
+++ b/sdktests/server_side_events_contexts.go
@@ -87,9 +87,7 @@ func makeEventContextTestParams() []eventContextTestParams {
 				m.KV("transient", m.Equal(true)),
 				m.KV("_meta", m.MapOf(
 					m.KV("secondary", m.Equal("s")),
-					m.KV("redactedAttributes", m.ItemsInAnyOrder(
-						m.Equal("name"), m.Equal("b"),
-					)),
+					m.KV("redactedAttributes", RedactedAttributesAre("name", "b")),
 				)),
 			),
 		},
@@ -111,9 +109,7 @@ func makeEventContextTestParams() []eventContextTestParams {
 				anyKeyMatcher, defaultKindMatcher,
 				m.KV("d", m.Equal("e")),
 				m.KV("_meta", m.MapOf(
-					m.KV("redactedAttributes", m.ItemsInAnyOrder(
-						m.Equal("name"), m.Equal("b"),
-					)),
+					m.KV("redactedAttributes", RedactedAttributesAre("name", "b")),
 				)),
 			),
 		},
@@ -137,9 +133,7 @@ func makeEventContextTestParams() []eventContextTestParams {
 				m.KV("b", m.JSONStrEqual(`{"prop2": 3}`)),
 				m.KV("c", m.JSONStrEqual(`{"prop1": {"sub1": true}, "prop2": {"sub2": 5}}`)),
 				m.KV("_meta", m.MapOf(
-					m.KV("redactedAttributes", m.ItemsInAnyOrder(
-						m.Equal("/b/prop1"), m.Equal("/c/prop2/sub1"),
-					)),
+					m.KV("redactedAttributes", RedactedAttributesAre("/b/prop1", "/c/prop2/sub1")),
 				)),
 			),
 		},


### PR DESCRIPTION
If the SDK (or the individual context) is configured to redact the attribute "attr", that could be specified either as "attr" or "/attr", and the SDK is allowed to use either variant when it builds the `redactedAttributes` list. The tests had an overly specific expectation about this, based on how the Go SDK happened to do it.