### PR TITLE
add client-side tests for custom & alias events

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -24,6 +24,7 @@ require (
 	github.com/mattn/go-colorable v0.1.9 // indirect
 	github.com/mattn/go-isatty v0.0.14 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
-	golang.org/x/sys v0.0.0-20210809222454-d867a43fc93e // indirect
+	golang.org/x/exp v0.0.0-20220414153411-bcd21879b8fd // indirect
+	golang.org/x/sys v0.0.0-20211019181941-9d821ace8654 // indirect
 	gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -37,11 +37,15 @@ github.com/stretchr/testify v1.6.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/
 github.com/stretchr/testify v1.6.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/stretchr/testify v1.7.0 h1:nwc3DEeHmmLAfoZucVR881uASk0Mfjw8xYJ99tb5CcY=
 github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
+golang.org/x/exp v0.0.0-20220414153411-bcd21879b8fd h1:zVFyTKZN/Q7mNRWSs1GOYnHM9NiFSJ54YVRsD0rNWT4=
+golang.org/x/exp v0.0.0-20220414153411-bcd21879b8fd/go.mod h1:lgLbSvA5ygNOMpwM/9anMpWVlVJ7Z+cHWq/eFuinpGE=
 golang.org/x/sys v0.0.0-20200116001909-b77594299b42/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20200223170610-d5e6a3e2c0ae/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20210630005230-0f9fa26af87c/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20210809222454-d867a43fc93e h1:WUoyKPm6nCo1BnNUvPGnFG3T5DUVem42yDJZZ4CNxMA=
 golang.org/x/sys v0.0.0-20210809222454-d867a43fc93e/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+golang.org/x/sys v0.0.0-20211019181941-9d821ace8654 h1:id054HUawV2/6IGm2IV8KZQjqtwAOo2CYlOToYqa0d0=
+golang.org/x/sys v0.0.0-20211019181941-9d821ace8654/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127 h1:qIbj1fsPNlZgppZ+VLlY7N33q108Sa+fhmuc+sWQYwY=
 gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=

--- a/sdktests/client_side_events_all.go
+++ b/sdktests/client_side_events_all.go
@@ -11,6 +11,8 @@ import (
 func doClientSideEventTests(t *ldtest.T) {
 	t.Run("requests", doClientSideEventRequestTests)
 	t.Run("identify events", doClientSideIdentifyEventTests)
+	t.Run("custom events", doClientSideCustomEventTests)
+	t.Run("alias events", doClientSideAliasEventTests)
 	t.Run("event capacity", doClientSideEventBufferTests)
 	t.Run("disabling", doClientSideEventDisableTests)
 }
@@ -44,6 +46,16 @@ func doClientSideEventRequestTests(t *ldtest.T) {
 func doClientSideIdentifyEventTests(t *ldtest.T) {
 	NewClientSideEventTests("doClientSideIdentifyEventTests").
 		IdentifyEvents(t)
+}
+
+func doClientSideCustomEventTests(t *ldtest.T) {
+	NewClientSideEventTests("doClientSideCustomEventTests").
+		CustomEvents(t)
+}
+
+func doClientSideAliasEventTests(t *ldtest.T) {
+	NewClientSideEventTests("doClientSideAliasEventTests").
+		AliasEvents(t)
 }
 
 func doClientSideEventBufferTests(t *ldtest.T) {

--- a/sdktests/common_tests_events_alias.go
+++ b/sdktests/common_tests_events_alias.go
@@ -3,33 +3,29 @@ package sdktests
 import (
 	"fmt"
 
+	h "github.com/launchdarkly/sdk-test-harness/framework/helpers"
 	"github.com/launchdarkly/sdk-test-harness/framework/ldtest"
-	"github.com/launchdarkly/sdk-test-harness/mockld"
 	"github.com/launchdarkly/sdk-test-harness/servicedef"
 
 	m "github.com/launchdarkly/go-test-helpers/v2/matchers"
 	"gopkg.in/launchdarkly/go-sdk-common.v2/lduser"
 )
 
-type aliasEventTestScenario struct {
-	params       servicedef.AliasEventParams
-	eventMatcher m.Matcher
-}
+func (c CommonEventTests) AliasEvents(t *ldtest.T) {
+	dataSource := NewSDKDataSource(t, nil)
 
-func doServerSideAliasEventTests(t *ldtest.T) {
-	userFactory := NewUserFactory("doServerSideAliasEventTests")
-
-	dataSource := NewSDKDataSource(t, mockld.EmptyServerSDKData())
-	events := NewSDKEventSink(t)
-	client := NewSDKClient(t, dataSource, events)
+	type aliasEventTestScenario struct {
+		params       servicedef.AliasEventParams
+		eventMatcher m.Matcher
+	}
 
 	var scenarios []aliasEventTestScenario
 	for _, user1IsAnon := range []bool{false, true} {
 		for _, user2IsAnon := range []bool{false, true} {
 			var scenario aliasEventTestScenario
 			var newContextKind, previousContextKind = "user", "user"
-			user1 := lduser.NewUserBuilderFromUser(userFactory.NextUniqueUser())
-			user2 := lduser.NewUserBuilderFromUser(userFactory.NextUniqueUser())
+			user1 := lduser.NewUserBuilderFromUser(c.userFactory.NextUniqueUser())
+			user2 := lduser.NewUserBuilderFromUser(c.userFactory.NextUniqueUser())
 			if user1IsAnon {
 				user1.Anonymous(true)
 				previousContextKind = "anonymousUser"
@@ -57,14 +53,20 @@ func doServerSideAliasEventTests(t *ldtest.T) {
 		}
 	}
 	for _, scenario := range scenarios {
-		anonDesc := map[bool]string{false: "non-anonymous", true: "anonymous"}
-		testDesc := fmt.Sprintf("from %s to %s", anonDesc[scenario.params.PreviousUser.GetAnonymous()],
-			anonDesc[scenario.params.User.GetAnonymous()])
+		anonDesc := func(isAnon bool) string { return h.IfElse(isAnon, "anonymous", "non-anonymous") }
+		testDesc := fmt.Sprintf("from %s to %s", anonDesc(scenario.params.PreviousUser.GetAnonymous()),
+			anonDesc(scenario.params.User.GetAnonymous()))
+
 		t.Run(testDesc, func(t *ldtest.T) {
+			events := NewSDKEventSink(t)
+			client := NewSDKClient(t, c.baseSDKConfigurationPlus(dataSource, events)...)
+
 			client.SendAliasEvent(t, scenario.params)
 			client.FlushEvents(t)
 			payload := events.ExpectAnalyticsEvents(t, defaultEventTimeout)
-			m.In(t).Assert(payload, m.Items(scenario.eventMatcher))
+
+			m.In(t).Assert(payload, m.Items(
+				append(c.initialEventPayloadExpectations(), scenario.eventMatcher)...))
 		})
 	}
 }

--- a/sdktests/server_side_events_all.go
+++ b/sdktests/server_side_events_all.go
@@ -43,6 +43,16 @@ func doServerSideIdentifyEventTests(t *ldtest.T) {
 		IdentifyEvents(t)
 }
 
+func doServerSideCustomEventTests(t *ldtest.T) {
+	NewServerSideEventTests("doServerSideCustomEventTests").
+		CustomEvents(t)
+}
+
+func doServerSideAliasEventTests(t *ldtest.T) {
+	NewServerSideEventTests("doServerSideAliasEventTests").
+		AliasEvents(t)
+}
+
 func doServerSideEventBufferTests(t *ldtest.T) {
 	NewServerSideEventTests("doServerSideEventCapacityTests").
 		BufferBehavior(t)

--- a/sdktests/server_side_events_index.go
+++ b/sdktests/server_side_events_index.go
@@ -13,6 +13,10 @@ import (
 )
 
 func doServerSideIndexEventTests(t *ldtest.T) {
+	// These tests only apply to server-side SDKs. Client-side SDKs do not send index events, because
+	// they are guaranteed to always send the user properties in an identify event whenever the
+	// current user is changed.
+
 	// These do not include detailed tests of the properties within the user object, which are in
 	// server_side_events_users.go.
 


### PR DESCRIPTION
Similar to https://github.com/launchdarkly/sdk-test-harness/pull/69 in that 1. I've refactored the server-side versions to share a lot of the logic and 2. we are _not_ testing details of the user properties in events (like private attributes) since those will be tested separately.

These all pass against the contract-tests branch of node-client-sdk-private.