### PR TITLE
add contract test for disabling events

### DIFF
--- a/docs/service_spec.md
+++ b/docs/service_spec.md
@@ -47,6 +47,14 @@ This means that the SDK supports Big Segments and can be configured with a custo
 
 For tests that involve Big Segments, the test harness will provide parameters in the `bigSegments` property of the configuration object, including a `callbackUri` that points to one of the test harness's callback services (see [Callback endpoints](#callback-endpoints)). The test service should configure the SDK with its own implementation of a Big Segment store, where every method of the store delegates to a corresponding endpoint in the callback service.
 
+#### Capability `"service-endpoints"`
+
+This means that the SDK supports setting the base URIs for the streaming, polling, and events services separately from whether those services are enabled.
+
+Certain tests are only possible to do if the SDK's configuration API works in this way. For instance, to test whether events can be disabled, the test harness has to be able to create a mock endpoint that _would_ receive events if they were sent, and then configure the SDK to know the base URI of that endpoint, while also telling the SDK not to send events. Such tests will use the `serviceEndpoints` part of the configuration object. They will be skipped if the capability is not present.
+
+Note that even if this capability is present, the test harness may still choose to use the other method of setting base URIs per service (that is, specifying a `baseUri` property within `streaming` or `events`) since that is guaranteed to work for all test service implementations.
+
 #### Capability `"tags"`
 
 This means that the SDK supports the "tags" configuration option and will send the `X-LaunchDarkly-Tags` header in HTTP requests if tags are defined.
@@ -66,11 +74,13 @@ A `POST` request indicates that the test harness wants to start an instance of t
   * `credential` (string, required): The SDK key.
   * `startWaitTimeMs` (number, optional): The initialization timeout in milliseconds. If omitted or zero, the default is 5000 (5 seconds).
   * `initCanFail` (boolean, optional): If true, the test service should _not_ return an error for client initialization failing in a way that still makes the client instance available (for instance, due to a timeout or a 401 error). See discussion of error handling below.
+  * `serviceEndpoints` (object, optional): See notes on the `"service-endpoints"` capability. If this object is present, the test service should use it to set the corresponding service URIs in the SDK.
+    * `streaming`, `polling`, `events` (string, optional): Each of these, if set, is the base URI for the corresponding service.
   * `streaming` (object, optional): Enables streaming mode and provides streaming configuration. Currently the test harness only supports streaming mode, so this will be inferred if it is omitted. Properties are
-    * `baseUri` (string, optional): The base URI for the streaming service. For contract testing, this will be the URI of a simulated streaming endpoint that the test harness provides. If it is null or an empty string, the SDK should connect to the real LaunchDarkly streaming service.
+    * `baseUri` (string, optional): The base URI for the streaming service. For contract testing, this will be the URI of a simulated streaming endpoint that the test harness provides. If it is null or an empty string, the SDK should default to the value from `serviceEndpoints.streaming` if any, or if that is not set either, connect to the real LaunchDarkly streaming service.
     * `initialRetryDelayMs` (number, optional): The initial stream retry delay in milliseconds. If omitted, use the SDK's default value.
   * `events` (object, optional): Enables events and provides events configuration, or disables events if it is omitted or null. Properties are:
-    * `baseUri` (string, optional): The base URI for the events service. For contract testing, this will be the URI of a simulated event-recorder endpoint that the test harness provides. If it is null or an empty string, the SDK should connect to the real LaunchDarkly events service.
+    * `baseUri` (string, optional): The base URI for the events service. For contract testing, this will be the URI of a simulated event-recorder endpoint that the test harness provides.  If it is null or an empty string, the SDK should default to the value from `serviceEndpoints.events` if any, or if that is not set either, connect to the real LaunchDarkly events service.
     * `capacity` (number, optional): If specified and greater than zero, the event buffer capacity should be set to this value.
     * `enableDiagnostics` (boolean, optional): If true, diagnostic events should be enabled. Otherwise they should be disabled.
     * `allAttributesPrivate` (boolean, optional): Corresponds to the SDK configuration property of the same name.

--- a/sdktests/server_side_events_disable.go
+++ b/sdktests/server_side_events_disable.go
@@ -1,0 +1,60 @@
+package sdktests
+
+import (
+	"time"
+
+	"github.com/launchdarkly/sdk-test-harness/framework/ldtest"
+	o "github.com/launchdarkly/sdk-test-harness/framework/opt"
+	"github.com/launchdarkly/sdk-test-harness/mockld"
+	"github.com/launchdarkly/sdk-test-harness/servicedef"
+	"gopkg.in/launchdarkly/go-sdk-common.v2/lduser"
+	"gopkg.in/launchdarkly/go-sdk-common.v2/ldvalue"
+)
+
+func doServerSideEventDisableTest(t *ldtest.T) {
+	// We can only do this test if the SDK allows us to say "set the events base URI to ____" and "don't send
+	// events" at the same time; otherwise there would be no way to verify that events were not sent to our
+	// mock endpoint.
+	t.RequireCapability(servicedef.CapabilityServiceEndpoints)
+
+	user := lduser.NewUser("user-key")
+
+	doTest := func(t *ldtest.T, name string, actionThatCausesEvent func(*ldtest.T, *SDKClient)) {
+		t.Run(name, func(t *ldtest.T) {
+			dataSource := NewSDKDataSource(t, mockld.EmptyServerSDKData())
+			events := NewSDKEventSink(t)
+			client := NewSDKClient(t,
+				WithServiceEndpointsConfig(servicedef.SDKConfigServiceEndpointsParams{
+					Events: events.Endpoint().BaseURL(),
+				}),
+				dataSource)
+
+			actionThatCausesEvent(t, client)
+			client.FlushEvents(t)
+
+			events.ExpectNoAnalyticsEvents(t, time.Millisecond*100)
+		})
+	}
+
+	doTest(t, "evaluation", func(t *ldtest.T, client *SDKClient) {
+		_ = basicEvaluateFlag(t, client, "nonexistent-flag", user, ldvalue.Null())
+	})
+
+	doTest(t, "identify event", func(t *ldtest.T, client *SDKClient) {
+		client.SendIdentifyEvent(t, user)
+	})
+
+	doTest(t, "custom event", func(t *ldtest.T, client *SDKClient) {
+		client.SendCustomEvent(t, servicedef.CustomEventParams{
+			EventKey: "event-key",
+			User:     o.Some(user),
+		})
+	})
+
+	doTest(t, "alias event", func(t *ldtest.T, client *SDKClient) {
+		client.SendAliasEvent(t, servicedef.AliasEventParams{
+			User:         user,
+			PreviousUser: lduser.NewUser("previous-user-key"),
+		})
+	})
+}

--- a/sdktests/testapi_sdk_client.go
+++ b/sdktests/testapi_sdk_client.go
@@ -38,6 +38,14 @@ func WithEventsConfig(eventsConfig servicedef.SDKConfigEventParams) SDKConfigure
 	})
 }
 
+// WithServiceEndpointsConfig is used with StartSDKClient to specify non-default service endpoints.
+// This will only work if the test service has the "service-endpoints" capability.
+func WithServiceEndpointsConfig(endpointsConfig servicedef.SDKConfigServiceEndpointsParams) SDKConfigurer {
+	return sdkConfigurerFunc(func(configOut *servicedef.SDKConfigParams) {
+		configOut.ServiceEndpoints = o.Some(endpointsConfig)
+	})
+}
+
 // WithStreamingConfig is used with StartSDKClient to specify a non-default streaming configuration.
 func WithStreamingConfig(streamingConfig servicedef.SDKConfigStreamingParams) SDKConfigurer {
 	return sdkConfigurerFunc(func(configOut *servicedef.SDKConfigParams) {

--- a/sdktests/testsuite_server_side.go
+++ b/sdktests/testsuite_server_side.go
@@ -61,6 +61,12 @@ func doServerSideDataStoreTests(t *ldtest.T) {
 	t.Run("updates from stream", doServerSideDataStoreStreamUpdateTests)
 }
 
+func doServerSideStreamTests(t *ldtest.T) {
+	t.Run("requests", doServerSideStreamRequestTests)
+	t.Run("retry behavior", doServerSideStreamRetryTests)
+	t.Run("validation", doServerSideStreamValidationTests)
+}
+
 func doServerSideEventTests(t *ldtest.T) {
 	t.Run("requests", doServerSideEventRequestTests)
 	t.Run("summary events", doServerSideSummaryEventTests)
@@ -74,10 +80,5 @@ func doServerSideEventTests(t *ldtest.T) {
 	t.Run("index events", doServerSideIndexEventTests)
 	t.Run("user properties", doServerSideEventUserTests)
 	t.Run("event capacity", doServerSideEventBufferTests)
-}
-
-func doServerSideStreamTests(t *ldtest.T) {
-	t.Run("requests", doServerSideStreamRequestTests)
-	t.Run("retry behavior", doServerSideStreamRetryTests)
-	t.Run("validation", doServerSideStreamValidationTests)
+	t.Run("disabling", doServerSideEventDisableTest)
 }

--- a/servicedef/sdk_config.go
+++ b/servicedef/sdk_config.go
@@ -11,11 +11,18 @@ type SDKConfigParams struct {
 	Credential          string                                      `json:"credential"`
 	StartWaitTimeMS     o.Maybe[ldtime.UnixMillisecondTime]         `json:"startWaitTimeMs,omitempty"`
 	InitCanFail         bool                                        `json:"initCanFail,omitempty"`
+	ServiceEndpoints    o.Maybe[SDKConfigServiceEndpointsParams]    `json:"serviceEndpoints,omitempty"`
 	Streaming           o.Maybe[SDKConfigStreamingParams]           `json:"streaming,omitempty"`
 	Events              o.Maybe[SDKConfigEventParams]               `json:"events,omitempty"`
 	PersistentDataStore o.Maybe[SDKConfigPersistentDataStoreParams] `json:"persistentDataStore,omitempty"`
 	BigSegments         o.Maybe[SDKConfigBigSegmentsParams]         `json:"bigSegments,omitempty"`
 	Tags                o.Maybe[SDKConfigTagsParams]                `json:"tags,omitempty"`
+}
+
+type SDKConfigServiceEndpointsParams struct {
+	Streaming string `json:"streaming,omitempty"`
+	Polling   string `json:"polling,omitempty"`
+	Events    string `json:"events,omitempty"`
 }
 
 type SDKConfigStreamingParams struct {

--- a/servicedef/service_params.go
+++ b/servicedef/service_params.go
@@ -11,8 +11,9 @@ const (
 	CapabilityAllFlagsClientSideOnly             = "all-flags-client-side-only"
 	CapabilityAllFlagsDetailsOnlyForTrackedFlags = "all-flags-details-only-for-tracked-flags"
 
-	CapabilityBigSegments = "big-segments"
-	CapabilityTags        = "tags"
+	CapabilityBigSegments      = "big-segments"
+	CapabilityServiceEndpoints = "service-endpoints"
+	CapabilityTags             = "tags"
 )
 
 type StatusRep struct {


### PR DESCRIPTION
This is opt-in via a capability, because not all SDKs have a way to say "here is a custom base URI for the events service, but _also_, events are disabled". And we need to be able to set that custom base URI, because otherwise we wouldn't be able to see any events that might wrongly be sent.