### PR TITLE
fix client-side eval reason expectation for wrong type error

### DIFF
--- a/sdktests/client_side_eval.go
+++ b/sdktests/client_side_eval.go
@@ -57,7 +57,9 @@ func runParameterizedClientSideEvalTests(t *ldtest.T) {
 					// If the client wasn't configured to request evaluation reasons, then there won't be
 					// any reasons that would have had to come from LD - but we can still get an error reason
 					// that is due to invalid SDK parameters.
-					if reason == ldreason.NewEvalReasonError(ldreason.EvalErrorFlagNotFound) {
+					switch reason {
+					case ldreason.NewEvalReasonError(ldreason.EvalErrorFlagNotFound),
+						ldreason.NewEvalReasonError(ldreason.EvalErrorWrongType):
 						return reason
 					}
 					return ldreason.EvaluationReason{}


### PR DESCRIPTION
This affects only _strongly-typed_ client-side SDKs, so the issue showed up in dotnet-client-sdk but not node-client-sdk.

The issue is this. If someone calls a VariationDetail method, but the SDK was _not_ configured to request evaluation reasons from LD, then normally that means you just won't get any reason in the returned detail object. However, some kinds of error reasons don't actually come from LD, they are generated by the SDK itself to tell the application "you can't do that"— so we _do_ expect the SDK to return a reason in that case no matter what. One such reason is "no such flag exists"; another, applicable only in strongly-typed SDKs, is "the flag variation is type X but you asked for type Y."