### PR TITLE
Update SDKConfigClientSideParams for u2c changes

### DIFF
--- a/docs/service_spec.md
+++ b/docs/service_spec.md
@@ -111,8 +111,8 @@ A `POST` request indicates that the test harness wants to start an instance of t
     * `applicationId` (string, optional): If present and non-null, the SDK should set the "application ID" property to this string.
     * `applicationVersion` (string, optional): If present and non-null, the SDK should set the "application version" property to this string.
   * `clientSide` (object): This is omitted for server-side SDKs, and required for client-side SDKs. Properties are:
-    * `initialUser` (object, required): The user properties to initialize the SDK with.
-    * `autoAliasingOptOut`, `evaluationReasons`, `useReport` (boolean, optional): These correspond to the SDK configuration properties of the same names.
+    * `initialContext` (object, required): The context properties to initialize the SDK with.
+    * `evaluationReasons`, `useReport` (boolean, optional): These correspond to the SDK configuration properties of the same names.
 
 The response to a valid request is any HTTP `2xx` status, with a `Location` header whose value is the URL of the test service resource representing this SDK client instance (that is, the one that would be used for "Close client" or "Send command" as described below).
 

--- a/servicedef/sdk_config.go
+++ b/servicedef/sdk_config.go
@@ -64,8 +64,7 @@ type SDKConfigTagsParams struct {
 }
 
 type SDKConfigClientSideParams struct {
-	InitialContext     ldcontext.Context `json:"initialUser"`
-	AutoAliasingOptOut o.Maybe[bool]     `json:"autoAliasingOptOut,omitempty"`
-	EvaluationReasons  o.Maybe[bool]     `json:"evaluationReasons,omitempty"`
-	UseReport          o.Maybe[bool]     `json:"useReport,omitempty"`
+	InitialContext    ldcontext.Context `json:"initialContext"`
+	EvaluationReasons o.Maybe[bool]     `json:"evaluationReasons,omitempty"`
+	UseReport         o.Maybe[bool]     `json:"useReport,omitempty"`
 }


### PR DESCRIPTION
- AutoAliasingOptOut is no longer supported post-u2c so we can remove
  this field from the struct.
- Since we are operating with contexts now, we should change the json
  field from `initialUser` to `initialContext`.