### PR TITLE
update goreleaser so we get arm64 binaries

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,7 @@
 
-GORELEASER_VERSION=v0.141.0
-GORELEASER_CMD=curl -sL https://git.io/goreleaser | GOPATH=$(mktemp -d) VERSION=$(GORELEASER_VERSION) bash -s -- --rm-dist
+GORELEASER_VERSION=v1.7.0
+GORELEASER_DOWNLOAD_URL=https://github.com/goreleaser/goreleaser/releases/download/v1.7.0/goreleaser_$(shell uname)_$(shell uname -m).tar.gz
+GORELEASER=./bin/goreleaser/goreleaser
 
 GOLANGCI_LINT_VERSION=v1.44.0
 
@@ -24,11 +25,15 @@ test:
 	go test -run=not-a-real-test ./...  # just ensures that the tests compile
 	go test ./...
 
-build-release:
-	$(GORELEASER_CMD) --snapshot --skip-publish --skip-validate
+$(GORELEASER):
+	mkdir -p ./bin/goreleaser
+	curl -qL $(GORELEASER_DOWNLOAD_URL) | tar xvz -C ./bin/goreleaser
+
+build-release: $(GORELEASER)
+	$(GORELEASER) --snapshot --skip-publish --skip-validate
 
 publish-release:
-	$(GORELEASER_CMD)
+	$(GORELEASER)
 
 $(LINTER_VERSION_FILE):
 	rm -f $(LINTER)

--- a/Makefile
+++ b/Makefile
@@ -32,7 +32,7 @@ $(GORELEASER):
 build-release: $(GORELEASER)
 	$(GORELEASER) --snapshot --skip-publish --skip-validate
 
-publish-release:
+publish-release: $(GORELEASER)
 	$(GORELEASER)
 
 $(LINTER_VERSION_FILE):


### PR DESCRIPTION
We don't have to do anything special in our `.goreleaser.yml` or our publish script to get arm64 builds— those will just automatically include whatever Goreleaser produces by default. We just have to update to a version that actually can produce them.