### PR TITLE
migrate to Go 1.18; use generic optional type & helpers

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -9,7 +9,7 @@ workflows:
 jobs:
   build-and-test:
     docker:
-      - image: cimg/go:1.17
+      - image: cimg/go:1.18
     steps:
       - checkout
       - run: make test

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -24,7 +24,9 @@ linters:
     - megacheck
     - misspell
     - nakedret
-    - nolintlint
+    #- nolintlint
+    # nolintlint is currently disabled because some linters don't yet work with Go 1.18, but we may have nolint
+    # directives that would be needed to suppress those linters if they did work.
     - prealloc
     - staticcheck
     - structcheck

--- a/.ldrelease/config.yml
+++ b/.ldrelease/config.yml
@@ -2,7 +2,7 @@ version: 2
 
 jobs:
   - docker:
-      image: cimg/go:1.17
+      image: cimg/go:1.18
       copyGitHistory: true  # required by goreleaser
     template:
       name: go

--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@ GORELEASER_VERSION=v1.7.0
 GORELEASER_DOWNLOAD_URL=https://github.com/goreleaser/goreleaser/releases/download/v1.7.0/goreleaser_$(shell uname)_$(shell uname -m).tar.gz
 GORELEASER=./bin/goreleaser/goreleaser
 
-GOLANGCI_LINT_VERSION=v1.44.0
+GOLANGCI_LINT_VERSION=v1.45.2
 
 LINTER=./bin/golangci-lint
 LINTER_VERSION_FILE=./bin/.golangci-lint-version-$(GOLANGCI_LINT_VERSION)
@@ -38,6 +38,7 @@ publish-release: $(GORELEASER)
 $(LINTER_VERSION_FILE):
 	rm -f $(LINTER)
 	curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b ./bin $(GOLANGCI_LINT_VERSION)
+	touch $(LINTER_VERSION_FILE)
 
 lint: $(LINTER_VERSION_FILE)
 	$(LINTER) run ./...

--- a/framework/harness/mock_endpoints.go
+++ b/framework/harness/mock_endpoints.go
@@ -13,6 +13,7 @@ import (
 	"time"
 
 	"github.com/launchdarkly/sdk-test-harness/framework"
+	"github.com/launchdarkly/sdk-test-harness/framework/helpers"
 )
 
 const endpointPathPrefix = "/endpoints/"
@@ -181,14 +182,25 @@ func (e *MockEndpoint) BaseURL() string {
 
 // AwaitConnection waits for an incoming request to the endpoint.
 func (e *MockEndpoint) AwaitConnection(timeout time.Duration) (IncomingRequestInfo, error) {
-	deadline := time.NewTimer(timeout)
-	defer deadline.Stop()
-	select {
-	case cxn := <-e.newConns:
-		return cxn, nil
-	case <-deadline.C:
-		return IncomingRequestInfo{}, fmt.Errorf("timed out waiting for an incoming request to %s", e.description)
+	maybeCxn := helpers.TryReceive(e.newConns, timeout)
+	if maybeCxn.IsDefined() {
+		return maybeCxn.Value(), nil
 	}
+	return IncomingRequestInfo{}, fmt.Errorf("timed out waiting for an incoming request to %s", e.description)
+}
+
+// RequireConnection waits for an incoming request to the endpoint, and causes the test to fail
+// and terminate if it timed out.
+func (e *MockEndpoint) RequireConnection(t helpers.TestContext, timeout time.Duration) IncomingRequestInfo {
+	return helpers.RequireValueWithMessage(t, e.newConns, timeout, "timed out waiting for request to %s (%s)",
+		e.description, e.basePath)
+}
+
+// RequireNoMoreConnections causes the test to fail and terminate if there is another incoming request
+// within the timeout.
+func (e *MockEndpoint) RequireNoMoreConnections(t helpers.TestContext, timeout time.Duration) {
+	helpers.RequireNoMoreValuesWithMessage(t, e.newConns, timeout,
+		"did not expect another request to %s (%s), but got one", e.description, e.basePath)
 }
 
 func (e *MockEndpoint) ActiveConnection() *IncomingRequestInfo {

--- a/framework/helpers/channels.go
+++ b/framework/helpers/channels.go
@@ -1,0 +1,77 @@
+package helpers
+
+import (
+	"time"
+
+	"github.com/launchdarkly/sdk-test-harness/framework/opt"
+)
+
+// NonBlockingSend is a shortcut for using select to do a non-blocking send. It returns
+// true on success or false if the channel was full.
+func NonBlockingSend[V any](ch chan<- V, value V) bool {
+	select {
+	case ch <- value:
+		return true
+	default:
+		return false
+	}
+}
+
+// TryReceive is a shortcut for using select to do a receive with timeout. It returns a
+// Maybe that has a value if one was available, or no value if it timed out.
+func TryReceive[V any](ch <-chan V, timeout time.Duration) opt.Maybe[V] {
+	deadline := time.NewTimer(timeout)
+	defer deadline.Stop()
+	select {
+	case value := <-ch:
+		return opt.Some(value)
+	case <-deadline.C:
+		return opt.None[V]()
+	}
+}
+
+// RequireValue tries to receive a value and returns it if successful, or causes the test
+// to fail and terminate immediately if it timed out.
+func RequireValue[V any](t TestContext, ch <-chan V, timeout time.Duration) V {
+	var empty V
+	return RequireValueWithMessage(t, ch, timeout, "timed out waiting for value of type %T", empty)
+}
+
+// RequireValueWithMessage is the same as RequireValue, but allows customization of the failure message.
+func RequireValueWithMessage[V any](
+	t TestContext,
+	ch <-chan V,
+	timeout time.Duration,
+	msgFormat string,
+	msgArgs ...interface{},
+) V {
+	maybeValue := TryReceive(ch, timeout)
+	if !maybeValue.IsDefined() {
+		t.Errorf(msgFormat, msgArgs...)
+		t.FailNow()
+	}
+	return maybeValue.Value()
+}
+
+// RequireNoMoreValues tries to receive a value within the given timeout, and causes the test
+// to fail and terminate immediately if a value was received.
+func RequireNoMoreValues[V any](t TestContext, ch <-chan V, timeout time.Duration) {
+	var empty V
+	RequireNoMoreValuesWithMessage(t, ch, timeout, "received unexpected extra value of type %T", empty)
+}
+
+// RequireNoMoreValuesWithMessage is the same as RequireNoMoreValues, but allows customization
+// of the failure message.
+func RequireNoMoreValuesWithMessage[V any](
+	t TestContext,
+	ch <-chan V,
+	timeout time.Duration,
+	msgFormat string,
+	msgArgs ...interface{},
+) {
+	maybeValue := TryReceive(ch, timeout)
+	if maybeValue.IsDefined() {
+		t.Errorf(msgFormat, msgArgs...)
+		t.FailNow()
+	}
+}

--- a/framework/helpers/channels_test.go
+++ b/framework/helpers/channels_test.go
@@ -1,0 +1,78 @@
+package helpers
+
+import (
+	"testing"
+	"time"
+
+	"github.com/launchdarkly/sdk-test-harness/framework/opt"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestNonBlockingSend(t *testing.T) {
+	ch1 := make(chan string)
+	assert.False(t, NonBlockingSend(ch1, "a"))
+
+	ch2 := make(chan string, 1)
+	assert.True(t, NonBlockingSend(ch2, "a"))
+	assert.Equal(t, "a", <-ch2)
+}
+
+func TestTryReceive(t *testing.T) {
+	ch := make(chan string, 1)
+	assert.Equal(t, opt.None[string](), TryReceive(ch, time.Millisecond))
+
+	ch <- "a"
+	assert.Equal(t, opt.Some("a"), TryReceive(ch, time.Millisecond))
+
+	go func() {
+		time.Sleep(time.Millisecond * 50)
+		ch <- "b"
+	}()
+	assert.Equal(t, opt.Some("b"), TryReceive(ch, time.Second))
+}
+
+func TestRequireValue(t *testing.T) {
+	tr1 := TestRecorder{PanicOnTerminate: true}
+	ch := make(chan string, 1)
+	assert.PanicsWithValue(t, &tr1, func() { _ = RequireValue(&tr1, ch, time.Millisecond) })
+	if assert.Error(t, tr1.Err()) {
+		assert.Contains(t, tr1.Err().Error(), "waiting for value of type string")
+	}
+
+	tr2 := TestRecorder{PanicOnTerminate: true}
+	ch <- "a"
+	assert.Equal(t, "a", RequireValue(&tr2, ch, time.Millisecond))
+	assert.NoError(t, tr2.Err())
+
+	tr3 := TestRecorder{PanicOnTerminate: true}
+	go func() {
+		time.Sleep(time.Millisecond * 50)
+		ch <- "b"
+	}()
+	assert.Equal(t, "b", RequireValue(&tr3, ch, time.Second))
+	assert.NoError(t, tr3.Err())
+}
+
+func TestRequireNoMoreValues(t *testing.T) {
+	tr1 := TestRecorder{PanicOnTerminate: true}
+	ch := make(chan string, 1)
+	RequireNoMoreValues(&tr1, ch, time.Millisecond)
+	assert.NoError(t, tr1.Err())
+
+	tr2 := TestRecorder{PanicOnTerminate: true}
+	ch <- "a"
+	assert.Panics(t, func() { RequireNoMoreValues(&tr2, ch, time.Millisecond) })
+	if assert.Error(t, tr2.Err()) {
+		assert.Contains(t, tr2.Err().Error(), "extra value of type string")
+	}
+
+	tr3 := TestRecorder{PanicOnTerminate: true}
+	go func() {
+		time.Sleep(time.Millisecond * 50)
+		ch <- "b"
+	}()
+	assert.Panics(t, func() { RequireNoMoreValues(&tr3, ch, time.Second) })
+	if assert.Error(t, tr3.Err()) {
+		assert.Contains(t, tr3.Err().Error(), "extra value of type string")
+	}
+}

--- a/framework/helpers/generics.go
+++ b/framework/helpers/generics.go
@@ -1,0 +1,19 @@
+package helpers
+
+// IfElse returns valueIfTrue or valueIfFalse depending on isTrue.
+func IfElse[V any](isTrue bool, valueIfTrue, valueIfFalse V) V {
+	if isTrue {
+		return valueIfTrue
+	}
+	return valueIfFalse
+}
+
+// SliceContains returns true if and only if the slice has an element that equals the value.
+func SliceContains[V comparable](value V, slice []V) bool {
+	for _, element := range slice {
+		if element == value {
+			return true
+		}
+	}
+	return false
+}

--- a/framework/helpers/generics_test.go
+++ b/framework/helpers/generics_test.go
@@ -1,0 +1,21 @@
+package helpers
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestIfElse(t *testing.T) {
+	assert.Equal(t, 3, IfElse(true, 3, 4))
+	assert.Equal(t, 4, IfElse(false, 3, 4))
+	assert.Equal(t, "a", IfElse(true, "a", "b"))
+	assert.Equal(t, "b", IfElse(false, "a", "b"))
+}
+
+func TestSliceContains(t *testing.T) {
+	assert.True(t, SliceContains(3, []int{1, 2, 3, 4}))
+	assert.False(t, SliceContains(5, []int{1, 2, 3, 4}))
+	assert.True(t, SliceContains("c", []string{"a", "b", "c", "d"}))
+	assert.False(t, SliceContains("e", []string{"a", "b", "c", "d"}))
+}

--- a/framework/helpers/test_abstraction.go
+++ b/framework/helpers/test_abstraction.go
@@ -1,8 +1,44 @@
 package helpers
 
+import (
+	"errors"
+	"fmt"
+	"strings"
+)
+
 // TestContext is a minimal interface for types like *testing.T and *ldtest.T representing a
 // test that can fail. Functions can use this to avoid specific dependencies on those packages.
 type TestContext interface {
 	Errorf(msgFormat string, msgArgs ...interface{})
 	FailNow()
+}
+
+// TestRecorder is a stub implementation of TestContext for testing test logic.
+type TestRecorder struct {
+	Errors           []string
+	Terminated       bool
+	PanicOnTerminate bool
+}
+
+// Errorf records an error message.
+func (t *TestRecorder) Errorf(format string, args ...interface{}) {
+	t.Errors = append(t.Errors, fmt.Sprintf(format, args...))
+}
+
+// FailNow simulates a condition where the test is supposed to immediately terminate. It sets
+// t.Terminated to true, and then does a panic(t) if and only if t.PanicOnTerminate is true.
+func (t *TestRecorder) FailNow() {
+	t.Terminated = true
+	if t.PanicOnTerminate {
+		panic(t)
+	}
+}
+
+// Err returns an error whose message is a concatenation of all error messages so far, or nil
+// if none.
+func (t *TestRecorder) Err() error {
+	if len(t.Errors) == 0 {
+		return nil
+	}
+	return errors.New(strings.Join(t.Errors, ", "))
 }

--- a/framework/helpers/test_abstraction.go
+++ b/framework/helpers/test_abstraction.go
@@ -1,0 +1,8 @@
+package helpers
+
+// TestContext is a minimal interface for types like *testing.T and *ldtest.T representing a
+// test that can fail. Functions can use this to avoid specific dependencies on those packages.
+type TestContext interface {
+	Errorf(msgFormat string, msgArgs ...interface{})
+	FailNow()
+}

--- a/framework/helpers/test_abstraction_test.go
+++ b/framework/helpers/test_abstraction_test.go
@@ -1,0 +1,32 @@
+package helpers
+
+import (
+	"errors"
+	"fmt"
+	"strings"
+)
+
+// TestRecorder is a stub implementation of TestContext for testing test logic.
+type TestRecorder struct {
+	Errors           []string
+	Terminated       bool
+	PanicOnTerminate bool
+}
+
+func (t *TestRecorder) Errorf(format string, args ...interface{}) {
+	t.Errors = append(t.Errors, fmt.Sprintf(format, args...))
+}
+
+func (t *TestRecorder) FailNow() {
+	t.Terminated = true
+	if t.PanicOnTerminate {
+		panic(t)
+	}
+}
+
+func (t *TestRecorder) Err() error {
+	if len(t.Errors) == 0 {
+		return nil
+	}
+	return errors.New(strings.Join(t.Errors, ", "))
+}

--- a/framework/ldtest/junit_test_logger.go
+++ b/framework/ldtest/junit_test_logger.go
@@ -10,8 +10,7 @@ import (
 
 	"github.com/launchdarkly/sdk-test-harness/framework"
 	"github.com/launchdarkly/sdk-test-harness/framework/harness"
-
-	"gopkg.in/launchdarkly/go-sdk-common.v2/ldvalue"
+	o "github.com/launchdarkly/sdk-test-harness/framework/opt"
 )
 
 type JUnitTestLogger struct {
@@ -25,7 +24,7 @@ type JUnitTestLogger struct {
 
 type jUnitTestStatus struct {
 	failures    []error
-	skipped     ldvalue.OptionalString
+	skipped     o.Maybe[string]
 	nonCritical bool
 	output      string
 	startTime   time.Time
@@ -117,7 +116,7 @@ func (j *JUnitTestLogger) TestSkipped(id TestID, reason string) {
 	j.lock.Lock()
 	defer j.lock.Unlock()
 	status := j.tests[id.String()]
-	status.skipped = ldvalue.NewOptionalString(reason)
+	status.skipped = o.Some(reason)
 	j.tests[id.String()] = status
 }
 
@@ -167,7 +166,7 @@ func (j *JUnitTestLogger) EndLog(results Results) error {
 				testCase.Name += " (non-critical)"
 			}
 			if status.skipped.IsDefined() {
-				testCase.SkipMessage = &jUnitXMLSkipMessage{Message: status.skipped.String()}
+				testCase.SkipMessage = &jUnitXMLSkipMessage{Message: status.skipped.Value()}
 			}
 			if len(status.failures) != 0 {
 				var messages []string

--- a/framework/opt/maybe.go
+++ b/framework/opt/maybe.go
@@ -1,0 +1,78 @@
+package opt
+
+import (
+	"encoding/json"
+)
+
+// Maybe is a simple implementation of an optional value type.
+type Maybe[V any] struct {
+	defined bool
+	value   V
+}
+
+// Some returns a Maybe that has a defined value.
+func Some[V any](value V) Maybe[V] {
+	return Maybe[V]{defined: true, value: value}
+}
+
+// None returns a Maybe with no value.
+func None[V any]() Maybe[V] { return Maybe[V]{} }
+
+// FromPtr returns a Maybe that has a defined value of *ptr if ptr is non-nil, or
+// no value if ptr is nil.
+func FromPtr[V any](ptr *V) Maybe[V] {
+	if ptr != nil {
+		return Some[V](*ptr)
+	}
+	return None[V]()
+}
+
+// IsDefined returns true if the Maybe has a value.
+func (m Maybe[V]) IsDefined() bool { return m.defined }
+
+// Value returns the value if a value is defined, or the zero value for the type otherwise.
+func (m Maybe[V]) Value() V { return m.value }
+
+// AsPtr returns a pointer to the value if the value is defined, or nil otherwise.
+func (m Maybe[V]) AsPtr() *V {
+	if m.defined {
+		return &m.value
+	}
+	return nil
+}
+
+// OrElse returns the value of the Maybe if any, or the valueIfUndefined otherwise.
+func (m Maybe[V]) OrElse(valueIfUndefined V) V {
+	if m.defined {
+		return m.value
+	}
+	return valueIfUndefined
+}
+
+// MarshalJSON produces whatever JSON representation would normally be produced for the value if
+// a value is defined, or a JSON null otherwise.
+func (m Maybe[V]) MarshalJSON() ([]byte, error) {
+	if m.defined {
+		return json.Marshal(m.value)
+	}
+	return []byte("null"), nil
+}
+
+// UnmarshalJSON sets the Maybe to None[V] if the data is a JSON null, or else unmarshals a value
+// of type V as usual and sets the Maybe to Some(value).
+func (m *Maybe[V]) UnmarshalJSON(data []byte) error {
+	var temp interface{}
+	if err := json.Unmarshal(data, &temp); err != nil {
+		return err
+	}
+	if temp == nil {
+		*m = None[V]()
+		return nil
+	}
+	var value V
+	if err := json.Unmarshal(data, &value); err != nil {
+		return err
+	}
+	*m = Some(value)
+	return nil
+}

--- a/framework/opt/maybe_test.go
+++ b/framework/opt/maybe_test.go
@@ -1,0 +1,69 @@
+package opt
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+type MyStruct struct {
+	Prop string `json:"prop"`
+}
+
+func TestNone(t *testing.T) {
+	assert.False(t, None[string]().IsDefined())
+
+	assert.Equal(t, 0, None[int]().Value())
+	assert.Equal(t, "", None[string]().Value())
+	assert.Nil(t, None[*string]().Value())
+	assert.Equal(t, MyStruct{}, None[MyStruct]().Value())
+}
+
+func TestSome(t *testing.T) {
+	assert.True(t, Some("").IsDefined())
+
+	assert.Equal(t, 1, Some(1).Value())
+	assert.Equal(t, "x", Some("x").Value())
+
+}
+
+func TestOrElse(t *testing.T) {
+	assert.Equal(t, 3, None[int]().OrElse(3))
+	assert.Equal(t, 4, Some(4).OrElse(3))
+}
+
+func TestFromPtr(t *testing.T) {
+	assert.Equal(t, None[string](), FromPtr((*string)(nil)))
+
+	s := "x"
+	assert.Equal(t, Some(s), FromPtr(&s))
+}
+
+func TestAsPtr(t *testing.T) {
+	assert.Nil(t, None[int]().AsPtr())
+
+	s := "x"
+	assert.Equal(t, &s, Some(s).AsPtr())
+}
+
+func TestMarshalUnmarshal(t *testing.T) {
+	testMarshalUnmarshal(t, None[int](), "null")
+	testMarshalUnmarshal(t, Some(3), "3")
+	testMarshalUnmarshal(t, Some(MyStruct{Prop: "x"}), `{"prop": "x"}`)
+
+	var ms Maybe[MyStruct]
+	assert.Error(t, ms.UnmarshalJSON([]byte(`malformed json`)))
+	assert.Error(t, ms.UnmarshalJSON([]byte(`{"prop": true}`)))
+}
+
+func testMarshalUnmarshal[V any](t *testing.T, expected Maybe[V], expectedJSON string) {
+	data, err := json.Marshal(expected)
+	require.NoError(t, err)
+	assert.JSONEq(t, expectedJSON, string(data))
+
+	var actual Maybe[V]
+	require.NoError(t, json.Unmarshal([]byte(expectedJSON), &actual))
+	assert.Equal(t, expected, actual)
+}

--- a/framework/opt/package_info.go
+++ b/framework/opt/package_info.go
@@ -1,0 +1,2 @@
+// Package opt provides the generic Maybe type for representing optional values without pointers.
+package opt

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/launchdarkly/sdk-test-harness
 
-go 1.17
+go 1.18
 
 require (
 	github.com/fatih/color v1.13.0

--- a/mockld/events_service.go
+++ b/mockld/events_service.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	"github.com/launchdarkly/sdk-test-harness/framework"
+	"github.com/launchdarkly/sdk-test-harness/framework/helpers"
 )
 
 // Somewhat arbitrary buffer size for the channel that we use as a queue for received events. We
@@ -53,12 +54,8 @@ func (s *EventsService) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 }
 
 func (s *EventsService) AwaitAnalyticsEventPayload(timeout time.Duration) (Events, bool) {
-	select {
-	case ep := <-s.AnalyticsEventPayloads:
-		return ep, true
-	case <-time.After(timeout):
-		return nil, false
-	}
+	ep := helpers.TryReceive(s.AnalyticsEventPayloads, timeout)
+	return ep.Value(), ep.IsDefined()
 }
 
 func (s *EventsService) SetHostTimeOverride(t time.Time) {

--- a/mockld/streaming_service_test.go
+++ b/mockld/streaming_service_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/launchdarkly/eventsource"
 	"github.com/launchdarkly/go-test-helpers/v2/httphelpers"
 	m "github.com/launchdarkly/go-test-helpers/v2/matchers"
+	"github.com/launchdarkly/sdk-test-harness/framework/helpers"
 	"gopkg.in/launchdarkly/go-sdk-common.v2/ldlog"
 	"gopkg.in/launchdarkly/go-sdk-common.v2/ldlogtest"
 	"gopkg.in/launchdarkly/go-sdk-common.v2/ldvalue"
@@ -55,13 +56,7 @@ func TestStreamingServiceServerSide(t *testing.T) {
 }
 
 func requireEvent(t *testing.T, stream *eventsource.Stream) eventsource.Event {
-	select {
-	case e := <-stream.Events:
-		return e
-	case <-time.After(time.Second * 5):
-		require.Fail(t, "timed out waiting for event")
-		return nil
-	}
+	return helpers.RequireValueWithMessage(t, stream.Events, time.Second*5, "timed out waiting for event")
 }
 
 func expectedPutData(sdkData SDKData) string {

--- a/sdktests/custom_matchers_general.go
+++ b/sdktests/custom_matchers_general.go
@@ -5,6 +5,8 @@ import (
 	"sort"
 	"strings"
 
+	h "github.com/launchdarkly/sdk-test-harness/framework/helpers"
+	o "github.com/launchdarkly/sdk-test-harness/framework/opt"
 	"github.com/launchdarkly/sdk-test-harness/servicedef"
 
 	"github.com/launchdarkly/go-test-helpers/v2/jsonhelpers"
@@ -31,7 +33,7 @@ func EvalResponseVariation() m.MatcherTransform {
 		"result variation index",
 		func(value interface{}) (interface{}, error) {
 			r := value.(servicedef.EvaluateFlagResponse)
-			return ldvalue.NewOptionalIntFromPointer(r.VariationIndex), nil
+			return r.VariationIndex, nil
 		}).
 		EnsureInputValueType(servicedef.EvaluateFlagResponse{})
 }
@@ -41,10 +43,10 @@ func EvalResponseReason() m.MatcherTransform {
 		"result reason",
 		func(value interface{}) (interface{}, error) {
 			r := value.(servicedef.EvaluateFlagResponse)
-			if r.Reason == nil {
-				return nil, nil
+			if r.Reason.IsDefined() {
+				return o.Some(r.Reason), nil
 			}
-			return *r.Reason, nil
+			return o.None[ldreason.EvaluationReason](), nil
 		}).
 		EnsureInputValueType(servicedef.EvaluateFlagResponse{})
 }
@@ -76,7 +78,7 @@ func JSONPropertyKeysCanOnlyBe(keys ...string) m.Matcher {
 	return m.New(
 		func(value interface{}) bool {
 			for _, key := range jsonKeys(value) {
-				if !stringInSlice(key, keys) {
+				if !h.SliceContains(key, keys) {
 					return false
 				}
 			}
@@ -88,7 +90,7 @@ func JSONPropertyKeysCanOnlyBe(keys ...string) m.Matcher {
 		func(value interface{}) string {
 			var badKeys []string
 			for _, key := range jsonKeys(value) {
-				if !stringInSlice(key, keys) {
+				if !h.SliceContains(key, keys) {
 					badKeys = append(badKeys, key)
 				}
 			}

--- a/sdktests/helpers.go
+++ b/sdktests/helpers.go
@@ -51,19 +51,19 @@ func basicEvaluateFlag(
 func computeExpectedBucketValue(
 	userValue string,
 	flagOrSegmentKey, salt string,
-	secondary ldvalue.OptionalString,
-	seed ldvalue.OptionalInt,
+	secondary o.Maybe[string],
+	seed o.Maybe[int],
 ) int {
 	hashInput := ""
 
 	if seed.IsDefined() {
-		hashInput += strconv.Itoa(seed.IntValue())
+		hashInput += strconv.Itoa(seed.Value())
 	} else {
 		hashInput += flagOrSegmentKey + "." + salt
 	}
 	hashInput += "." + userValue
 	if secondary.IsDefined() {
-		hashInput += "." + secondary.StringValue()
+		hashInput += "." + secondary.Value()
 	}
 
 	hashOutputBytes := sha1.Sum([]byte(hashInput)) //nolint:gosec // this isn't for authentication
@@ -195,6 +195,20 @@ func checkForUpdatedValue(
 		}
 		return false
 	}
+}
+
+func optionalIntFrom(m o.Maybe[int]) ldvalue.OptionalInt {
+	if m.IsDefined() {
+		return ldvalue.NewOptionalInt(m.Value())
+	}
+	return ldvalue.OptionalInt{}
+}
+
+func optionalIntToMaybe(oi ldvalue.OptionalInt) o.Maybe[int] {
+	if oi.IsDefined() {
+		return o.Some(oi.IntValue())
+	}
+	return o.None[int]()
 }
 
 func pollUntilFlagValueUpdated(

--- a/sdktests/helpers.go
+++ b/sdktests/helpers.go
@@ -11,13 +11,11 @@ import (
 	"strings"
 	"time"
 
-	m "github.com/launchdarkly/go-test-helpers/v2/matchers"
-	"github.com/launchdarkly/sdk-test-harness/framework/harness"
 	"github.com/launchdarkly/sdk-test-harness/framework/ldtest"
+	o "github.com/launchdarkly/sdk-test-harness/framework/opt"
 	"github.com/launchdarkly/sdk-test-harness/mockld"
 	"github.com/launchdarkly/sdk-test-harness/servicedef"
 
-	"gopkg.in/launchdarkly/go-sdk-common.v2/ldtime"
 	"gopkg.in/launchdarkly/go-sdk-common.v2/lduser"
 	"gopkg.in/launchdarkly/go-sdk-common.v2/ldvalue"
 	"gopkg.in/launchdarkly/go-server-sdk-evaluation.v1/ldbuilders"
@@ -39,7 +37,7 @@ func basicEvaluateFlag(
 ) ldvalue.Value {
 	result := client.EvaluateFlag(t, servicedef.EvaluateFlagParams{
 		FlagKey:      flagKey,
-		User:         user,
+		User:         o.Some(user),
 		ValueType:    servicedef.ValueTypeAny,
 		DefaultValue: defaultValue,
 	})
@@ -80,13 +78,6 @@ func computeExpectedBucketValue(
 	return int(result.Int64())
 }
 
-func conditionalMatcher(isTrue bool, matcherIfTrue, matcherIfFalse m.Matcher) m.Matcher {
-	if isTrue {
-		return matcherIfTrue
-	}
-	return matcherIfFalse
-}
-
 func evaluateFlagDetail(
 	t *ldtest.T,
 	client *SDKClient,
@@ -96,22 +87,11 @@ func evaluateFlagDetail(
 ) servicedef.EvaluateFlagResponse {
 	return client.EvaluateFlag(t, servicedef.EvaluateFlagParams{
 		FlagKey:      flagKey,
-		User:         user,
+		User:         o.Some(user),
 		ValueType:    servicedef.ValueTypeAny,
 		DefaultValue: defaultValue,
 		Detail:       true,
 	})
-}
-
-func expectNoMoreRequests(t *ldtest.T, endpoint *harness.MockEndpoint) {
-	_, err := endpoint.AwaitConnection(time.Millisecond * 100)
-	require.Error(t, err, "did not expect another request, but got one")
-}
-
-func expectRequest(t *ldtest.T, endpoint *harness.MockEndpoint, timeout time.Duration) harness.IncomingRequestInfo {
-	request, err := endpoint.AwaitConnection(timeout)
-	require.NoError(t, err, "timed out waiting for request")
-	return request
 }
 
 func getValueTypesToTest(t *ldtest.T) []servicedef.ValueType {
@@ -234,30 +214,10 @@ func pollUntilFlagValueUpdated(
 		time.Second, time.Millisecond*50, "timed out without seeing updated flag value")
 }
 
-func selectString(boolValue bool, valueIfTrue, valueIfFalse string) string {
-	if boolValue {
-		return valueIfTrue
-	}
-	return valueIfFalse
-}
-
 func sortedStrings(ss []string) []string {
 	ret := append([]string(nil), ss...)
 	sort.Strings(ret)
 	return ret
-}
-
-func stringInSlice(value string, slice []string) bool {
-	for _, s := range slice {
-		if s == value {
-			return true
-		}
-	}
-	return false
-}
-
-func timeValueAsPointer(value ldtime.UnixMillisecondTime) *ldtime.UnixMillisecondTime {
-	return &value
 }
 
 func testDescFromType(valueType servicedef.ValueType) string {

--- a/sdktests/helpers.go
+++ b/sdktests/helpers.go
@@ -204,13 +204,6 @@ func optionalIntFrom(m o.Maybe[int]) ldvalue.OptionalInt {
 	return ldvalue.OptionalInt{}
 }
 
-func optionalIntToMaybe(oi ldvalue.OptionalInt) o.Maybe[int] {
-	if oi.IsDefined() {
-		return o.Some(oi.IntValue())
-	}
-	return o.None[int]()
-}
-
 func pollUntilFlagValueUpdated(
 	t *ldtest.T,
 	client *SDKClient,

--- a/sdktests/helpers_test.go
+++ b/sdktests/helpers_test.go
@@ -4,6 +4,8 @@ import (
 	"fmt"
 	"testing"
 
+	h "github.com/launchdarkly/sdk-test-harness/framework/helpers"
+
 	"gopkg.in/launchdarkly/go-sdk-common.v2/ldvalue"
 
 	"github.com/stretchr/testify/assert"
@@ -41,7 +43,7 @@ func TestComputeExpectedBucketValue(t *testing.T) {
 					ldvalue.NewOptionalString(secondary),
 					p.seed,
 				)
-				failureDesc := selectString(secondary == "", "empty secondary key", "empty-but-not-undefined secondary key") +
+				failureDesc := h.IfElse(secondary == "", "empty secondary key", "empty-but-not-undefined secondary key") +
 					" should have changed result, but did not"
 				assert.NotEqual(t, p.expectedValue, valueWithSecondaryKey, failureDesc)
 			}

--- a/sdktests/helpers_test.go
+++ b/sdktests/helpers_test.go
@@ -5,8 +5,7 @@ import (
 	"testing"
 
 	h "github.com/launchdarkly/sdk-test-harness/framework/helpers"
-
-	"gopkg.in/launchdarkly/go-sdk-common.v2/ldvalue"
+	o "github.com/launchdarkly/sdk-test-harness/framework/opt"
 
 	"github.com/stretchr/testify/assert"
 )
@@ -17,20 +16,20 @@ func TestComputeExpectedBucketValue(t *testing.T) {
 	// used in unit tests for some of the SDKs.
 	for _, p := range []struct {
 		flagOrSegmentKey, salt, userValue string
-		seed                              ldvalue.OptionalInt
+		seed                              o.Maybe[int]
 		expectedValue                     int
 	}{
-		{"hashKey", "saltyA", "userKeyA", ldvalue.OptionalInt{}, 42157},
-		{"hashKey", "saltyA", "userKeyB", ldvalue.OptionalInt{}, 67084},
-		{"hashKey", "saltyA", "userKeyC", ldvalue.OptionalInt{}, 10343},
-		{"hashKey", "saltyA", "userKeyA", ldvalue.NewOptionalInt(61), 9801},
+		{"hashKey", "saltyA", "userKeyA", o.None[int](), 42157},
+		{"hashKey", "saltyA", "userKeyB", o.None[int](), 67084},
+		{"hashKey", "saltyA", "userKeyC", o.None[int](), 10343},
+		{"hashKey", "saltyA", "userKeyA", o.Some(61), 9801},
 	} {
 		t.Run(fmt.Sprintf("%+v", p), func(t *testing.T) {
 			computedValue := computeExpectedBucketValue(
 				p.userValue,
 				p.flagOrSegmentKey,
 				p.salt,
-				ldvalue.OptionalString{},
+				o.None[string](),
 				p.seed,
 			)
 			assert.Equal(t, p.expectedValue, computedValue, "computed value did not match expected value")
@@ -40,7 +39,7 @@ func TestComputeExpectedBucketValue(t *testing.T) {
 					p.userValue,
 					p.flagOrSegmentKey,
 					p.salt,
-					ldvalue.NewOptionalString(secondary),
+					o.Some(secondary),
 					p.seed,
 				)
 				failureDesc := h.IfElse(secondary == "", "empty secondary key", "empty-but-not-undefined secondary key") +

--- a/sdktests/server_side_big_segments.go
+++ b/sdktests/server_side_big_segments.go
@@ -6,6 +6,7 @@ import (
 	"time"
 
 	"github.com/launchdarkly/sdk-test-harness/framework/ldtest"
+	o "github.com/launchdarkly/sdk-test-harness/framework/opt"
 	"github.com/launchdarkly/sdk-test-harness/mockld"
 	"github.com/launchdarkly/sdk-test-harness/servicedef"
 
@@ -244,9 +245,9 @@ func doBigSegmentsMembershipCachingTests(t *ldtest.T) {
 	t.Run("user cache expiration (cache time)", func(t *ldtest.T) {
 		bigSegmentStore := NewBigSegmentStore(t, ldreason.BigSegmentsHealthy)
 		client := NewSDKClient(t, WithConfig(servicedef.SDKConfigParams{
-			BigSegments: &servicedef.SDKConfigBigSegmentsParams{
-				UserCacheTimeMS: 10,
-			},
+			BigSegments: o.Some(servicedef.SDKConfigBigSegmentsParams{
+				UserCacheTimeMS: o.Some(ldtime.UnixMillisecondTime(10)),
+			}),
 		}), dataSource, bigSegmentStore)
 
 		bigSegmentStore.SetupMemberships(t, map[string]map[string]bool{
@@ -278,9 +279,9 @@ func doBigSegmentsMembershipCachingTests(t *ldtest.T) {
 	t.Run("user cache eviction (cache size)", func(t *ldtest.T) {
 		bigSegmentStore := NewBigSegmentStore(t, ldreason.BigSegmentsHealthy)
 		client := NewSDKClient(t, WithConfig(servicedef.SDKConfigParams{
-			BigSegments: &servicedef.SDKConfigBigSegmentsParams{
-				UserCacheSize: ldvalue.NewOptionalInt(2),
-			},
+			BigSegments: o.Some(servicedef.SDKConfigBigSegmentsParams{
+				UserCacheSize: o.Some(2),
+			}),
 		}), dataSource, bigSegmentStore)
 
 		bigSegmentStore.SetupMemberships(t, map[string]map[string]bool{
@@ -323,9 +324,9 @@ func doBigSegmentsStatusPollingTests(t *ldtest.T) {
 		bigSegmentStore := NewBigSegmentStore(t, ldreason.BigSegmentsHealthy)
 
 		_ = NewSDKClient(t, WithConfig(servicedef.SDKConfigParams{
-			BigSegments: &servicedef.SDKConfigBigSegmentsParams{
-				StatusPollIntervalMS: ldtime.UnixMillisecondTime(10),
-			},
+			BigSegments: o.Some(servicedef.SDKConfigBigSegmentsParams{
+				StatusPollIntervalMS: o.Some(ldtime.UnixMillisecondTime(10)),
+			}),
 		}), dataSource, bigSegmentStore)
 
 		for i := 0; i < 3; i++ {
@@ -340,9 +341,9 @@ func doBigSegmentsStatusPollingTests(t *ldtest.T) {
 		bigSegmentStore := NewBigSegmentStore(t, ldreason.BigSegmentsHealthy)
 
 		client := NewSDKClient(t, WithConfig(servicedef.SDKConfigParams{
-			BigSegments: &servicedef.SDKConfigBigSegmentsParams{
-				StatusPollIntervalMS: ldtime.UnixMillisecondTime(10000),
-			},
+			BigSegments: o.Some(servicedef.SDKConfigBigSegmentsParams{
+				StatusPollIntervalMS: o.Some(ldtime.UnixMillisecondTime(10000)),
+			}),
 		}), dataSource, bigSegmentStore)
 
 		initialStatus := client.GetBigSegmentStoreStatus(t)
@@ -357,9 +358,9 @@ func doBigSegmentsStatusPollingTests(t *ldtest.T) {
 			bigSegmentStore := NewBigSegmentStore(t, oldStatus)
 
 			client := NewSDKClient(t, WithConfig(servicedef.SDKConfigParams{
-				BigSegments: &servicedef.SDKConfigBigSegmentsParams{
-					StatusPollIntervalMS: ldtime.UnixMillisecondTime(10),
-				},
+				BigSegments: o.Some(servicedef.SDKConfigBigSegmentsParams{
+					StatusPollIntervalMS: o.Some(ldtime.UnixMillisecondTime(10)),
+				}),
 			}), dataSource, bigSegmentStore)
 
 			initialStatus := client.GetBigSegmentStoreStatus(t)
@@ -403,9 +404,9 @@ func doBigSegmentsStatusPollingTests(t *ldtest.T) {
 		bigSegmentStore := NewBigSegmentStore(t, ldreason.BigSegmentsHealthy)
 
 		client := NewSDKClient(t, WithConfig(servicedef.SDKConfigParams{
-			BigSegments: &servicedef.SDKConfigBigSegmentsParams{
-				StatusPollIntervalMS: ldtime.UnixMillisecondTime(10000),
-			},
+			BigSegments: o.Some(servicedef.SDKConfigBigSegmentsParams{
+				StatusPollIntervalMS: o.Some(ldtime.UnixMillisecondTime(10000)),
+			}),
 		}), dataSource, bigSegmentStore)
 
 		initialStatus := client.GetBigSegmentStoreStatus(t)

--- a/sdktests/server_side_data_store_updates.go
+++ b/sdktests/server_side_data_store_updates.go
@@ -7,6 +7,7 @@ import (
 	"github.com/launchdarkly/go-test-helpers/v2/jsonhelpers"
 	m "github.com/launchdarkly/go-test-helpers/v2/matchers"
 	"github.com/launchdarkly/sdk-test-harness/framework/ldtest"
+	o "github.com/launchdarkly/sdk-test-harness/framework/opt"
 	"github.com/launchdarkly/sdk-test-harness/mockld"
 	"github.com/launchdarkly/sdk-test-harness/servicedef"
 
@@ -96,7 +97,7 @@ func doServerSideDataStoreStreamUpdateTests(t *ldtest.T) {
 					)
 				}
 
-				allFlags := client.EvaluateAllFlags(t, servicedef.EvaluateAllFlagsParams{User: &user})
+				allFlags := client.EvaluateAllFlags(t, servicedef.EvaluateAllFlagsParams{User: o.Some(user)})
 				if shouldApply {
 					if isDelete {
 						assert.NotContains(t, allFlags.State, flagKey)

--- a/sdktests/server_side_eval.go
+++ b/sdktests/server_side_eval.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 
 	"github.com/launchdarkly/sdk-test-harness/framework/ldtest"
+	o "github.com/launchdarkly/sdk-test-harness/framework/opt"
 	"github.com/launchdarkly/sdk-test-harness/mockld"
 	"github.com/launchdarkly/sdk-test-harness/servicedef"
 	"github.com/launchdarkly/sdk-test-harness/testdata"
@@ -11,6 +12,7 @@ import (
 
 	m "github.com/launchdarkly/go-test-helpers/v2/matchers"
 	"gopkg.in/launchdarkly/go-sdk-common.v2/ldreason"
+	"gopkg.in/launchdarkly/go-sdk-common.v2/ldtime"
 	"gopkg.in/launchdarkly/go-sdk-common.v2/lduser"
 	"gopkg.in/launchdarkly/go-sdk-common.v2/ldvalue"
 
@@ -60,7 +62,7 @@ func RunParameterizedServerSideEvalTests(t *ldtest.T) {
 					if !suite.SkipEvaluateAllFlags {
 						t.Run("evaluate all flags", func(t *ldtest.T) {
 							result := client.EvaluateAllFlags(t, servicedef.EvaluateAllFlagsParams{
-								User: &test.User,
+								User: o.Some(test.User),
 							})
 							if test.Expect.VariationIndex.IsDefined() {
 								require.Contains(t, result.State, test.FlagKey)
@@ -86,7 +88,8 @@ func RunParameterizedServerSideClientNotReadyEvalTests(t *ldtest.T) {
 
 	dataSource := NewSDKDataSource(t, mockld.BlockingUnavailableSDKData(mockld.ServerSideSDK))
 	client := NewSDKClient(t,
-		WithConfig(servicedef.SDKConfigParams{StartWaitTimeMS: 1, InitCanFail: true}),
+		WithConfig(servicedef.SDKConfigParams{StartWaitTimeMS: o.Some(ldtime.UnixMillisecondTime(1)),
+			InitCanFail: true}),
 		dataSource)
 
 	for _, valueType := range getValueTypesToTest(t) {
@@ -96,7 +99,7 @@ func RunParameterizedServerSideClientNotReadyEvalTests(t *ldtest.T) {
 			t.Run("evaluate flag without detail", func(t *ldtest.T) {
 				result := client.EvaluateFlag(t, servicedef.EvaluateFlagParams{
 					FlagKey:      flagKey,
-					User:         user,
+					User:         o.Some(user),
 					ValueType:    valueType,
 					DefaultValue: defaultValue,
 				})
@@ -106,7 +109,7 @@ func RunParameterizedServerSideClientNotReadyEvalTests(t *ldtest.T) {
 			t.Run("evaluate flag with detail", func(t *ldtest.T) {
 				result := client.EvaluateFlag(t, servicedef.EvaluateFlagParams{
 					FlagKey:      flagKey,
-					User:         user,
+					User:         o.Some(user),
 					ValueType:    valueType,
 					DefaultValue: defaultValue,
 					Detail:       true,
@@ -144,7 +147,7 @@ func parseServerSideEvalTestSuite(t *ldtest.T, source testdata.SourceInfo) testm
 func makeEvalFlagParams(test testmodel.EvalTest, sdkData mockld.ServerSDKData) servicedef.EvaluateFlagParams {
 	p := servicedef.EvaluateFlagParams{
 		FlagKey:      test.FlagKey,
-		User:         test.User,
+		User:         o.Some(test.User),
 		ValueType:    test.ValueType,
 		DefaultValue: test.Default,
 	}

--- a/sdktests/server_side_eval.go
+++ b/sdktests/server_side_eval.go
@@ -54,7 +54,7 @@ func RunParameterizedServerSideEvalTests(t *ldtest.T) {
 						result := client.EvaluateFlag(t, params)
 						m.In(t).Assert(result, m.AllOf(
 							EvalResponseValue().Should(m.Equal(test.Expect.Value)),
-							EvalResponseVariation().Should(m.Equal(test.Expect.VariationIndex)),
+							EvalResponseVariation().Should(m.Equal(optionalIntToMaybe(test.Expect.VariationIndex))),
 							EvalResponseReason().Should(EqualReason(test.Expect.Reason)),
 						))
 					})
@@ -116,7 +116,7 @@ func RunParameterizedServerSideClientNotReadyEvalTests(t *ldtest.T) {
 				})
 				m.In(t).Assert(result, m.AllOf(
 					EvalResponseValue().Should(m.Equal(defaultValue)),
-					EvalResponseVariation().Should(m.Equal(ldvalue.OptionalInt{})),
+					EvalResponseVariation().Should(m.Equal(o.None[int]())),
 					EvalResponseReason().Should(EqualReason(expectedReason)),
 				))
 			})

--- a/sdktests/server_side_eval.go
+++ b/sdktests/server_side_eval.go
@@ -54,7 +54,7 @@ func RunParameterizedServerSideEvalTests(t *ldtest.T) {
 						result := client.EvaluateFlag(t, params)
 						m.In(t).Assert(result, m.AllOf(
 							EvalResponseValue().Should(m.Equal(test.Expect.Value)),
-							EvalResponseVariation().Should(m.Equal(optionalIntToMaybe(test.Expect.VariationIndex))),
+							EvalResponseVariation().Should(m.Equal(test.Expect.VariationIndex)),
 							EvalResponseReason().Should(EqualReason(test.Expect.Reason)),
 						))
 					})

--- a/sdktests/server_side_eval_all_flags.go
+++ b/sdktests/server_side_eval_all_flags.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 
 	"github.com/launchdarkly/sdk-test-harness/framework/ldtest"
+	o "github.com/launchdarkly/sdk-test-harness/framework/opt"
 	"github.com/launchdarkly/sdk-test-harness/mockld"
 	"github.com/launchdarkly/sdk-test-harness/servicedef"
 
@@ -69,7 +70,7 @@ func doServerSideAllFlagsBasicTest(t *ldtest.T) {
 	user := lduser.NewUser("user-key")
 
 	result := client.EvaluateAllFlags(t, servicedef.EvaluateAllFlagsParams{
-		User: &user,
+		User: o.Some(user),
 	})
 	resultJSON, _ := json.Marshal(canonicalizeAllFlagsData(result.State))
 	expectedJSON := `{
@@ -119,7 +120,7 @@ func doServerSideAllFlagsWithReasonsTest(t *ldtest.T) {
 	user := lduser.NewUser("user-key")
 
 	result := client.EvaluateAllFlags(t, servicedef.EvaluateAllFlagsParams{
-		User:        &user,
+		User:        o.Some(user),
 		WithReasons: true,
 	})
 	resultJSON, _ := json.Marshal(canonicalizeAllFlagsData(result.State))
@@ -162,7 +163,7 @@ func doServerSideAllFlagsExperimentationTest(t *ldtest.T) {
 	user := lduser.NewUser("user-key")
 
 	result := client.EvaluateAllFlags(t, servicedef.EvaluateAllFlagsParams{
-		User: &user,
+		User: o.Some(user),
 	})
 	resultJSON, _ := json.Marshal(canonicalizeAllFlagsData(result.State))
 	expectedJSON := `{
@@ -209,7 +210,7 @@ func doServerSideAllFlagsErrorInFlagTest(t *ldtest.T) {
 
 	t.Run("without reasons", func(t *ldtest.T) {
 		result := client.EvaluateAllFlags(t, servicedef.EvaluateAllFlagsParams{
-			User: &user,
+			User: o.Some(user),
 		})
 
 		resultJSON, _ := json.Marshal(canonicalizeAllFlagsData(result.State))
@@ -231,7 +232,7 @@ func doServerSideAllFlagsErrorInFlagTest(t *ldtest.T) {
 
 	t.Run("with reasons", func(t *ldtest.T) {
 		result := client.EvaluateAllFlags(t, servicedef.EvaluateAllFlagsParams{
-			User:        &user,
+			User:        o.Some(user),
 			WithReasons: true,
 		})
 
@@ -272,7 +273,7 @@ func doServerSideAllFlagsClientSideOnlyTest(t *ldtest.T) {
 	user := lduser.NewUser("user-key")
 
 	result := client.EvaluateAllFlags(t, servicedef.EvaluateAllFlagsParams{
-		User:           &user,
+		User:           o.Some(user),
 		ClientSideOnly: true,
 	})
 	assert.Contains(t, result.State, flag3.Key)
@@ -319,7 +320,7 @@ func doServerSideAllFlagsDetailsOnlyForTrackedFlagsTest(t *ldtest.T) {
 	user := lduser.NewUser("user-key")
 
 	result := client.EvaluateAllFlags(t, servicedef.EvaluateAllFlagsParams{
-		User:                       &user,
+		User:                       o.Some(user),
 		WithReasons:                true,
 		DetailsOnlyForTrackedFlags: true,
 	})
@@ -348,12 +349,13 @@ func doServerSideAllFlagsDetailsOnlyForTrackedFlagsTest(t *ldtest.T) {
 func doServerSideAllFlagsClientNotReadyTest(t *ldtest.T) {
 	dataSource := NewSDKDataSource(t, mockld.BlockingUnavailableSDKData(mockld.ServerSideSDK))
 	client := NewSDKClient(t,
-		WithConfig(servicedef.SDKConfigParams{StartWaitTimeMS: 1, InitCanFail: true}),
+		WithConfig(servicedef.SDKConfigParams{StartWaitTimeMS: o.Some(ldtime.UnixMillisecondTime(1)),
+			InitCanFail: true}),
 		dataSource)
 	user := lduser.NewUser("user-key")
 
 	result := client.EvaluateAllFlags(t, servicedef.EvaluateAllFlagsParams{
-		User: &user,
+		User: o.Some(user),
 	})
 	resultJSON, _ := json.Marshal(result.State)
 	expectedJSON := `{
@@ -382,7 +384,7 @@ func doServerSideAllFlagsCompactRepresentationsTest(t *ldtest.T) {
 	user := lduser.NewUser("user-key")
 
 	result := client.EvaluateAllFlags(t, servicedef.EvaluateAllFlagsParams{
-		User: &user,
+		User: o.Some(user),
 	})
 
 	resultJSON, _ := json.Marshal(result.State["$flagsState"])

--- a/sdktests/server_side_eval_bucketing.go
+++ b/sdktests/server_side_eval_bucketing.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"strconv"
 
+	h "github.com/launchdarkly/sdk-test-harness/framework/helpers"
 	"github.com/launchdarkly/sdk-test-harness/framework/ldtest"
 	"github.com/launchdarkly/sdk-test-harness/mockld"
 
@@ -272,13 +273,13 @@ func RunServerSideEvalBucketingTests(t *ldtest.T) {
 				return b.Build()
 			}
 
-			desc := selectString(secondary == "", "secondary key is an empty string", "secondary key is a non-empty string")
+			desc := h.IfElse(secondary == "", "secondary key is an empty string", "secondary key is a non-empty string")
 			t.Run(desc, func(t *ldtest.T) {
 				for _, isExperiment := range []bool{false, true} {
 					// Note: in the SDK versions that this version of sdk-test-harness is for, the defined behavior
 					// was that the secondary key could be used for either a rollout or an experiment. In later
 					// versions, the secondary key is ignored in experiments and this test logic is changed.
-					desc := fmt.Sprintf("affects bucketing calculation in %s", selectString(isExperiment, "experiments", "rollouts"))
+					desc := fmt.Sprintf("affects bucketing calculation in %s", h.IfElse(isExperiment, "experiments", "rollouts"))
 					t.Run(desc, func(t *ldtest.T) {
 						if secondary == "" {
 							t.NonCritical(
@@ -328,7 +329,7 @@ func RunServerSideEvalBucketingTests(t *ldtest.T) {
 		// versions, bucketBy is ignored in experiments and this test logic is changed.
 
 		for _, isExperiment := range []bool{false, true} {
-			t.Run(selectString(isExperiment, "experiments", "rollouts"), func(t *ldtest.T) {
+			t.Run(h.IfElse(isExperiment, "experiments", "rollouts"), func(t *ldtest.T) {
 				rolloutKind := ldmodel.RolloutKindRollout
 				if isExperiment {
 					rolloutKind = ldmodel.RolloutKindExperiment

--- a/sdktests/server_side_events_buffer.go
+++ b/sdktests/server_side_events_buffer.go
@@ -2,6 +2,7 @@ package sdktests
 
 import (
 	"github.com/launchdarkly/sdk-test-harness/framework/ldtest"
+	o "github.com/launchdarkly/sdk-test-harness/framework/opt"
 	"github.com/launchdarkly/sdk-test-harness/mockld"
 	"github.com/launchdarkly/sdk-test-harness/servicedef"
 
@@ -17,7 +18,7 @@ func doServerSideEventBufferTests(t *ldtest.T) {
 	capacity := 20
 	extraItemsOverCapacity := 3 // arbitrary non-zero value for how many events to try to add past the limit
 	eventsConfig := baseEventsConfig()
-	eventsConfig.Capacity = ldvalue.NewOptionalInt(capacity)
+	eventsConfig.Capacity = o.Some(capacity)
 
 	userFactory := NewUserFactory("doServerSideEventCapacityTests",
 		func(b lduser.UserBuilder) { b.Name("my favorite user") })
@@ -76,7 +77,7 @@ func doServerSideEventBufferTests(t *ldtest.T) {
 
 		_ = client.EvaluateFlag(t, servicedef.EvaluateFlagParams{
 			FlagKey:      flag.Key,
-			User:         users[0],
+			User:         o.Some(users[0]),
 			ValueType:    servicedef.ValueTypeBool,
 			DefaultValue: ldvalue.Bool(false),
 		})

--- a/sdktests/server_side_events_eval.go
+++ b/sdktests/server_side_events_eval.go
@@ -94,11 +94,11 @@ func doServerSideFeatureEventTests(t *ldtest.T) {
 			t.Run(testDescFromType(valueType), func(t *ldtest.T) {
 				flag := trackedFlags.ForType(valueType)
 				expectedValue := flagValues(valueType)
-				expectedVariation := ldvalue.NewOptionalInt(0)
+				expectedVariation := o.Some(0)
 				if isBadFlag {
 					flag = malformedFlag
 					expectedValue = defaultValues(valueType)
-					expectedVariation = ldvalue.OptionalInt{}
+					expectedVariation = o.None[int]()
 				}
 				user := users.NextUniqueUserMaybeAnonymous(isAnonymousUser)
 				resp := client.EvaluateFlag(t, servicedef.EvaluateFlagParams{

--- a/sdktests/server_side_events_eval.go
+++ b/sdktests/server_side_events_eval.go
@@ -3,7 +3,9 @@ package sdktests
 import (
 	"time"
 
+	h "github.com/launchdarkly/sdk-test-harness/framework/helpers"
 	"github.com/launchdarkly/sdk-test-harness/framework/ldtest"
+	o "github.com/launchdarkly/sdk-test-harness/framework/opt"
 	"github.com/launchdarkly/sdk-test-harness/mockld"
 	"github.com/launchdarkly/sdk-test-harness/servicedef"
 
@@ -51,7 +53,7 @@ func doServerSideFeatureEventTests(t *ldtest.T) {
 
 	t.Run("only index + summary event for untracked flag", func(t *ldtest.T) {
 		for _, withReason := range []bool{false, true} {
-			t.Run(selectString(withReason, "with reasons", "without reasons"), func(t *ldtest.T) {
+			t.Run(h.IfElse(withReason, "with reasons", "without reasons"), func(t *ldtest.T) {
 				for _, valueType := range getValueTypesToTest(t) {
 					t.Run(testDescFromType(valueType), func(t *ldtest.T) {
 						flag := untrackedFlags.ForType(valueType)
@@ -59,7 +61,7 @@ func doServerSideFeatureEventTests(t *ldtest.T) {
 
 						resp := client.EvaluateFlag(t, servicedef.EvaluateFlagParams{
 							FlagKey:      flag.Key,
-							User:         user,
+							User:         o.Some(user),
 							ValueType:    valueType,
 							DefaultValue: defaultValues(valueType),
 							Detail:       withReason,
@@ -101,7 +103,7 @@ func doServerSideFeatureEventTests(t *ldtest.T) {
 				user := users.NextUniqueUserMaybeAnonymous(isAnonymousUser)
 				resp := client.EvaluateFlag(t, servicedef.EvaluateFlagParams{
 					FlagKey:      flag.Key,
-					User:         user,
+					User:         o.Some(user),
 					ValueType:    valueType,
 					DefaultValue: defaultValues(valueType),
 					Detail:       withReason,
@@ -142,11 +144,11 @@ func doServerSideFeatureEventTests(t *ldtest.T) {
 
 	t.Run("full feature event for tracked flag", func(t *ldtest.T) {
 		for _, withReason := range []bool{false, true} {
-			t.Run(selectString(withReason, "with reason", "without reason"), func(t *ldtest.T) {
+			t.Run(h.IfElse(withReason, "with reason", "without reason"), func(t *ldtest.T) {
 				for _, isAnonymousUser := range []bool{false, true} {
-					t.Run(selectString(isAnonymousUser, "anonymous user", "non-anonymous user"), func(t *ldtest.T) {
+					t.Run(h.IfElse(isAnonymousUser, "anonymous user", "non-anonymous user"), func(t *ldtest.T) {
 						for _, isBadFlag := range []bool{false, true} {
-							t.Run(selectString(isBadFlag, "malformed flag", "valid flag"), func(t *ldtest.T) {
+							t.Run(h.IfElse(isBadFlag, "malformed flag", "valid flag"), func(t *ldtest.T) {
 								doFeatureEventTest(t, withReason, isAnonymousUser, isBadFlag)
 							})
 						}
@@ -209,14 +211,14 @@ func doServerSideDebugEventTests(t *ldtest.T) {
 		}
 
 		for _, withReasons := range []bool{false, true} {
-			t.Run(selectString(withReasons, "with reasons", "without reasons"), func(t *ldtest.T) {
+			t.Run(h.IfElse(withReasons, "with reasons", "without reasons"), func(t *ldtest.T) {
 				for _, valueType := range getValueTypesToTest(t) {
 					t.Run(testDescFromType(valueType), func(t *ldtest.T) {
 						user := users.NextUniqueUser()
 						flag := flags.ForType(valueType)
 						result := client.EvaluateFlag(t, servicedef.EvaluateFlagParams{
 							FlagKey:      flag.Key,
-							User:         user,
+							User:         o.Some(user),
 							ValueType:    valueType,
 							DefaultValue: defaultValues(valueType),
 							Detail:       withReasons,
@@ -326,7 +328,7 @@ func doServerSideFeaturePrerequisiteEventTests(t *ldtest.T) {
 		Build()
 
 	for _, withReason := range []bool{false, true} {
-		t.Run(selectString(withReason, "with reasons", "without reasons"), func(t *ldtest.T) {
+		t.Run(h.IfElse(withReason, "with reasons", "without reasons"), func(t *ldtest.T) {
 			dataBuilder := mockld.NewServerSDKDataBuilder()
 			dataBuilder.Flag(flag1, flag2, flag3)
 
@@ -336,7 +338,7 @@ func doServerSideFeaturePrerequisiteEventTests(t *ldtest.T) {
 
 			result := client.EvaluateFlag(t, servicedef.EvaluateFlagParams{
 				FlagKey:      flag1.Key,
-				User:         user,
+				User:         o.Some(user),
 				ValueType:    servicedef.ValueTypeString,
 				DefaultValue: ldvalue.String("default"),
 				Detail:       withReason,
@@ -387,7 +389,7 @@ func doServerSideFeaturePrerequisiteEventTests(t *ldtest.T) {
 }
 
 func maybeReason(withReason bool, reason ldreason.EvaluationReason) m.Matcher {
-	return conditionalMatcher(withReason,
+	return h.IfElse(withReason,
 		m.JSONProperty("reason").Should(m.JSONEqual(reason)),
 		JSONPropertyNullOrAbsent("reason"))
 }

--- a/sdktests/server_side_events_identify.go
+++ b/sdktests/server_side_events_identify.go
@@ -3,7 +3,9 @@ package sdktests
 import (
 	"time"
 
+	h "github.com/launchdarkly/sdk-test-harness/framework/helpers"
 	"github.com/launchdarkly/sdk-test-harness/framework/ldtest"
+	o "github.com/launchdarkly/sdk-test-harness/framework/opt"
 	"github.com/launchdarkly/sdk-test-harness/mockld"
 	"github.com/launchdarkly/sdk-test-harness/servicedef"
 
@@ -23,7 +25,7 @@ func doServerSideIdentifyEventTests(t *ldtest.T) {
 
 	t.Run("basic properties", func(t *ldtest.T) {
 		for _, isAnonymousUser := range []bool{false, true} {
-			t.Run(selectString(isAnonymousUser, "anonymous user", "non-anonymous user"), func(t *ldtest.T) {
+			t.Run(h.IfElse(isAnonymousUser, "anonymous user", "non-anonymous user"), func(t *ldtest.T) {
 				user := users.NextUniqueUserMaybeAnonymous(isAnonymousUser)
 				client.SendIdentifyEvent(t, user)
 				client.FlushEvents(t)
@@ -51,7 +53,7 @@ func doServerSideIdentifyEventTests(t *ldtest.T) {
 		client.SendIdentifyEvent(t, user)
 		client.SendCustomEvent(t, servicedef.CustomEventParams{
 			EventKey: "event-key",
-			User:     user,
+			User:     o.Some(user),
 		})
 		// Sending a custom event would also generate an index event for the user,
 		// if we hadn't already seen that user

--- a/sdktests/server_side_events_index.go
+++ b/sdktests/server_side_events_index.go
@@ -1,7 +1,9 @@
 package sdktests
 
 import (
+	h "github.com/launchdarkly/sdk-test-harness/framework/helpers"
 	"github.com/launchdarkly/sdk-test-harness/framework/ldtest"
+	o "github.com/launchdarkly/sdk-test-harness/framework/opt"
 	"github.com/launchdarkly/sdk-test-harness/mockld"
 	"github.com/launchdarkly/sdk-test-harness/servicedef"
 
@@ -30,7 +32,7 @@ func doServerSideIndexEventTests(t *ldtest.T) {
 		client := NewSDKClient(t, dataSource, events)
 
 		for _, isAnonymousUser := range []bool{false, true} {
-			t.Run(selectString(isAnonymousUser, "anonymous user", "non-anonymous user"), func(t *ldtest.T) {
+			t.Run(h.IfElse(isAnonymousUser, "anonymous user", "non-anonymous user"), func(t *ldtest.T) {
 				user := users.NextUniqueUserMaybeAnonymous(isAnonymousUser)
 
 				basicEvaluateFlag(t, client, "arbitrary-flag-key", user, ldvalue.Null())
@@ -79,8 +81,8 @@ func doServerSideIndexEventTests(t *ldtest.T) {
 
 			user1 := users.NextUniqueUser()
 			user2 := users.NextUniqueUser()
-			params1 := servicedef.CustomEventParams{EventKey: "event1", User: user1}
-			params2 := servicedef.CustomEventParams{EventKey: "event1", User: user2}
+			params1 := servicedef.CustomEventParams{EventKey: "event1", User: o.Some(user1)}
+			params2 := servicedef.CustomEventParams{EventKey: "event1", User: o.Some(user2)}
 
 			client.SendCustomEvent(t, params1)
 			client.SendCustomEvent(t, params1)

--- a/sdktests/server_side_events_request.go
+++ b/sdktests/server_side_events_request.go
@@ -31,7 +31,7 @@ func doServerSideEventRequestTests(t *ldtest.T) {
 		client.SendIdentifyEvent(t, user)
 		client.FlushEvents(t)
 
-		request := expectRequest(t, events.Endpoint(), time.Second)
+		request := events.Endpoint().RequireConnection(t, time.Second)
 
 		assert.Equal(t, "POST", request.Method)
 		assert.Equal(t, sdkKey, request.Headers.Get("Authorization"))
@@ -58,7 +58,7 @@ func doServerSideEventRequestTests(t *ldtest.T) {
 
 		seenIDs := make(map[string]bool)
 		for i := 0; i < numPayloads; i++ {
-			request := expectRequest(t, events.Endpoint(), time.Second)
+			request := events.Endpoint().RequireConnection(t, time.Second)
 			id := request.Headers.Get("X-LaunchDarkly-Payload-Id")
 			assert.NotEqual(t, "", id)
 			assert.False(t, seenIDs[id], "saw payload ID %q twice", id)
@@ -75,7 +75,7 @@ func doServerSideEventRequestTests(t *ldtest.T) {
 		client.SendIdentifyEvent(t, user)
 		client.FlushEvents(t)
 
-		request := expectRequest(t, events.Endpoint(), time.Second)
+		request := events.Endpoint().RequireConnection(t, time.Second)
 		assert.Equal(t, "/bulk", request.URL.Path)
 	})
 
@@ -88,7 +88,7 @@ func doServerSideEventRequestTests(t *ldtest.T) {
 		client.SendIdentifyEvent(t, user)
 		client.FlushEvents(t)
 
-		request := expectRequest(t, events.Endpoint(), time.Second)
+		request := events.Endpoint().RequireConnection(t, time.Second)
 		assert.Equal(t, "/bulk", request.URL.Path)
 	})
 }

--- a/sdktests/server_side_events_summary.go
+++ b/sdktests/server_side_events_summary.go
@@ -4,6 +4,7 @@ import (
 	"time"
 
 	"github.com/launchdarkly/sdk-test-harness/framework/ldtest"
+	o "github.com/launchdarkly/sdk-test-harness/framework/opt"
 	"github.com/launchdarkly/sdk-test-harness/mockld"
 	"github.com/launchdarkly/sdk-test-harness/servicedef"
 
@@ -51,12 +52,16 @@ func doServerSideSummaryEventBasicTest(t *ldtest.T) {
 	client := NewSDKClient(t, dataSource, events)
 
 	// evaluations for flag1: two for userA producing value1a, one for userB producing value1b
-	_ = client.EvaluateFlag(t, servicedef.EvaluateFlagParams{FlagKey: flag1.Key, User: userA, DefaultValue: default1})
-	_ = client.EvaluateFlag(t, servicedef.EvaluateFlagParams{FlagKey: flag1.Key, User: userB, DefaultValue: default1})
-	_ = client.EvaluateFlag(t, servicedef.EvaluateFlagParams{FlagKey: flag1.Key, User: userA, DefaultValue: default1})
+	_ = client.EvaluateFlag(t, servicedef.EvaluateFlagParams{FlagKey: flag1.Key,
+		User: o.Some(userA), DefaultValue: default1})
+	_ = client.EvaluateFlag(t, servicedef.EvaluateFlagParams{FlagKey: flag1.Key,
+		User: o.Some(userB), DefaultValue: default1})
+	_ = client.EvaluateFlag(t, servicedef.EvaluateFlagParams{FlagKey: flag1.Key,
+		User: o.Some(userA), DefaultValue: default1})
 
 	// evaluations for flag2: one for userA producing value2a
-	_ = client.EvaluateFlag(t, servicedef.EvaluateFlagParams{FlagKey: flag2.Key, User: userA, DefaultValue: default2})
+	_ = client.EvaluateFlag(t, servicedef.EvaluateFlagParams{FlagKey: flag2.Key,
+		User: o.Some(userA), DefaultValue: default2})
 
 	client.FlushEvents(t)
 	payload := events.ExpectAnalyticsEvents(t, defaultEventTimeout)
@@ -94,8 +99,10 @@ func doServerSideSummaryEventUnknownFlagTest(t *ldtest.T) {
 	client := NewSDKClient(t, dataSource, events)
 
 	// evaluate the unknown flag twice
-	_ = client.EvaluateFlag(t, servicedef.EvaluateFlagParams{FlagKey: unknownKey, User: user, DefaultValue: default1})
-	_ = client.EvaluateFlag(t, servicedef.EvaluateFlagParams{FlagKey: unknownKey, User: user, DefaultValue: default1})
+	_ = client.EvaluateFlag(t, servicedef.EvaluateFlagParams{FlagKey: unknownKey,
+		User: o.Some(user), DefaultValue: default1})
+	_ = client.EvaluateFlag(t, servicedef.EvaluateFlagParams{FlagKey: unknownKey,
+		User: o.Some(user), DefaultValue: default1})
 
 	client.FlushEvents(t)
 	payload := events.ExpectAnalyticsEvents(t, defaultEventTimeout)
@@ -133,10 +140,12 @@ func doServerSideSummaryEventResetTest(t *ldtest.T) {
 
 	// evaluate flag 10 times for userA producing value-a, 3 times for userB producing value-b
 	for i := 0; i < 10; i++ {
-		_ = client.EvaluateFlag(t, servicedef.EvaluateFlagParams{FlagKey: flag.Key, User: userA, DefaultValue: defaultValue})
+		_ = client.EvaluateFlag(t, servicedef.EvaluateFlagParams{FlagKey: flag.Key,
+			User: o.Some(userA), DefaultValue: defaultValue})
 	}
 	for i := 0; i < 3; i++ {
-		_ = client.EvaluateFlag(t, servicedef.EvaluateFlagParams{FlagKey: flag.Key, User: userB, DefaultValue: defaultValue})
+		_ = client.EvaluateFlag(t, servicedef.EvaluateFlagParams{FlagKey: flag.Key,
+			User: o.Some(userB), DefaultValue: defaultValue})
 	}
 
 	client.FlushEvents(t)
@@ -158,7 +167,8 @@ func doServerSideSummaryEventResetTest(t *ldtest.T) {
 
 	// Now do 2 evaluations for value-b and verify that the summary shows only those, not the previous counts
 	for i := 0; i < 2; i++ {
-		_ = client.EvaluateFlag(t, servicedef.EvaluateFlagParams{FlagKey: flag.Key, User: userB, DefaultValue: defaultValue})
+		_ = client.EvaluateFlag(t, servicedef.EvaluateFlagParams{FlagKey: flag.Key,
+			User: o.Some(userB), DefaultValue: defaultValue})
 	}
 
 	client.FlushEvents(t)
@@ -207,7 +217,8 @@ func doServerSideSummaryEventPrerequisitesTest(t *ldtest.T) {
 
 	// evaluate flag1 3 times, which should cause flag2 and flag3 to also be evaluated 3 times
 	for i := 0; i < 3; i++ {
-		_ = client.EvaluateFlag(t, servicedef.EvaluateFlagParams{FlagKey: flag1.Key, User: user, DefaultValue: defaultValue})
+		_ = client.EvaluateFlag(t, servicedef.EvaluateFlagParams{FlagKey: flag1.Key,
+			User: o.Some(user), DefaultValue: defaultValue})
 	}
 
 	client.FlushEvents(t)

--- a/sdktests/server_side_events_users.go
+++ b/sdktests/server_side_events_users.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 
 	"github.com/launchdarkly/sdk-test-harness/framework/ldtest"
+	o "github.com/launchdarkly/sdk-test-harness/framework/opt"
 	"github.com/launchdarkly/sdk-test-harness/mockld"
 	"github.com/launchdarkly/sdk-test-harness/servicedef"
 
@@ -95,7 +96,7 @@ func doServerSideEventUserTests(t *ldtest.T) {
 				user := scenario.MakeUser(users.NextUniqueUser())
 				client.EvaluateFlag(t, servicedef.EvaluateFlagParams{
 					FlagKey:      flag.Key,
-					User:         user,
+					User:         o.Some(user),
 					ValueType:    servicedef.ValueTypeAny,
 					DefaultValue: defaultValue,
 				})
@@ -132,10 +133,10 @@ func doServerSideEventUserTests(t *ldtest.T) {
 				eventData := ldvalue.Bool(true)
 				metricValue := float64(10)
 				client.SendCustomEvent(t, servicedef.CustomEventParams{
-					User:        user,
+					User:        o.Some(user),
 					EventKey:    "event-key",
 					Data:        eventData,
-					MetricValue: &metricValue,
+					MetricValue: o.Some(metricValue),
 				})
 				client.FlushEvents(t)
 

--- a/sdktests/server_side_stream_request.go
+++ b/sdktests/server_side_stream_request.go
@@ -20,7 +20,7 @@ func doServerSideStreamRequestTests(t *ldtest.T) {
 			Credential: sdkKey,
 		}), dataSource)
 
-		request := expectRequest(t, dataSource.Endpoint(), time.Second)
+		request := dataSource.Endpoint().RequireConnection(t, time.Second)
 
 		assert.Equal(t, sdkKey, request.Headers.Get("Authorization"))
 		assert.NotEqual(t, sdkKey, request.Headers.Get("User-Agent"))
@@ -32,7 +32,7 @@ func doServerSideStreamRequestTests(t *ldtest.T) {
 			BaseURI: strings.TrimSuffix(dataSource.Endpoint().BaseURL(), "/") + "/",
 		}))
 
-		request := expectRequest(t, dataSource.Endpoint(), time.Second)
+		request := dataSource.Endpoint().RequireConnection(t, time.Second)
 		assert.Equal(t, "/all", request.URL.Path)
 	})
 
@@ -42,7 +42,7 @@ func doServerSideStreamRequestTests(t *ldtest.T) {
 			BaseURI: strings.TrimSuffix(dataSource.Endpoint().BaseURL(), "/"),
 		}))
 
-		request := expectRequest(t, dataSource.Endpoint(), time.Second)
+		request := dataSource.Endpoint().RequireConnection(t, time.Second)
 		assert.Equal(t, "/all", request.URL.Path)
 	})
 }

--- a/sdktests/server_side_stream_retry.go
+++ b/sdktests/server_side_stream_retry.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/launchdarkly/sdk-test-harness/framework/harness"
 	"github.com/launchdarkly/sdk-test-harness/framework/ldtest"
+	o "github.com/launchdarkly/sdk-test-harness/framework/opt"
 	"github.com/launchdarkly/sdk-test-harness/mockld"
 	"github.com/launchdarkly/sdk-test-harness/servicedef"
 
@@ -22,7 +23,7 @@ const briefDelay ldtime.UnixMillisecondTime = 1
 func baseStreamConfig(endpoint *harness.MockEndpoint) servicedef.SDKConfigStreamingParams {
 	return servicedef.SDKConfigStreamingParams{
 		BaseURI:             endpoint.BaseURL(),
-		InitialRetryDelayMs: timeValueAsPointer(briefDelay),
+		InitialRetryDelayMs: o.Some(briefDelay),
 	}
 }
 
@@ -49,17 +50,17 @@ func doServerSideStreamRetryTests(t *ldtest.T) {
 		t.Defer(streamEndpoint.Close)
 
 		client := NewSDKClient(t, WithStreamingConfig(baseStreamConfig(streamEndpoint)))
-		result := client.EvaluateAllFlags(t, servicedef.EvaluateAllFlagsParams{User: &user})
+		result := client.EvaluateAllFlags(t, servicedef.EvaluateAllFlagsParams{User: o.Some(user)})
 		m.In(t).Assert(result, EvalAllFlagsValueForKeyShouldEqual(flagKey, expectedValueV1))
 
 		// Get the request info for the first request
-		request1 := expectRequest(t, streamEndpoint, time.Second*5)
+		request1 := streamEndpoint.RequireConnection(t, time.Second*5)
 
 		// Now cause the stream to close; this should trigger a reconnect
 		request1.Cancel()
 
 		// Expect the second request; it succeeds and gets the second stream data
-		expectRequest(t, streamEndpoint, time.Millisecond*100)
+		_ = streamEndpoint.RequireConnection(t, time.Millisecond*100)
 
 		// Check that the client got the new data from the second stream
 		pollUntilFlagValueUpdated(t, client, flagKey, user, expectedValueV1, expectedValueV2, ldvalue.Null())
@@ -74,15 +75,15 @@ func doServerSideStreamRetryTests(t *ldtest.T) {
 		stream := NewSDKDataSource(t, dataV1)
 		client := NewSDKClient(t,
 			WithStreamingConfig(servicedef.SDKConfigStreamingParams{
-				InitialRetryDelayMs: timeValueAsPointer(10000),
+				InitialRetryDelayMs: o.Some(ldtime.UnixMillisecondTime(10000)),
 			}),
 			stream,
 		)
-		result := client.EvaluateAllFlags(t, servicedef.EvaluateAllFlagsParams{User: &user})
+		result := client.EvaluateAllFlags(t, servicedef.EvaluateAllFlagsParams{User: o.Some(user)})
 		m.In(t).Assert(result, EvalAllFlagsValueForKeyShouldEqual(flagKey, expectedValueV1))
 
 		// Get the request info for the first request
-		request1 := expectRequest(t, stream.Endpoint(), time.Second*5)
+		request1 := stream.Endpoint().RequireConnection(t, time.Second*5)
 
 		// Now cause the stream to close; this should trigger a reconnect
 		request1.Cancel()
@@ -98,7 +99,7 @@ func doServerSideStreamRetryTests(t *ldtest.T) {
 		// since they set a very short retry delay and expect to see connections in much less
 		// than 500ms. So, the failure condition we're really checking for here is "the SDK does
 		// not do a delay at all, it retries immediately".
-		expectNoMoreRequests(t, stream.Endpoint())
+		stream.Endpoint().RequireNoMoreConnections(t, time.Millisecond*100)
 	})
 
 	shouldRetryAfterErrorOnInitialConnect := func(t *ldtest.T, errorHandler http.Handler) {
@@ -112,14 +113,14 @@ func doServerSideStreamRetryTests(t *ldtest.T) {
 		t.Defer(streamEndpoint.Close)
 
 		client := NewSDKClient(t, WithStreamingConfig(baseStreamConfig(streamEndpoint)))
-		result := client.EvaluateAllFlags(t, servicedef.EvaluateAllFlagsParams{User: &user})
+		result := client.EvaluateAllFlags(t, servicedef.EvaluateAllFlagsParams{User: o.Some(user)})
 		m.In(t).Assert(result, EvalAllFlagsValueForKeyShouldEqual(flagKey, expectedValueV1))
 
 		for i := 0; i < 3; i++ { // expect three requests
-			expectRequest(t, streamEndpoint, time.Second*5)
+			_ = streamEndpoint.RequireConnection(t, time.Second*5)
 		}
 
-		expectNoMoreRequests(t, streamEndpoint)
+		streamEndpoint.RequireNoMoreConnections(t, time.Millisecond*100)
 	}
 
 	t.Run("retry after IO error on initial connect", func(t *ldtest.T) {
@@ -147,23 +148,23 @@ func doServerSideStreamRetryTests(t *ldtest.T) {
 		t.Defer(streamEndpoint.Close)
 
 		client := NewSDKClient(t, WithStreamingConfig(baseStreamConfig(streamEndpoint)))
-		result := client.EvaluateAllFlags(t, servicedef.EvaluateAllFlagsParams{User: &user})
+		result := client.EvaluateAllFlags(t, servicedef.EvaluateAllFlagsParams{User: o.Some(user)})
 		m.In(t).Assert(result, EvalAllFlagsValueForKeyShouldEqual(flagKey, expectedValueV1))
 
 		// Get the request info for the first request
-		request1 := expectRequest(t, streamEndpoint, time.Second*5)
+		request1 := streamEndpoint.RequireConnection(t, time.Second*5)
 
 		// Now cause the stream to close; this should trigger a reconnect
 		request1.Cancel()
 
 		// Expect the second request; it will receive an error, causing another attempt
-		_ = expectRequest(t, streamEndpoint, time.Millisecond*100)
+		_ = streamEndpoint.RequireConnection(t, time.Millisecond*100)
 
 		// Expect the third request; it will also receive an error, causing another attempt
-		_ = expectRequest(t, streamEndpoint, time.Millisecond*100)
+		_ = streamEndpoint.RequireConnection(t, time.Millisecond*100)
 
 		// expect the fourth request; this one succeeds and gets the second stream data
-		_ = expectRequest(t, streamEndpoint, time.Millisecond*100)
+		_ = streamEndpoint.RequireConnection(t, time.Millisecond*100)
 
 		// check that the client got the new data from the second stream
 		pollUntilFlagValueUpdated(t, client, flagKey, user, expectedValueV1, expectedValueV2, ldvalue.Null())
@@ -195,9 +196,9 @@ func doServerSideStreamRetryTests(t *ldtest.T) {
 				_ = NewSDKClient(t, WithConfig(servicedef.SDKConfigParams{InitCanFail: true}),
 					WithStreamingConfig(baseStreamConfig(streamEndpoint)))
 
-				_ = expectRequest(t, streamEndpoint, time.Second*5)
+				_ = streamEndpoint.RequireConnection(t, time.Second*5)
 
-				expectNoMoreRequests(t, streamEndpoint)
+				streamEndpoint.RequireNoMoreConnections(t, time.Millisecond*100)
 			})
 		}
 	})
@@ -215,19 +216,19 @@ func doServerSideStreamRetryTests(t *ldtest.T) {
 				t.Defer(streamEndpoint.Close)
 
 				client := NewSDKClient(t, WithStreamingConfig(baseStreamConfig(streamEndpoint)))
-				result := client.EvaluateAllFlags(t, servicedef.EvaluateAllFlagsParams{User: &user})
+				result := client.EvaluateAllFlags(t, servicedef.EvaluateAllFlagsParams{User: o.Some(user)})
 				m.In(t).Assert(result, EvalAllFlagsValueForKeyShouldEqual(flagKey, expectedValueV1))
 
 				// get the request info for the first request
-				request1 := expectRequest(t, streamEndpoint, time.Second*5)
+				request1 := streamEndpoint.RequireConnection(t, time.Second*5)
 
 				// now cause the stream to close; this should trigger a reconnect
 				request1.Cancel()
 
 				// expect the second request; it will receive an error
-				_ = expectRequest(t, streamEndpoint, time.Millisecond*100)
+				_ = streamEndpoint.RequireConnection(t, time.Millisecond*100)
 
-				expectNoMoreRequests(t, streamEndpoint)
+				streamEndpoint.RequireNoMoreConnections(t, time.Millisecond*100)
 			})
 		}
 	})

--- a/sdktests/server_side_stream_validation.go
+++ b/sdktests/server_side_stream_validation.go
@@ -8,8 +8,10 @@ import (
 	"github.com/launchdarkly/go-test-helpers/v2/jsonhelpers"
 	m "github.com/launchdarkly/go-test-helpers/v2/matchers"
 	"github.com/launchdarkly/sdk-test-harness/framework/ldtest"
+	o "github.com/launchdarkly/sdk-test-harness/framework/opt"
 	"github.com/launchdarkly/sdk-test-harness/mockld"
 	"github.com/launchdarkly/sdk-test-harness/servicedef"
+
 	"gopkg.in/launchdarkly/go-sdk-common.v2/lduser"
 	"gopkg.in/launchdarkly/go-sdk-common.v2/ldvalue"
 )
@@ -34,17 +36,17 @@ func doServerSideStreamValidationTests(t *ldtest.T) {
 		t.Defer(streamEndpoint.Close)
 
 		client := NewSDKClient(t, WithStreamingConfig(baseStreamConfig(streamEndpoint)))
-		result := client.EvaluateAllFlags(t, servicedef.EvaluateAllFlagsParams{User: &user})
+		result := client.EvaluateAllFlags(t, servicedef.EvaluateAllFlagsParams{User: o.Some(user)})
 		m.In(t).Assert(result, EvalAllFlagsValueForKeyShouldEqual(flagKey, expectedValueV1))
 
 		// Get & discard the request info for the first request
-		_ = expectRequest(t, streamEndpoint, time.Second*5)
+		_ = streamEndpoint.RequireConnection(t, time.Second*5)
 
 		// Send the bad event; this should cause the SDK to drop the first stream
 		stream1.Service().PushEvent(badEventName, badEventData)
 
 		// Expect the second request; it succeeds and gets the second stream data
-		_ = expectRequest(t, streamEndpoint, time.Millisecond*100)
+		_ = streamEndpoint.RequireConnection(t, time.Millisecond*100)
 
 		// Check that the client got the new data from the second stream
 		pollUntilFlagValueUpdated(t, client, flagKey, user, expectedValueV1, expectedValueV2, ldvalue.Null())
@@ -81,14 +83,14 @@ func doServerSideStreamValidationTests(t *ldtest.T) {
 	shouldIgnoreEvent := func(t *ldtest.T, eventName string, eventData json.RawMessage) {
 		dataSource := NewSDKDataSource(t, dataV1)
 		client := NewSDKClient(t, WithStreamingConfig(servicedef.SDKConfigStreamingParams{
-			InitialRetryDelayMs: timeValueAsPointer(briefDelay), // brief delay so we can easily detect if it reconnects
+			InitialRetryDelayMs: o.Some(briefDelay), // brief delay so we can easily detect if it reconnects
 		}), dataSource)
 
-		result := client.EvaluateAllFlags(t, servicedef.EvaluateAllFlagsParams{User: &user})
+		result := client.EvaluateAllFlags(t, servicedef.EvaluateAllFlagsParams{User: o.Some(user)})
 		m.In(t).Assert(result, EvalAllFlagsValueForKeyShouldEqual(flagKey, expectedValueV1))
 
 		// Get & discard the request info for the first request
-		_ = expectRequest(t, dataSource.Endpoint(), time.Second*5)
+		_ = dataSource.Endpoint().RequireConnection(t, time.Second*5)
 
 		// Push an event that isn't recognized, but isn't bad enough to cause any problems
 		dataSource.Service().PushEvent(eventName, eventData)
@@ -100,7 +102,7 @@ func doServerSideStreamValidationTests(t *ldtest.T) {
 		pollUntilFlagValueUpdated(t, client, flagKey, user, expectedValueV1, expectedValueV2, ldvalue.Null())
 
 		// Verify that it did not reconnect
-		expectNoMoreRequests(t, dataSource.Endpoint())
+		dataSource.Endpoint().RequireNoMoreConnections(t, time.Millisecond*100)
 	}
 
 	t.Run("unrecognized data that can be safely ignored", func(t *ldtest.T) {

--- a/sdktests/testapi_sdk_big_segments.go
+++ b/sdktests/testapi_sdk_big_segments.go
@@ -6,7 +6,9 @@ import (
 	"time"
 
 	"github.com/launchdarkly/sdk-test-harness/framework/harness"
+	"github.com/launchdarkly/sdk-test-harness/framework/helpers"
 	"github.com/launchdarkly/sdk-test-harness/framework/ldtest"
+	o "github.com/launchdarkly/sdk-test-harness/framework/opt"
 	"github.com/launchdarkly/sdk-test-harness/mockld"
 	"github.com/launchdarkly/sdk-test-harness/servicedef"
 
@@ -14,7 +16,6 @@ import (
 	"gopkg.in/launchdarkly/go-sdk-common.v2/ldtime"
 
 	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 )
 
 // BigSegmentStore is a test fixture that provides callback endpoints for SDK clients to connect to,
@@ -54,13 +55,9 @@ func NewBigSegmentStore(t *ldtest.T, initialStatus ldreason.BigSegmentsStatus) *
 // ApplyConfiguration updates the SDK client configuration for NewSDKClient, causing the SDK
 // to connect to the appropriate base URI for the big segments test fixture.
 func (b *BigSegmentStore) ApplyConfiguration(config *servicedef.SDKConfigParams) {
-	if config.BigSegments == nil {
-		config.BigSegments = &servicedef.SDKConfigBigSegmentsParams{}
-	} else {
-		bc := *config.BigSegments
-		config.BigSegments = &bc // copy to avoid side effects
-	}
-	config.BigSegments.CallbackURI = b.endpoint.BaseURL()
+	newState := config.BigSegments.Value()
+	newState.CallbackURI = b.endpoint.BaseURL()
+	config.BigSegments = o.Some(newState)
 }
 
 // SetupGetMetadata causes the specified function to be called whenever the SDK calls the "get
@@ -115,22 +112,14 @@ func (b *BigSegmentStore) SetupMemberships(t *ldtest.T, memberships map[string]m
 
 // ExpectMetadataQuery blocks until the Big Segment store has received a metadata query.
 func (b *BigSegmentStore) ExpectMetadataQuery(t *ldtest.T, timeout time.Duration) {
-	select {
-	case <-b.metadataQueries:
-		return
-	case <-time.After(timeout):
-		require.Fail(t, "timed out waiting for big segments metadata query")
-	}
+	_ = helpers.RequireValueWithMessage(t, b.metadataQueries, timeout,
+		"timed out waiting for big segments metadata query")
 }
 
 // ExpectNoMoreMetadataQueries causes a test failure if the Big Segment store receives a
 // metadata query.
 func (b *BigSegmentStore) ExpectNoMoreMetadataQueries(t *ldtest.T, timeout time.Duration) {
-	select {
-	case <-b.metadataQueries:
-		require.Fail(t, "got an unexpected big segments metadata query")
-	case <-time.After(timeout):
-	}
+	helpers.RequireNoMoreValues(t, b.metadataQueries, timeout)
 }
 
 // GetMembershipQueries returns the user hashes of all membership queries that have been

--- a/sdktests/testapi_sdk_client.go
+++ b/sdktests/testapi_sdk_client.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/launchdarkly/sdk-test-harness/framework/harness"
 	"github.com/launchdarkly/sdk-test-harness/framework/ldtest"
+	o "github.com/launchdarkly/sdk-test-harness/framework/opt"
 	"github.com/launchdarkly/sdk-test-harness/servicedef"
 
 	"gopkg.in/launchdarkly/go-sdk-common.v2/lduser"
@@ -33,14 +34,14 @@ func WithConfig(config servicedef.SDKConfigParams) SDKConfigurer {
 // WithEventsConfig is used with StartSDKClient to specify a non-default events configuration.
 func WithEventsConfig(eventsConfig servicedef.SDKConfigEventParams) SDKConfigurer {
 	return sdkConfigurerFunc(func(configOut *servicedef.SDKConfigParams) {
-		configOut.Events = &eventsConfig
+		configOut.Events = o.Some(eventsConfig)
 	})
 }
 
 // WithStreamingConfig is used with StartSDKClient to specify a non-default streaming configuration.
 func WithStreamingConfig(streamingConfig servicedef.SDKConfigStreamingParams) SDKConfigurer {
 	return sdkConfigurerFunc(func(configOut *servicedef.SDKConfigParams) {
-		configOut.Streaming = &streamingConfig
+		configOut.Streaming = o.Some(streamingConfig)
 	})
 }
 
@@ -112,10 +113,10 @@ func TryNewSDKClient(t *ldtest.T, configurer SDKConfigurer, moreConfigurers ...S
 }
 
 func validateSDKConfig(config servicedef.SDKConfigParams) error {
-	if config.Streaming == nil || config.Streaming.BaseURI == "" {
+	if !config.Streaming.IsDefined() || config.Streaming.Value().BaseURI == "" {
 		return errors.New("streaming base URI was not set-- did you forget to include the SDKDataSource as a parameter?")
 	}
-	if config.Events != nil && config.Events.BaseURI == "" {
+	if config.Events.IsDefined() && config.Events.Value().BaseURI == "" {
 		return errors.New("events were enabled but base URI was not set--" +
 			" did you forget to include the SDKEventSink as a parameter?")
 	}
@@ -140,7 +141,7 @@ func (c *SDKClient) EvaluateFlag(t *ldtest.T, params servicedef.EvaluateFlagPara
 	require.NoError(t, c.sdkClientEntity.SendCommandWithParams(
 		servicedef.CommandParams{
 			Command:  servicedef.CommandEvaluateFlag,
-			Evaluate: &params,
+			Evaluate: o.Some(params),
 		},
 		t.DebugLogger(),
 		&resp,
@@ -160,7 +161,7 @@ func (c *SDKClient) EvaluateAllFlags(
 	require.NoError(t, c.sdkClientEntity.SendCommandWithParams(
 		servicedef.CommandParams{
 			Command:     servicedef.CommandEvaluateAllFlags,
-			EvaluateAll: &params,
+			EvaluateAll: o.Some(params),
 		},
 		t.DebugLogger(),
 		&resp,
@@ -175,7 +176,7 @@ func (c *SDKClient) SendIdentifyEvent(t *ldtest.T, user lduser.User) {
 	require.NoError(t, c.sdkClientEntity.SendCommandWithParams(
 		servicedef.CommandParams{
 			Command:       servicedef.CommandIdentifyEvent,
-			IdentifyEvent: &servicedef.IdentifyEventParams{User: user},
+			IdentifyEvent: o.Some(servicedef.IdentifyEventParams{User: user}),
 		},
 		t.DebugLogger(),
 		nil,
@@ -189,7 +190,7 @@ func (c *SDKClient) SendCustomEvent(t *ldtest.T, params servicedef.CustomEventPa
 	require.NoError(t, c.sdkClientEntity.SendCommandWithParams(
 		servicedef.CommandParams{
 			Command:     servicedef.CommandCustomEvent,
-			CustomEvent: &params,
+			CustomEvent: o.Some(params),
 		},
 		t.DebugLogger(),
 		nil,
@@ -203,7 +204,7 @@ func (c *SDKClient) SendAliasEvent(t *ldtest.T, params servicedef.AliasEventPara
 	require.NoError(t, c.sdkClientEntity.SendCommandWithParams(
 		servicedef.CommandParams{
 			Command:    servicedef.CommandAliasEvent,
-			AliasEvent: &params,
+			AliasEvent: o.Some(params),
 		},
 		t.DebugLogger(),
 		nil,

--- a/sdktests/testapi_sdk_data.go
+++ b/sdktests/testapi_sdk_data.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/launchdarkly/sdk-test-harness/framework/harness"
 	"github.com/launchdarkly/sdk-test-harness/framework/ldtest"
+	o "github.com/launchdarkly/sdk-test-harness/framework/opt"
 	"github.com/launchdarkly/sdk-test-harness/mockld"
 	"github.com/launchdarkly/sdk-test-harness/servicedef"
 )
@@ -62,11 +63,7 @@ func (d *SDKDataSource) ApplyConfiguration(config *servicedef.SDKConfigParams) {
 	if d.streamingEndpoint == nil {
 		panic("Tried to use an SDKDataSource without its own endpoint as a parameter to NewSDKClient")
 	}
-	if config.Streaming == nil {
-		config.Streaming = &servicedef.SDKConfigStreamingParams{}
-	} else {
-		sc := *config.Streaming
-		config.Streaming = &sc // copy to avoid side effects
-	}
-	config.Streaming.BaseURI = d.streamingEndpoint.BaseURL()
+	newState := config.Streaming.Value()
+	newState.BaseURI = d.streamingEndpoint.BaseURL()
+	config.Streaming = o.Some(newState)
 }

--- a/sdktests/testapi_sdk_events.go
+++ b/sdktests/testapi_sdk_events.go
@@ -5,8 +5,11 @@ import (
 
 	"github.com/launchdarkly/sdk-test-harness/framework/harness"
 	"github.com/launchdarkly/sdk-test-harness/framework/ldtest"
+	o "github.com/launchdarkly/sdk-test-harness/framework/opt"
 	"github.com/launchdarkly/sdk-test-harness/mockld"
 	"github.com/launchdarkly/sdk-test-harness/servicedef"
+
+	"gopkg.in/launchdarkly/go-sdk-common.v2/ldtime"
 
 	"github.com/stretchr/testify/require"
 )
@@ -14,7 +17,7 @@ import (
 func baseEventsConfig() servicedef.SDKConfigEventParams {
 	return servicedef.SDKConfigEventParams{
 		// Set a very long flush interval so event payloads will only be flushed when we force a flush
-		FlushIntervalMS: 1000000,
+		FlushIntervalMS: o.Some(ldtime.UnixMillisecondTime(1000000)),
 	}
 }
 
@@ -45,14 +48,9 @@ func NewSDKEventSink(t *ldtest.T) *SDKEventSink {
 // ApplyConfiguration updates the SDK client configuration for NewSDKClient, causing the SDK
 // to connect to the appropriate base URI for the test fixture.
 func (e *SDKEventSink) ApplyConfiguration(config *servicedef.SDKConfigParams) {
-	if config.Events != nil {
-		ec := *config.Events
-		config.Events = &ec // copy to avoid side effects
-	} else {
-		ec := baseEventsConfig()
-		config.Events = &ec
-	}
-	config.Events.BaseURI = e.eventsEndpoint.BaseURL()
+	newState := config.Events.Value()
+	newState.BaseURI = e.eventsEndpoint.BaseURL()
+	config.Events = o.Some(newState)
 }
 
 // Endpoint returns the low-level object that manages incoming requests.

--- a/sdktests/testdata_factories.go
+++ b/sdktests/testdata_factories.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 
 	"github.com/launchdarkly/sdk-test-harness/servicedef"
+
 	"gopkg.in/launchdarkly/go-sdk-common.v2/ldreason"
 	"gopkg.in/launchdarkly/go-sdk-common.v2/ldtime"
 	"gopkg.in/launchdarkly/go-sdk-common.v2/lduser"

--- a/servicedef/command_params.go
+++ b/servicedef/command_params.go
@@ -1,6 +1,8 @@
 package servicedef
 
 import (
+	o "github.com/launchdarkly/sdk-test-harness/framework/opt"
+
 	"gopkg.in/launchdarkly/go-sdk-common.v2/ldreason"
 	"gopkg.in/launchdarkly/go-sdk-common.v2/lduser"
 	"gopkg.in/launchdarkly/go-sdk-common.v2/ldvalue"
@@ -27,33 +29,33 @@ const (
 )
 
 type CommandParams struct {
-	Command       string                  `json:"command"`
-	Evaluate      *EvaluateFlagParams     `json:"evaluate,omitempty"`
-	EvaluateAll   *EvaluateAllFlagsParams `json:"evaluateAll,omitempty"`
-	CustomEvent   *CustomEventParams      `json:"customEvent,omitempty"`
-	IdentifyEvent *IdentifyEventParams    `json:"identifyEvent,omitempty"`
-	AliasEvent    *AliasEventParams       `json:"aliasEvent,omitempty"`
+	Command       string                          `json:"command"`
+	Evaluate      o.Maybe[EvaluateFlagParams]     `json:"evaluate,omitempty"`
+	EvaluateAll   o.Maybe[EvaluateAllFlagsParams] `json:"evaluateAll,omitempty"`
+	CustomEvent   o.Maybe[CustomEventParams]      `json:"customEvent,omitempty"`
+	IdentifyEvent o.Maybe[IdentifyEventParams]    `json:"identifyEvent,omitempty"`
+	AliasEvent    o.Maybe[AliasEventParams]       `json:"aliasEvent,omitempty"`
 }
 
 type EvaluateFlagParams struct {
-	FlagKey      string        `json:"flagKey"`
-	User         lduser.User   `json:"user"`
-	ValueType    ValueType     `json:"valueType"`
-	DefaultValue ldvalue.Value `json:"defaultValue"`
-	Detail       bool          `json:"detail"`
+	FlagKey      string               `json:"flagKey"`
+	User         o.Maybe[lduser.User] `json:"user"`
+	ValueType    ValueType            `json:"valueType"`
+	DefaultValue ldvalue.Value        `json:"defaultValue"`
+	Detail       bool                 `json:"detail"`
 }
 
 type EvaluateFlagResponse struct {
-	Value          ldvalue.Value              `json:"value"`
-	VariationIndex *int                       `json:"variationIndex,omitempty"`
-	Reason         *ldreason.EvaluationReason `json:"reason,omitempty"`
+	Value          ldvalue.Value                      `json:"value"`
+	VariationIndex o.Maybe[int]                       `json:"variationIndex,omitempty"`
+	Reason         o.Maybe[ldreason.EvaluationReason] `json:"reason,omitempty"`
 }
 
 type EvaluateAllFlagsParams struct {
-	User                       *lduser.User `json:"user,omitempty"`
-	WithReasons                bool         `json:"withReasons"`
-	ClientSideOnly             bool         `json:"clientSideOnly"`
-	DetailsOnlyForTrackedFlags bool         `json:"detailsOnlyForTrackedFlags"`
+	User                       o.Maybe[lduser.User] `json:"user,omitempty"`
+	WithReasons                bool                 `json:"withReasons"`
+	ClientSideOnly             bool                 `json:"clientSideOnly"`
+	DetailsOnlyForTrackedFlags bool                 `json:"detailsOnlyForTrackedFlags"`
 }
 
 type EvaluateAllFlagsResponse struct {
@@ -61,11 +63,11 @@ type EvaluateAllFlagsResponse struct {
 }
 
 type CustomEventParams struct {
-	EventKey     string        `json:"eventKey"`
-	User         lduser.User   `json:"user"`
-	Data         ldvalue.Value `json:"data,omitempty"`
-	OmitNullData bool          `json:"omitNullData"`
-	MetricValue  *float64      `json:"metricValue,omitempty"`
+	EventKey     string               `json:"eventKey"`
+	User         o.Maybe[lduser.User] `json:"user"`
+	Data         ldvalue.Value        `json:"data,omitempty"`
+	OmitNullData bool                 `json:"omitNullData"`
+	MetricValue  o.Maybe[float64]     `json:"metricValue,omitempty"`
 }
 
 type IdentifyEventParams struct {

--- a/servicedef/sdk_config.go
+++ b/servicedef/sdk_config.go
@@ -1,35 +1,36 @@
 package servicedef
 
 import (
+	o "github.com/launchdarkly/sdk-test-harness/framework/opt"
+
 	"gopkg.in/launchdarkly/go-sdk-common.v2/ldtime"
 	"gopkg.in/launchdarkly/go-sdk-common.v2/lduser"
-	"gopkg.in/launchdarkly/go-sdk-common.v2/ldvalue"
 )
 
 type SDKConfigParams struct {
-	Credential          string                              `json:"credential"`
-	StartWaitTimeMS     ldtime.UnixMillisecondTime          `json:"startWaitTimeMs,omitempty"`
-	InitCanFail         bool                                `json:"initCanFail,omitempty"`
-	Streaming           *SDKConfigStreamingParams           `json:"streaming,omitempty"`
-	Events              *SDKConfigEventParams               `json:"events,omitempty"`
-	PersistentDataStore *SDKConfigPersistentDataStoreParams `json:"persistentDataStore,omitempty"`
-	BigSegments         *SDKConfigBigSegmentsParams         `json:"bigSegments,omitempty"`
-	Tags                *SDKConfigTagsParams                `json:"tags,omitempty"`
+	Credential          string                                      `json:"credential"`
+	StartWaitTimeMS     o.Maybe[ldtime.UnixMillisecondTime]         `json:"startWaitTimeMs,omitempty"`
+	InitCanFail         bool                                        `json:"initCanFail,omitempty"`
+	Streaming           o.Maybe[SDKConfigStreamingParams]           `json:"streaming,omitempty"`
+	Events              o.Maybe[SDKConfigEventParams]               `json:"events,omitempty"`
+	PersistentDataStore o.Maybe[SDKConfigPersistentDataStoreParams] `json:"persistentDataStore,omitempty"`
+	BigSegments         o.Maybe[SDKConfigBigSegmentsParams]         `json:"bigSegments,omitempty"`
+	Tags                o.Maybe[SDKConfigTagsParams]                `json:"tags,omitempty"`
 }
 
 type SDKConfigStreamingParams struct {
-	BaseURI             string                      `json:"baseUri,omitempty"`
-	InitialRetryDelayMs *ldtime.UnixMillisecondTime `json:"initialRetryDelayMs,omitempty"`
+	BaseURI             string                              `json:"baseUri,omitempty"`
+	InitialRetryDelayMs o.Maybe[ldtime.UnixMillisecondTime] `json:"initialRetryDelayMs,omitempty"`
 }
 
 type SDKConfigEventParams struct {
-	BaseURI                 string                     `json:"baseUri,omitempty"`
-	Capacity                ldvalue.OptionalInt        `json:"capacity,omitempty"`
-	EnableDiagnostics       bool                       `json:"enableDiagnostics"`
-	AllAttributesPrivate    bool                       `json:"allAttributesPrivate,omitempty"`
-	GlobalPrivateAttributes []lduser.UserAttribute     `json:"globalPrivateAttributes,omitempty"`
-	FlushIntervalMS         ldtime.UnixMillisecondTime `json:"flushIntervalMs,omitempty"`
-	InlineUsers             bool                       `json:"inlineUsers,omitempty"`
+	BaseURI                 string                              `json:"baseUri,omitempty"`
+	Capacity                o.Maybe[int]                        `json:"capacity,omitempty"`
+	EnableDiagnostics       bool                                `json:"enableDiagnostics"`
+	AllAttributesPrivate    bool                                `json:"allAttributesPrivate,omitempty"`
+	GlobalPrivateAttributes []lduser.UserAttribute              `json:"globalPrivateAttributes,omitempty"`
+	FlushIntervalMS         o.Maybe[ldtime.UnixMillisecondTime] `json:"flushIntervalMs,omitempty"`
+	InlineUsers             bool                                `json:"inlineUsers,omitempty"`
 }
 
 type SDKConfigPersistentDataStoreParams struct {
@@ -37,14 +38,14 @@ type SDKConfigPersistentDataStoreParams struct {
 }
 
 type SDKConfigBigSegmentsParams struct {
-	CallbackURI          string                     `json:"callbackUri"`
-	UserCacheSize        ldvalue.OptionalInt        `json:"userCacheSize,omitempty"`
-	UserCacheTimeMS      ldtime.UnixMillisecondTime `json:"userCacheTimeMs,omitempty"`
-	StatusPollIntervalMS ldtime.UnixMillisecondTime `json:"statusPollIntervalMs,omitempty"`
-	StaleAfterMS         ldtime.UnixMillisecondTime `json:"staleAfterMs,omitempty"`
+	CallbackURI          string                              `json:"callbackUri"`
+	UserCacheSize        o.Maybe[int]                        `json:"userCacheSize,omitempty"`
+	UserCacheTimeMS      o.Maybe[ldtime.UnixMillisecondTime] `json:"userCacheTimeMs,omitempty"`
+	StatusPollIntervalMS o.Maybe[ldtime.UnixMillisecondTime] `json:"statusPollIntervalMs,omitempty"`
+	StaleAfterMS         o.Maybe[ldtime.UnixMillisecondTime] `json:"staleAfterMs,omitempty"`
 }
 
 type SDKConfigTagsParams struct {
-	ApplicationID      ldvalue.OptionalString `json:"applicationId,omitempty"`
-	ApplicationVersion ldvalue.OptionalString `json:"applicationVersion,omitempty"`
+	ApplicationID      o.Maybe[string] `json:"applicationId,omitempty"`
+	ApplicationVersion o.Maybe[string] `json:"applicationVersion,omitempty"`
 }

--- a/servicedef/service_params.go
+++ b/servicedef/service_params.go
@@ -3,6 +3,7 @@ package servicedef
 import "github.com/launchdarkly/sdk-test-harness/framework/harness"
 
 const (
+	CapabilityClientSide    = "client-side"
 	CapabilityServerSide    = "server-side"
 	CapabilityStronglyTyped = "strongly-typed"
 

--- a/servicedef/service_params.go
+++ b/servicedef/service_params.go
@@ -6,6 +6,8 @@ const (
 	CapabilityClientSide    = "client-side"
 	CapabilityServerSide    = "server-side"
 	CapabilityStronglyTyped = "strongly-typed"
+	CapabilityMobile        = "mobile"
+	CapabilitySingleton     = "singleton"
 
 	CapabilityAllFlagsWithReasons                = "all-flags-with-reasons"
 	CapabilityAllFlagsClientSideOnly             = "all-flags-client-side-only"

--- a/servicedef/service_params.go
+++ b/servicedef/service_params.go
@@ -3,19 +3,15 @@ package servicedef
 import "github.com/launchdarkly/sdk-test-harness/framework/harness"
 
 const (
-	CapabilityClientSide    = "client-side"
 	CapabilityServerSide    = "server-side"
 	CapabilityStronglyTyped = "strongly-typed"
-	CapabilityMobile        = "mobile"
-	CapabilitySingleton     = "singleton"
 
 	CapabilityAllFlagsWithReasons                = "all-flags-with-reasons"
 	CapabilityAllFlagsClientSideOnly             = "all-flags-client-side-only"
 	CapabilityAllFlagsDetailsOnlyForTrackedFlags = "all-flags-details-only-for-tracked-flags"
 
-	CapabilityPersistentDataStore = "persistent-data-store"
-	CapabilityBigSegments         = "big-segments"
-	CapabilityTags                = "tags"
+	CapabilityBigSegments = "big-segments"
+	CapabilityTags        = "tags"
 )
 
 type StatusRep struct {

--- a/testdata/testmodel/eval.go
+++ b/testdata/testmodel/eval.go
@@ -1,6 +1,7 @@
 package testmodel
 
 import (
+	o "github.com/launchdarkly/sdk-test-harness/framework/opt"
 	"github.com/launchdarkly/sdk-test-harness/mockld"
 	"github.com/launchdarkly/sdk-test-harness/servicedef"
 
@@ -20,10 +21,16 @@ type EvalTestSuite struct {
 }
 
 type EvalTest struct {
-	Name      string                    `json:"name"`
-	FlagKey   string                    `json:"flagKey"`
-	User      lduser.User               `json:"user"`
-	ValueType servicedef.ValueType      `json:"valueType"`
-	Default   ldvalue.Value             `json:"default"`
-	Expect    ldreason.EvaluationDetail `json:"expect"`
+	Name      string               `json:"name"`
+	FlagKey   string               `json:"flagKey"`
+	User      lduser.User          `json:"user"`
+	ValueType servicedef.ValueType `json:"valueType"`
+	Default   ldvalue.Value        `json:"default"`
+	Expect    ValueDetail          `json:"expect"`
+}
+
+type ValueDetail struct {
+	Value          ldvalue.Value             `json:"value"`
+	VariationIndex o.Maybe[int]              `json:"variationIndex"`
+	Reason         ldreason.EvaluationReason `json:"reason"`
 }


### PR DESCRIPTION
Since this is a standalone codebase, it's a good test case for adopting Go 1.18 in situations where we don't need to support older versions.

The code changes consist of adding two new support packages, `framework/helpers` and `framework/opt`, containing generic-based helper types, and then doing a lot of DRY throughout the project to make use of them:

* `opt.Maybe[V]` replaces `ldvalue.OptionalString`, `ldvalue.OptionalInt`, `ldvalue.OptionalBool`... and all of our uses of pointers to represent optionality, so it's now very hard for us to mess up and cause a nil pointer panic (which I have done more than once in this code).
* The functions in `helpers/channels.go` and related functions replace `expectRequest`, `expectNoRequest`, and many similar cases where we used a select pattern to do a non-blocking receive with timeout or a non-blocking send. They work with channels of any type.
* The functions in `helpers/generics.go` replace `selectString`, `conditionalMatcher`, `stringInSlice`, and similar cases.
* The types in `helpers/test_abstractions.go` help in writing and verifying test helpers. These don't have anything to do with generics, but they were useful in testing the other stuff.