### PR TITLE
add tests for context kind in segments

### DIFF
--- a/data/data-files/server-side-eval/segment-match.yml
+++ b/data/data-files/server-side-eval/segment-match.yml
@@ -34,6 +34,14 @@ sdkData:
           clauses:
             - { attribute: "", op: "segmentMatch", values: [ "segment1", "segment2" ]}
 
+    flag-using-segment-with-context-kinds:
+      <<: *boolean_flag_base
+      rules:
+        - id: ruleid
+          variation: 0
+          clauses:
+            - { attribute: "", op: "segmentMatch", values: [ "segment-with-context-kinds" ]}
+
     flag-using-unknown-segment:
       <<: *boolean_flag_base
       rules:
@@ -55,11 +63,23 @@ sdkData:
         - clauses:
             - { attribute: "segment2RuleShouldMatch", op: "in", values: [ true ] }
 
+    segment-with-context-kinds:
+      included: [ "included-user-key" ]
+      excluded: [ "excluded-user-key" ]
+      includedContexts:
+        - { contextKind: "kind1", values: [ "included-kind1-key" ] }
+        - { contextKind: "kind2", values: [ "included-kind2-key" ] }
+      excludedContexts:
+        - { contextKind: "kind1", values: [ "excluded-kind1-key" ] }
+        - { contextKind: "kind2", values: [ "excluded-kind2-key" ] }
+      rules:
+        - { clauses: [ { attribute: "match-user-rule", op: "in", values: [ true ] } ] }
+        - { clauses: [ { contextKind: "kind1", attribute: "match-kind1-rule", op: "in", values: [ true ] } ] }
+
 evaluations:
   - name: user matches via include
     flagKey: flag-using-segment1
-    context:
-      key: "user-included-in-segment"
+    context: { key: "user-included-in-segment" }
     expect: <IS_MATCH>
 
   - name: user matches via rule
@@ -78,8 +98,7 @@ evaluations:
 
   - name: user does not match and is not included
     flagKey: flag-using-segment1
-    context:
-      key: "some-user"
+    context: { key: "some-user" }
     expect: <IS_NOT_MATCH>
 
   - name: clause matches if any of the segments match
@@ -91,6 +110,51 @@ evaluations:
 
   - name: unknown segment is non-match, not an error
     flagKey: flag-using-unknown-segment
-    context:
-      key: "user-key"
+    context: { key: "user-key" }
     expect: <IS_NOT_MATCH>
+
+  - name: included list is specific to user kind
+    flagKey: flag-using-segment-with-context-kinds
+    context: { kind: "kind1", key: "included-user-key" }
+    expect: <IS_NOT_MATCH>
+
+  - name: includedContexts match for non-default context kind
+    flagKey: flag-using-segment-with-context-kinds
+    context: { kind: "kind1", key: "included-kind1-key" }
+    expect: <IS_MATCH>
+
+  - name: includedContexts non-match for default context kind
+    flagKey: flag-using-segment-with-context-kinds
+    context: { kind: "user", key: "included-kind1-key" }
+    expect: <IS_NOT_MATCH>
+
+  - name: includedContexts non-match for non-default context kind
+    flagKey: flag-using-segment-with-context-kinds
+    context: { kind: "kind2", key: "included-kind1-key" }
+    expect: <IS_NOT_MATCH>
+
+  - name: excluded list is specific to user kind
+    flagKey: flag-using-segment-with-context-kinds
+    context: { kind: "kind1", key: "excluded-user-key", match-kind1-rule: true }
+    expect: <IS_MATCH>
+
+  - name: rule match for non-default context kind
+    flagKey: flag-using-segment-with-context-kinds
+    context: { kind: "kind1", key: "some-other-key", match-kind1-rule: true }
+    expect: <IS_MATCH>
+
+  - name: excludedContexts match for non-default context kind
+    flagKey: flag-using-segment-with-context-kinds
+    context: { kind: "kind1", key: "excluded-kind1-key", match-kind1-rule: true }
+    expect: <IS_NOT_MATCH>
+
+  - name: excludedContexts non-match for default context kind
+    flagKey: flag-using-segment-with-context-kinds
+    context: { kind: "user", key: "excluded-kind1-key", match-user-rule: true }
+    expect: <IS_MATCH>
+
+  - name: excludedContexts non-match for non-default context kind
+    # is matched by kind1 rule; is not matched by exclude for kind2 despite key
+    flagKey: flag-using-segment-with-context-kinds
+    context: { kind: "kind1", key: "excluded-kind2-key", match-kind1-rule: true }
+    expect: <IS_MATCH>

--- a/sdktests/custom_matchers_general.go
+++ b/sdktests/custom_matchers_general.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/launchdarkly/sdk-test-harness/v2/servicedef"
 
+	"github.com/launchdarkly/go-sdk-common/v3/ldreason"
 	"github.com/launchdarkly/go-sdk-common/v3/ldvalue"
 	"github.com/launchdarkly/go-test-helpers/v2/jsonhelpers"
 	m "github.com/launchdarkly/go-test-helpers/v2/matchers"
@@ -14,6 +15,13 @@ import (
 
 // The functions in this file are for convenient use of the matchers API with complex
 // types. For more information, see matchers.Transform.
+
+// EqualReason is a type-safe replacement for m.Equal(EvaluationReason) that also provides better
+// failure output, by treating it as a JSON object-- since the default implementation of String()
+// for EvaluationReason returns a shorter string that doesn't include every property.
+func EqualReason(reason ldreason.EvaluationReason) m.Matcher {
+	return m.JSONEqual(reason)
+}
 
 func EvalResponseValue() m.MatcherTransform {
 	return m.Transform(


### PR DESCRIPTION
See PR comments. The behavior for regular segments is pretty straightforward, so those cases are just added to the YAML files for the parameterized tests. For big segments, there's other behavior that we need to cover in Go code.