### PR TITLE
allow api_key scheme in auth header

### DIFF
--- a/sdktests/client_side_events_all.go
+++ b/sdktests/client_side_events_all.go
@@ -26,8 +26,11 @@ func doClientSideEventRequestTests(t *ldtest.T) {
 	eventTests := NewClientSideEventTests("doClientSideEventRequestTests.MethodAndHeaders",
 		WithCredential(envIDOrMobileKey))
 
-	authHeaderMatcher := Header("Authorization").Should(m.Equal(
-		h.IfElse(sdkKind == mockld.MobileSDK, envIDOrMobileKey, "")))
+	authHeaderMatcher := h.IfElse(
+		sdkKind == mockld.MobileSDK,
+		HasAuthorizationHeader(envIDOrMobileKey), // mobile SDKs send Authorization header
+		HasNoAuthorizationHeader(),               // JS-based SDKs do not
+	)
 	eventTests.RequestMethodAndHeaders(t, authHeaderMatcher)
 
 	requestPathMatcher := h.IfElse(

--- a/sdktests/custom_matchers_general.go
+++ b/sdktests/custom_matchers_general.go
@@ -72,6 +72,24 @@ func EvalAllFlagsValueForKeyShouldEqual(key string, value ldvalue.Value) m.Match
 	return EvalAllFlagsStateMap().Should(m.ValueForKey(key).Should(m.JSONEqual(value)))
 }
 
+// HasAuthorizationHeader is a matcher for an http.Header map that verifies that the Authorization
+// header is present and contains the specified key. Some SDKs send just the raw key, while others
+// prefix it with an "api_key" scheme identifier; the latter is more technically correct, but we
+// need to allow both since LD allows both.
+func HasAuthorizationHeader(authKey string) m.Matcher {
+	return Header("Authorization").Should(
+		m.AnyOf(
+			m.Equal(authKey),
+			m.Equal("api_key "+authKey),
+		))
+}
+
+func HasNoAuthorizationHeader() m.Matcher {
+	return Header("Authorization").Should(m.Equal(""))
+}
+
+// Header allows matchers to be applied to a specific named header from an http.Header map. It
+// assumes that there is just one value for that name (i.e. it calls Header.Get()).
 func Header(name string) m.MatcherTransform {
 	return m.Transform(
 		fmt.Sprintf("header %q", name),

--- a/sdktests/server_side_events_all.go
+++ b/sdktests/server_side_events_all.go
@@ -31,8 +31,7 @@ func doServerSideEventRequestTests(t *ldtest.T) {
 			Credential: sdkKey,
 		}))
 
-	eventTests.RequestMethodAndHeaders(t,
-		Header("Authorization").Should(m.Equal(sdkKey)))
+	eventTests.RequestMethodAndHeaders(t, HasAuthorizationHeader(sdkKey))
 
 	eventTests.RequestURLPath(t, m.Equal("/bulk"))
 

--- a/sdktests/server_side_stream_request.go
+++ b/sdktests/server_side_stream_request.go
@@ -8,6 +8,8 @@ import (
 	"github.com/launchdarkly/sdk-test-harness/mockld"
 	"github.com/launchdarkly/sdk-test-harness/servicedef"
 
+	m "github.com/launchdarkly/go-test-helpers/v2/matchers"
+
 	"github.com/stretchr/testify/assert"
 )
 
@@ -22,8 +24,7 @@ func doServerSideStreamRequestTests(t *ldtest.T) {
 
 		request := dataSource.Endpoint().RequireConnection(t, time.Second)
 
-		assert.Equal(t, sdkKey, request.Headers.Get("Authorization"))
-		assert.NotEqual(t, sdkKey, request.Headers.Get("User-Agent"))
+		m.In(t).For("request headers").Assert(request.Headers, HasAuthorizationHeader(sdkKey))
 	})
 
 	t.Run("URL path is correct when base URI has a trailing slash", func(t *ldtest.T) {


### PR DESCRIPTION
I categorized this as a client-side test fix just because currently (I think) the mobile SDKs are the only ones that like to send `Authorization: api_key xxx` rather than just `Authorization: xxx`. Including the `api_key` scheme identifier is technically a correct thing to do (and probably better than omitting it), and we haven't been consistent about it, and so the tests need to allow both (as LD does).