### PR TITLE
Allow contextKind/previousContextKind properties to be omitted when user not anonymous

### DIFF
--- a/sdktests/custom_matchers_events.go
+++ b/sdktests/custom_matchers_events.go
@@ -30,6 +30,13 @@ func HasContextKind(user lduser.User) m.Matcher {
 	return JSONPropertyNullOrAbsent("contextKind")
 }
 
+func HasPreviousContextKind(user lduser.User) m.Matcher {
+	if user.GetAnonymous() {
+		return m.JSONProperty("previousContextKind").Should(m.Equal("anonymousUser"))
+	}
+	return JSONPropertyNullOrAbsent("previousContextKind")
+}
+
 func HasAnyCreationDate() m.Matcher {
 	return m.JSONProperty("creationDate").Should(ValueIsPositiveNonZeroInteger())
 }

--- a/sdktests/server_side_events_alias.go
+++ b/sdktests/server_side_events_alias.go
@@ -16,6 +16,14 @@ type aliasEventTestScenario struct {
 	eventMatcher m.Matcher
 }
 
+func JSONPropertyOrAbsent(name string, required bool, matcher m.Matcher) m.Matcher {
+	if required {
+		return m.JSONProperty(name).Should(matcher)
+	} else {
+		return m.JSONOptProperty(name).Should(m.BeNil())
+	}
+}
+
 func doServerSideAliasEventTests(t *ldtest.T) {
 	userFactory := NewUserFactory("doServerSideAliasEventTests")
 
@@ -50,8 +58,8 @@ func doServerSideAliasEventTests(t *ldtest.T) {
 				HasAnyCreationDate(),
 				m.JSONProperty("key").Should(m.Equal(scenario.params.User.GetKey())),
 				m.JSONProperty("previousKey").Should(m.Equal(scenario.params.PreviousUser.GetKey())),
-				m.JSONProperty("contextKind").Should(m.Equal(newContextKind)),
-				m.JSONProperty("previousContextKind").Should(m.Equal(previousContextKind)),
+				JSONPropertyOrAbsent("contextKind", user2IsAnon, m.Equal(newContextKind)),
+				JSONPropertyOrAbsent("previousContextKind", user1IsAnon, m.Equal(previousContextKind)),
 			)
 			scenarios = append(scenarios, scenario)
 		}

--- a/sdktests/server_side_events_alias.go
+++ b/sdktests/server_side_events_alias.go
@@ -16,14 +16,6 @@ type aliasEventTestScenario struct {
 	eventMatcher m.Matcher
 }
 
-func JSONPropertyOrAbsent(name string, required bool, matcher m.Matcher) m.Matcher {
-	if required {
-		return m.JSONProperty(name).Should(matcher)
-	} else {
-		return m.JSONOptProperty(name).Should(m.BeNil())
-	}
-}
-
 func doServerSideAliasEventTests(t *ldtest.T) {
 	userFactory := NewUserFactory("doServerSideAliasEventTests")
 
@@ -35,18 +27,15 @@ func doServerSideAliasEventTests(t *ldtest.T) {
 	for _, user1IsAnon := range []bool{false, true} {
 		for _, user2IsAnon := range []bool{false, true} {
 			var scenario aliasEventTestScenario
-			var newContextKind, previousContextKind = "user", "user"
 			user1 := lduser.NewUserBuilderFromUser(userFactory.NextUniqueUser())
 			user2 := lduser.NewUserBuilderFromUser(userFactory.NextUniqueUser())
 			if user1IsAnon {
 				user1.Anonymous(true)
-				previousContextKind = "anonymousUser"
 			} else {
 				user1.Name("Mina")
 			}
 			if user2IsAnon {
 				user2.Anonymous(true)
-				newContextKind = "anonymousUser"
 			} else {
 				user2.Name("Lucy")
 			}
@@ -58,8 +47,8 @@ func doServerSideAliasEventTests(t *ldtest.T) {
 				HasAnyCreationDate(),
 				m.JSONProperty("key").Should(m.Equal(scenario.params.User.GetKey())),
 				m.JSONProperty("previousKey").Should(m.Equal(scenario.params.PreviousUser.GetKey())),
-				JSONPropertyOrAbsent("contextKind", user2IsAnon, m.Equal(newContextKind)),
-				JSONPropertyOrAbsent("previousContextKind", user1IsAnon, m.Equal(previousContextKind)),
+				HasContextKind(scenario.params.User),
+				HasPreviousContextKind(scenario.params.PreviousUser),
 			)
 			scenarios = append(scenarios, scenario)
 		}


### PR DESCRIPTION
Looking at the events specification, `contextKind` and `previousContextKind` fields only need to be included in alias events if the user's `anonymous` property is true.

This PR updates the alias event tests to use the `HasContext` matcher, and additionally adds a new `HasPreviousContext` matcher.