### PR TITLE
miscellaneous fixes for client-side U2C behavior

### DIFF
--- a/framework/helpers/generics.go
+++ b/framework/helpers/generics.go
@@ -17,3 +17,11 @@ func SliceContains[V comparable](value V, slice []V) bool {
 	}
 	return false
 }
+
+func TransformSlice[V any, W any](slice []V, fn func(V) W) []W {
+	ret := make([]W, 0, len(slice))
+	for _, element := range slice {
+		ret = append(ret, fn(element))
+	}
+	return ret
+}

--- a/framework/helpers/generics.go
+++ b/framework/helpers/generics.go
@@ -17,11 +17,3 @@ func SliceContains[V comparable](value V, slice []V) bool {
 	}
 	return false
 }
-
-func TransformSlice[V any, W any](slice []V, fn func(V) W) []W {
-	ret := make([]W, 0, len(slice))
-	for _, element := range slice {
-		ret = append(ret, fn(element))
-	}
-	return ret
-}

--- a/sdktests/client_side_poll_all.go
+++ b/sdktests/client_side_poll_all.go
@@ -51,5 +51,5 @@ func doClientSidePollRequestTest(t *ldtest.T) {
 	getPath := h.IfElse(sdkKind == mockld.MobileSDK,
 		mockld.PollingPathMobileGet,
 		strings.ReplaceAll(mockld.PollingPathJSClientGet, mockld.PollingPathEnvIDParam, envIDOrMobileKey))
-	pollTests.RequestUserProperties(t, getPath)
+	pollTests.RequestContextProperties(t, getPath)
 }

--- a/sdktests/client_side_stream_all.go
+++ b/sdktests/client_side_stream_all.go
@@ -53,7 +53,7 @@ func doClientSideStreamRequestTest(t *ldtest.T) {
 	getPath := h.IfElse(sdkKind == mockld.MobileSDK,
 		mockld.StreamingPathMobileGet,
 		strings.ReplaceAll(mockld.StreamingPathJSClientGet, mockld.PollingPathEnvIDParam, envIDOrMobileKey))
-	streamTests.RequestUserProperties(t, getPath)
+	streamTests.RequestContextProperties(t, getPath)
 }
 
 func doClientSideStreamUpdateTests(t *ldtest.T) {

--- a/sdktests/common_tests_base.go
+++ b/sdktests/common_tests_base.go
@@ -10,6 +10,16 @@ import (
 	"github.com/launchdarkly/sdk-test-harness/v2/servicedef"
 )
 
+// commonTestsBase provides shared behavior for server-side and client-side SDK tests, if their
+// behavior is similar enough to share most of the test logic. Each subcategory of tests defines
+// its own type embedding this struct (such as CommonEventTests) so that its methods can be
+// namespaced within that category.
+//
+// When we call newCommonTestsBase, it automatically determines whether this is a client-side or
+// a server-side SDK by looking up the test service capabilities. If it is a client-side SDK,
+// isClientSide is set to true, and sdkConfigurers is set to include the minimal required
+// configuration for a client-side SDK (that is, an initial user). For this to work, the test
+// logic should always use baseSDKConfigurationPlus() when creating a client.
 type commonTestsBase struct {
 	sdkKind        mockld.SDKKind
 	isClientSide   bool

--- a/sdktests/common_tests_eval.go
+++ b/sdktests/common_tests_eval.go
@@ -78,7 +78,9 @@ func (c CommonEvalParameterizedTestRunner[SDKDataType]) runTestSuite(
 
 	// We can't rely on the test framework's usual auto-closing of the client, because this method could
 	// be called multiple times for a single value of t.
-	defer client.Close()
+	defer func() {
+		_ = client.Close()
+	}()
 
 	if len(suite.Evaluations) == 1 && suite.Evaluations[0].Name == "" {
 		c.runTestEval(t, suite, suite.Evaluations[0], sdkData, client)

--- a/sdktests/common_tests_eval.go
+++ b/sdktests/common_tests_eval.go
@@ -60,7 +60,6 @@ func (c CommonEvalParameterizedTestRunner[SDKDataType]) runTestSuite(
 	t *ldtest.T,
 	suite testmodel.EvalTestSuite[SDKDataType],
 ) {
-	t.Debug("*** yo %+v", suite)
 	if suite.RequireCapability != "" {
 		t.RequireCapability(suite.RequireCapability)
 	}
@@ -76,6 +75,10 @@ func (c CommonEvalParameterizedTestRunner[SDKDataType]) runTestSuite(
 		clientConfig = c.SDKConfigurers(suite)
 	}
 	client := NewSDKClient(t, append(clientConfig, dataSource)...)
+
+	// We can't rely on the test framework's usual auto-closing of the client, because this method could
+	// be called multiple times for a single value of t.
+	defer client.Close()
 
 	if len(suite.Evaluations) == 1 && suite.Evaluations[0].Name == "" {
 		c.runTestEval(t, suite, suite.Evaluations[0], sdkData, client)

--- a/sdktests/common_tests_poll_request.go
+++ b/sdktests/common_tests_poll_request.go
@@ -12,6 +12,7 @@ import (
 	"github.com/launchdarkly/sdk-test-harness/v2/mockld"
 	"github.com/launchdarkly/sdk-test-harness/v2/servicedef"
 
+	"github.com/launchdarkly/go-sdk-common/v3/ldcontext"
 	m "github.com/launchdarkly/go-test-helpers/v2/matchers"
 )
 
@@ -75,6 +76,7 @@ func (c CommonPollingTests) RequestURLPath(t *ldtest.T, pathMatcher func(flagReq
 								c.withFlagRequestMethod(method),
 								WithClientSideConfig(servicedef.SDKConfigClientSideParams{
 									EvaluationReasons: withReasons,
+									InitialContext:    ldcontext.New("irrelevant-key"),
 								}),
 								dataSource,
 							)...)
@@ -103,7 +105,7 @@ func (c CommonPollingTests) RequestURLPath(t *ldtest.T, pathMatcher func(flagReq
 	}
 }
 
-func (c CommonPollingTests) RequestUserProperties(t *ldtest.T, getPath string) {
+func (c CommonPollingTests) RequestContextProperties(t *ldtest.T, getPath string) {
 	t.RequireCapability(servicedef.CapabilityClientSide) // server-side SDKs do not send user properties in stream requests
 
 	t.Run("context properties", func(t *ldtest.T) {

--- a/sdktests/common_tests_stream_request.go
+++ b/sdktests/common_tests_stream_request.go
@@ -12,6 +12,7 @@ import (
 	"github.com/launchdarkly/sdk-test-harness/v2/mockld"
 	"github.com/launchdarkly/sdk-test-harness/v2/servicedef"
 
+	"github.com/launchdarkly/go-sdk-common/v3/ldcontext"
 	m "github.com/launchdarkly/go-test-helpers/v2/matchers"
 )
 
@@ -78,6 +79,7 @@ func (c CommonStreamingTests) RequestURLPath(t *ldtest.T, pathMatcher func(flagR
 								append(configurers,
 									WithClientSideConfig(servicedef.SDKConfigClientSideParams{
 										EvaluationReasons: withReasons,
+										InitialContext:    ldcontext.New("irrelevant-key"),
 									}),
 									c.withFlagRequestMethod(method),
 								)...)...)
@@ -106,7 +108,7 @@ func (c CommonStreamingTests) RequestURLPath(t *ldtest.T, pathMatcher func(flagR
 	}
 }
 
-func (c CommonStreamingTests) RequestUserProperties(t *ldtest.T, getPath string) {
+func (c CommonStreamingTests) RequestContextProperties(t *ldtest.T, getPath string) {
 	t.RequireCapability(servicedef.CapabilityClientSide) // server-side SDKs do not send user properties in stream requests
 
 	t.Run("context properties", func(t *ldtest.T) {

--- a/sdktests/custom_matchers_contexts_test.go
+++ b/sdktests/custom_matchers_contexts_test.go
@@ -1,0 +1,205 @@
+package sdktests
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/launchdarkly/go-sdk-common/v3/ldcontext"
+	m "github.com/launchdarkly/go-test-helpers/v2/matchers"
+	"github.com/stretchr/testify/require"
+)
+
+func TestJSONMatchesContext(t *testing.T) {
+	type testParams struct {
+		c     ldcontext.Context
+		input string
+	}
+
+	t.Run("match", func(t *testing.T) {
+		for _, p := range []testParams{
+			{
+				c:     ldcontext.NewWithKind("a", "b"),
+				input: `{"kind": "a", "key": "b"}`,
+			},
+			{
+				c:     ldcontext.NewWithKind("a", "b"),
+				input: `{"kind": "a", "key": "b", "transient": false}`,
+			},
+			{
+				c:     ldcontext.NewWithKind("a", "b"),
+				input: `{"kind": "a", "key": "b", "_meta": {}}`,
+			},
+			{
+				c:     ldcontext.NewWithKind("a", "b"),
+				input: `{"kind": "a", "key": "b", "_meta": {"secondary": null}}`,
+			},
+			{
+				c:     ldcontext.NewWithKind("a", "b"),
+				input: `{"kind": "a", "key": "b", "_meta": {"privateAttributes": null}}`,
+			},
+			{
+				c:     ldcontext.NewWithKind("a", "b"),
+				input: `{"kind": "a", "key": "b", "_meta": {"privateAttributes": []}}`,
+			},
+			{
+				c:     ldcontext.NewBuilder("a").Transient(true).Name("b").Secondary("c").Build(),
+				input: `{"kind": "user", "key": "a", "transient": true, "name": "b", "_meta": {"secondary": "c"}}`,
+			},
+			{
+				c:     ldcontext.NewBuilder("a").Name("b").Private("d", "c").Build(),
+				input: `{"kind": "user", "key": "a", "name": "b", "_meta": {"privateAttributes": ["c", "d"]}}`,
+			},
+			{
+				c: ldcontext.NewMulti(
+					ldcontext.NewWithKind("kind1", "key1"), ldcontext.NewWithKind("kind2", "key2"),
+				),
+				input: `{"kind": "multi", "kind1": {"key": "key1"}, "kind2": {"key": "key2"}}`,
+			},
+		} {
+			t.Run(p.input, func(t *testing.T) {
+				m.In(t).Assert(json.RawMessage(p.input), JSONMatchesContext(p.c))
+			})
+		}
+	})
+
+	t.Run("non-match", func(t *testing.T) {
+		for _, p := range []testParams{
+			{
+				c:     ldcontext.NewWithKind("a", "b"),
+				input: `{"kind": "c", "key": "b"}`,
+			},
+			{
+				c:     ldcontext.NewWithKind("a", "b"),
+				input: `{"kind": "a", "key": "c"}`,
+			},
+			{
+				c:     ldcontext.NewWithKind("a", "b"),
+				input: `{"kind": "a", "key": "b", "name": "c"}`,
+			},
+			{
+				c:     ldcontext.NewWithKind("a", "b"),
+				input: `{"kind": "a", "key": "b", "attr1": "c"}`,
+			},
+			{
+				c:     ldcontext.NewWithKind("a", "b"),
+				input: `{"kind": "a", "key": "b", "transient": true}`,
+			},
+			{
+				c:     ldcontext.NewWithKind("a", "b"),
+				input: `{"kind": "a", "key": "b", "_meta": {"secondary": "c"}}`,
+			},
+			{
+				c:     ldcontext.NewWithKind("a", "b"),
+				input: `{"kind": "a", "key": "b", "_meta": {"privateAttributes": ["c", "d"]}}`,
+			},
+			{
+				c:     ldcontext.NewBuilder("a").Transient(true).Build(),
+				input: `{"kind": "user", "key": "a"}`,
+			},
+			{
+				c:     ldcontext.NewBuilder("a").Transient(true).Build(),
+				input: `{"kind": "user", "key": "a", "transient": false}`,
+			},
+			{
+				c:     ldcontext.NewBuilder("a").Secondary("b").Build(),
+				input: `{"kind": "user", "key": "a", "transient": true, "name": "b", "_meta": {"secondary": "c"}}`,
+			},
+			{
+				c:     ldcontext.NewBuilder("a").Name("b").Private("c", "d", "e").Build(),
+				input: `{"kind": "user", "key": "a", "name": "b", "_meta": {"privateAttributes": ["c", "d"]}}`,
+			},
+			{
+				c: ldcontext.NewMulti(
+					ldcontext.NewWithKind("kind1", "key1"), ldcontext.NewWithKind("kind2", "key3"),
+				),
+				input: `{"kind": "multi", "kind1": {"key": "key1"}, "kind2": {"key": "key2"}}`,
+			},
+			{
+				c: ldcontext.NewMulti(
+					ldcontext.NewWithKind("kind1", "key1"), ldcontext.NewWithKind("kind2", "key2"),
+				),
+				input: `{"kind": "multi", "kind1": {"key": "key1"}, "kind2": {"key": "key2"}, "kind3": {"key": "key3"}}`,
+			},
+			{
+				c: ldcontext.NewMulti(
+					ldcontext.NewWithKind("kind1", "key1"),
+					ldcontext.NewWithKind("kind2", "key2"),
+					ldcontext.NewWithKind("kind3", "key3"),
+				),
+				input: `{"kind": "multi", "kind1": {"key": "key1"}, "kind2": {"key": "key2"}}`,
+			},
+		} {
+			t.Run(p.input, func(t *testing.T) {
+				var parsed interface{}
+				require.NoError(t, json.Unmarshal([]byte(p.input), &parsed))
+				if pass, _ := JSONMatchesContext(p.c).Test(json.RawMessage(p.input)); pass {
+					t.Errorf("context %s should not have matched, but did", p.c)
+				}
+			})
+		}
+	})
+}
+
+func TestJSONMatchesEventContext(t *testing.T) {
+	// Here we're trusting that the logic is all the same except for the redacted attributes
+
+	type testParams struct {
+		c                ldcontext.Context
+		input            string
+		redactedShouldBe []string
+	}
+
+	t.Run("match", func(t *testing.T) {
+		for _, p := range []testParams{
+			{
+				c:     ldcontext.NewWithKind("a", "b"),
+				input: `{"kind": "a", "key": "b"}`,
+			},
+			{
+				c:     ldcontext.NewWithKind("a", "b"),
+				input: `{"kind": "a", "key": "b", "_meta": {"redactedAttributes": null}}`,
+			},
+			{
+				c:     ldcontext.NewWithKind("a", "b"),
+				input: `{"kind": "a", "key": "b", "_meta": {"redactedAttributes": []}}`,
+			},
+			{
+				c:                ldcontext.New("a"),
+				input:            `{"kind": "user", "key": "a", "_meta": {"redactedAttributes": ["b", "c"]}}`,
+				redactedShouldBe: []string{"c", "b"},
+			},
+		} {
+			t.Run(p.input, func(t *testing.T) {
+				m.In(t).Assert(json.RawMessage(p.input), JSONMatchesEventContext(p.c, p.redactedShouldBe))
+			})
+		}
+	})
+
+	t.Run("non-match", func(t *testing.T) {
+		for _, p := range []testParams{
+			{
+				c:                ldcontext.New("a"),
+				input:            `{"kind": "user", "key": "a"}`,
+				redactedShouldBe: []string{"b"},
+			},
+			{
+				c:                ldcontext.New("a"),
+				input:            `{"kind": "user", "key": "a", "_meta": {"redactedAttributes": ["b", "c"]}}`,
+				redactedShouldBe: []string{"b"},
+			},
+			{
+				c:                ldcontext.NewBuilder("a").Private("b").Build(),
+				input:            `{"kind": "user", "key": "a", "_meta": {"privateAttributes": ["b"]}}`,
+				redactedShouldBe: []string{"b"},
+			},
+		} {
+			t.Run(p.input, func(t *testing.T) {
+				var parsed interface{}
+				require.NoError(t, json.Unmarshal([]byte(p.input), &parsed))
+				if pass, _ := JSONMatchesEventContext(p.c, p.redactedShouldBe).Test(json.RawMessage(p.input)); pass {
+					t.Errorf("context %s should not have matched (wanted redacted attributes: %v), but did", p.c, p.redactedShouldBe)
+				}
+			})
+		}
+	})
+}

--- a/sdktests/custom_matchers_events.go
+++ b/sdktests/custom_matchers_events.go
@@ -1,8 +1,6 @@
 package sdktests
 
 import (
-	"strings"
-
 	"github.com/launchdarkly/go-sdk-common/v3/ldcontext"
 	m "github.com/launchdarkly/go-test-helpers/v2/matchers"
 )
@@ -106,21 +104,4 @@ func IsValidSummaryEventWithFlags(keyValueMatchers ...m.KeyValueMatcher) m.Match
 		JSONPropertyKeysCanOnlyBe("kind", "startDate", "endDate", "features"),
 		m.JSONProperty("features").Should(m.MapOf(keyValueMatchers...)),
 	)
-}
-
-// RedactedAttributesAre is a matcher for the value of an event context's redactedAttributes property,
-// verifying that it has the specified attribute names/references and no others. This is not just a
-// plain slice match, because 1. they can be in any order and 2. for simple attribute names, the SDK
-// is allowed to send either "name" or "/name" (with any slashes or tildes escaped in the latter case).
-func RedactedAttributesAre(attrStrings ...string) m.Matcher {
-	matchers := make([]m.Matcher, 0, len(attrStrings))
-	for _, s := range attrStrings {
-		if strings.HasPrefix(s, "/") {
-			matchers = append(matchers, m.Equal(s))
-		} else {
-			escapedName := strings.ReplaceAll(strings.ReplaceAll(s, "~", "~0"), "/", "~1")
-			matchers = append(matchers, m.AnyOf(m.Equal(s), m.Equal("/"+escapedName)))
-		}
-	}
-	return m.ItemsInAnyOrder(matchers...)
 }


### PR DESCRIPTION
The initial implementation of U2C tests was for server-side. Client-side tests had been merged forward from the main branch, but hadn't yet been tested against a client-side U2C SDK, and there were various problems that showed up once I started testing against an in-progress dotnet-client-sdk.