### PR TITLE
in context build/convert tests, expect "multi"-kind to become single if there's only one kind

### DIFF
--- a/sdktests/sdk_context_type.go
+++ b/sdktests/sdk_context_type.go
@@ -75,9 +75,15 @@ func doSDKContextBuildTests(t *ldtest.T) {
 			kinds    []servicedef.ContextBuildSingleParams
 			expected string
 		}{
-			{[]servicedef.ContextBuildSingleParams{{Key: "a"}}, `{"kind": "multi", "user": {"key": "a"}}`},
-			{[]servicedef.ContextBuildSingleParams{{Kind: optStr("org"), Key: "a"}, {Key: "b"}},
-				`{"kind": "multi", "org": {"key": "a"}, "user": {"key": "b"}}`},
+			{
+				[]servicedef.ContextBuildSingleParams{{Kind: optStr("org"), Key: "a"}, {Key: "b"}},
+				`{"kind": "multi", "org": {"key": "a"}, "user": {"key": "b"}}`,
+			},
+			{
+				// multi-kind with only one kind becomes single-kind
+				[]servicedef.ContextBuildSingleParams{{Kind: optStr("org"), Key: "a"}},
+				`{"kind": "org", "key": "a"}`,
+			},
 		}
 
 		type testCase struct {
@@ -147,7 +153,8 @@ func doSDKContextConvertTests(t *ldtest.T) {
 
 			// verify that all allowable characters in kind are accepted
 			`{"kind": "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ013456789-_.", "key": "x"}`,
-			`{"kind": "multi", "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ013456789-_.": {"key": "x"}}`,
+			`{"kind": "multi", "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ013456789-_.": {"key": "x"},`+
+				` "other": {"key": "y"}}`,
 		)
 
 		for _, input := range inputs {
@@ -214,6 +221,14 @@ func doSDKContextConvertTests(t *ldtest.T) {
 				m.In(t).Assert(json.RawMessage(resp.Output), m.JSONEqual(json.RawMessage(p.out)))
 			})
 		}
+	})
+
+	t.Run("multi-kind with only one kind becomes single-kind", func(t *ldtest.T) {
+		singleKindJSON := `{"kind": "org", "key": "a", "name": "b"}`
+		multiKindJSON := `{"kind": "multi", "org": {"key": "a", "name": "b"}}`
+		resp := client.ContextConvert(t, servicedef.ContextConvertParams{Input: multiKindJSON})
+		require.Equal(t, "", resp.Error)
+		m.In(t).Assert(json.RawMessage(resp.Output), m.JSONEqual(json.RawMessage(singleKindJSON)))
 	})
 
 	t.Run("invalid context", func(t *ldtest.T) {


### PR DESCRIPTION
This corresponds to https://github.com/launchdarkly/go-sdk-common-private/pull/77.