### PR TITLE
rename "transient" back to "anonymous"

### DIFF
--- a/data/context_factory.go
+++ b/data/context_factory.go
@@ -141,7 +141,7 @@ func NewContextFactoriesForExercisingAllAttributes(
 	setAllAttributes := func(b *ldcontext.Builder) {
 		b.Name("a").
 			Secondary("b").
-			Transient(true).
+			Anonymous(true).
 			SetBool("c", true).
 			SetInt("d", 1).
 			SetFloat64("e", 1.5).

--- a/data/data-files/server-side-eval/builtin-attrs.yml
+++ b/data/data-files/server-side-eval/builtin-attrs.yml
@@ -38,14 +38,14 @@ parameters:
     CLAUSE: { attribute: "name", op: "in", values: [""], negate: true }
     EXPECT: <IS_NOT_MATCH>
 
-  - NAME: transient match false
+  - NAME: anonymous match false
     CONTEXT: { kind: "user", key: "a" }
-    CLAUSE: { attribute: "transient", op: "in", values: [false] }
+    CLAUSE: { attribute: "anonymous", op: "in", values: [false] }
     EXPECT: <IS_MATCH>
 
-  - NAME: transient match true
-    CONTEXT: { kind: "user", key: "a", transient: true }
-    CLAUSE: { attribute: "transient", op: "in", values: [true] }
+  - NAME: anonymous match true
+    CONTEXT: { kind: "user", key: "a", anonymous: true }
+    CLAUSE: { attribute: "anonymous", op: "in", values: [true] }
     EXPECT: <IS_MATCH>
 
 sdkData:

--- a/docs/service_spec.md
+++ b/docs/service_spec.md
@@ -237,7 +237,7 @@ The `contextBuild` property in the request body will be a JSON object with these
   * `kind` (string, optional): Even though a context always has a kind, this is optional because the builder should use `"user"` as a default.
   * `key` (string, required)
   * `name` (string, optional)
-  * `transient` (boolean, optional)
+  * `anonymous` (boolean, optional)
   * `secondary` (string, optional)
   * `private` (array of strings, optional): These strings should be treated as attribute references, i.e. they may be slash-delimited paths.
   * `custom` (object, optional): If present, these are name-value pairs for custom attributes.

--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/gorilla/mux v1.8.0
 	github.com/launchdarkly/eventsource v1.6.2
 	github.com/launchdarkly/go-jsonstream/v2 v2.0.0
-	github.com/launchdarkly/go-sdk-common/v3 v3.0.0-alpha.pub.6
+	github.com/launchdarkly/go-sdk-common/v3 v3.0.0-alpha.pub.7
 	github.com/launchdarkly/go-server-sdk-evaluation/v2 v2.0.0-alpha.pub.4
 	github.com/launchdarkly/go-test-helpers/v2 v2.3.2
 	github.com/stretchr/testify v1.7.0

--- a/go.sum
+++ b/go.sum
@@ -16,8 +16,9 @@ github.com/launchdarkly/eventsource v1.6.2 h1:5SbcIqzUomn+/zmJDrkb4LYw7ryoKFzH/0
 github.com/launchdarkly/eventsource v1.6.2/go.mod h1:LHxSeb4OnqznNZxCSXbFghxS/CjIQfzHovNoAqbO/Wk=
 github.com/launchdarkly/go-jsonstream/v2 v2.0.0 h1:5NBbJmQAiUVVfAGR6tPuMITGO2+8mxLD0Azyeqgq5Yw=
 github.com/launchdarkly/go-jsonstream/v2 v2.0.0/go.mod h1:8WhgeCtJdsc7VXg7tSzQmCYnw+nRAo5ReOLhVYcLiJk=
-github.com/launchdarkly/go-sdk-common/v3 v3.0.0-alpha.pub.6 h1:/M5tUOTx8ZtOaJVs6leESggt6YQuYWkgo+fFkL9yykE=
 github.com/launchdarkly/go-sdk-common/v3 v3.0.0-alpha.pub.6/go.mod h1:YnR3wgQ71r/ORkZeMG2OPAZFrb9Xcd5rH3QKiK3Z45A=
+github.com/launchdarkly/go-sdk-common/v3 v3.0.0-alpha.pub.7 h1:LWWaAgPBJzaHh5h/drTmhKOEUEF453eZv/MTW3uM7GI=
+github.com/launchdarkly/go-sdk-common/v3 v3.0.0-alpha.pub.7/go.mod h1:YnR3wgQ71r/ORkZeMG2OPAZFrb9Xcd5rH3QKiK3Z45A=
 github.com/launchdarkly/go-semver v1.0.2 h1:sYVRnuKyvxlmQCnCUyDkAhtmzSFRoX6rG2Xa21Mhg+w=
 github.com/launchdarkly/go-semver v1.0.2/go.mod h1:xFmMwXba5Mb+3h72Z+VeSs9ahCvKo2QFUTHRNHVqR28=
 github.com/launchdarkly/go-server-sdk-evaluation/v2 v2.0.0-alpha.pub.4 h1:TD8HPFi42lp2cZzGxcEY98qtL0MDCNxv6vJ21B5MHos=

--- a/sdktests/common_tests_events_contexts.go
+++ b/sdktests/common_tests_events_contexts.go
@@ -51,20 +51,20 @@ func makeEventContextTestParams() []eventContextTestParams {
 					b.Name("a")
 					b.SetString("b", "c")
 					b.Secondary("s")
-					b.Transient(true)
+					b.Anonymous(true)
 				})
 			},
 		},
 		{
 			name: "single-kind, allAttributesPrivate",
-			// proves that name and custom attributes are redacted, key/transient/meta are not
+			// proves that name and custom attributes are redacted, key/anonymous/meta are not
 			eventsConfig: servicedef.SDKConfigEventParams{AllAttributesPrivate: true},
 			contextFactory: func(prefix string) *data.ContextFactory {
 				return data.NewContextFactory(prefix, func(b *ldcontext.Builder) {
 					b.Name("a")
 					b.SetString("b", "c")
 					b.Secondary("s")
-					b.Transient(true)
+					b.Anonymous(true)
 				})
 			},
 			outputContext: func(c ldcontext.Context) ldcontext.Context {

--- a/sdktests/custom_matchers_contexts.go
+++ b/sdktests/custom_matchers_contexts.go
@@ -13,7 +13,7 @@ import (
 // endpoints), not the event schema.
 //
 // The matcher should be tolerant of all allowable variants: for instance, it is legal to include
-// `"transient": false` in the representation rather than omitting transient.
+// `"anonymous": false` in the representation rather than omitting anonymous.
 func JSONMatchesContext(context ldcontext.Context) m.Matcher {
 	return jsonMatchesContext(context, false, nil)
 }
@@ -23,7 +23,7 @@ func JSONMatchesContext(context ldcontext.Context) m.Matcher {
 // private attribute redaction; redactedShouldBe specifies what we expect to see in redactedAttributes.
 //
 // The matcher should be tolerant of all allowable variants: for instance, it is legal to include
-// `"transient": false` in the representation rather than omitting transient, and attribute names that
+// `"anonymous": false` in the representation rather than omitting anonymous, and attribute names that
 // appear in redactedAttributes could either use the literal syntax or the slash syntax.
 func JSONMatchesEventContext(context ldcontext.Context, redactedShouldBe []string) m.Matcher {
 	return jsonMatchesContext(context, true, redactedShouldBe)
@@ -37,12 +37,12 @@ func jsonMatchesContext(topLevelContext ldcontext.Context, isEventContext bool, 
 			keys = append(keys, "kind")
 			ms = append(ms, m.JSONProperty("kind").Should(m.Equal(string(c.Kind()))))
 		}
-		keys = append(keys, "key", "transient", "_meta")
+		keys = append(keys, "key", "anonymous", "_meta")
 		ms = append(ms, m.JSONProperty("key").Should(m.Equal(c.Key())))
-		if c.Transient() {
-			ms = append(ms, m.JSONProperty("transient").Should(m.Equal(true)))
+		if c.Anonymous() {
+			ms = append(ms, m.JSONProperty("anonymous").Should(m.Equal(true)))
 		} else {
-			ms = append(ms, JSONPropertyNullOrAbsentOrEqualTo("transient", false))
+			ms = append(ms, JSONPropertyNullOrAbsentOrEqualTo("anonymous", false))
 		}
 		for _, attr := range c.GetOptionalAttributeNames(nil) {
 			if value := c.GetValue(attr); value.IsDefined() {

--- a/sdktests/custom_matchers_contexts_test.go
+++ b/sdktests/custom_matchers_contexts_test.go
@@ -23,7 +23,7 @@ func TestJSONMatchesContext(t *testing.T) {
 			},
 			{
 				c:     ldcontext.NewWithKind("a", "b"),
-				input: `{"kind": "a", "key": "b", "transient": false}`,
+				input: `{"kind": "a", "key": "b", "anonymous": false}`,
 			},
 			{
 				c:     ldcontext.NewWithKind("a", "b"),
@@ -42,8 +42,8 @@ func TestJSONMatchesContext(t *testing.T) {
 				input: `{"kind": "a", "key": "b", "_meta": {"privateAttributes": []}}`,
 			},
 			{
-				c:     ldcontext.NewBuilder("a").Transient(true).Name("b").Secondary("c").Build(),
-				input: `{"kind": "user", "key": "a", "transient": true, "name": "b", "_meta": {"secondary": "c"}}`,
+				c:     ldcontext.NewBuilder("a").Anonymous(true).Name("b").Secondary("c").Build(),
+				input: `{"kind": "user", "key": "a", "anonymous": true, "name": "b", "_meta": {"secondary": "c"}}`,
 			},
 			{
 				c:     ldcontext.NewBuilder("a").Name("b").Private("d", "c").Build(),
@@ -82,7 +82,7 @@ func TestJSONMatchesContext(t *testing.T) {
 			},
 			{
 				c:     ldcontext.NewWithKind("a", "b"),
-				input: `{"kind": "a", "key": "b", "transient": true}`,
+				input: `{"kind": "a", "key": "b", "anonymous": true}`,
 			},
 			{
 				c:     ldcontext.NewWithKind("a", "b"),
@@ -93,16 +93,16 @@ func TestJSONMatchesContext(t *testing.T) {
 				input: `{"kind": "a", "key": "b", "_meta": {"privateAttributes": ["c", "d"]}}`,
 			},
 			{
-				c:     ldcontext.NewBuilder("a").Transient(true).Build(),
+				c:     ldcontext.NewBuilder("a").Anonymous(true).Build(),
 				input: `{"kind": "user", "key": "a"}`,
 			},
 			{
-				c:     ldcontext.NewBuilder("a").Transient(true).Build(),
-				input: `{"kind": "user", "key": "a", "transient": false}`,
+				c:     ldcontext.NewBuilder("a").Anonymous(true).Build(),
+				input: `{"kind": "user", "key": "a", "anonymous": false}`,
 			},
 			{
 				c:     ldcontext.NewBuilder("a").Secondary("b").Build(),
-				input: `{"kind": "user", "key": "a", "transient": true, "name": "b", "_meta": {"secondary": "c"}}`,
+				input: `{"kind": "user", "key": "a", "anonymous": true, "name": "b", "_meta": {"secondary": "c"}}`,
 			},
 			{
 				c:     ldcontext.NewBuilder("a").Name("b").Private("c", "d", "e").Build(),

--- a/sdktests/sdk_context_type.go
+++ b/sdktests/sdk_context_type.go
@@ -49,10 +49,10 @@ func doSDKContextBuildTests(t *ldtest.T) {
 				`{"kind": "org", "key": "a"}`},
 			{servicedef.ContextBuildSingleParams{Key: "a", Name: optStr("b")},
 				`{"kind": "user", "key": "a", "name": "b"}`},
-			{servicedef.ContextBuildSingleParams{Key: "a", Transient: optBool(false)},
+			{servicedef.ContextBuildSingleParams{Key: "a", Anonymous: optBool(false)},
 				`{"kind": "user", "key": "a"}`},
-			{servicedef.ContextBuildSingleParams{Key: "a", Transient: optBool(true)},
-				`{"kind": "user", "key": "a", "transient": true}`},
+			{servicedef.ContextBuildSingleParams{Key: "a", Anonymous: optBool(true)},
+				`{"kind": "user", "key": "a", "anonymous": true}`},
 			{servicedef.ContextBuildSingleParams{Key: "a", Secondary: optStr("b")},
 				`{"kind": "user", "key": "a", "_meta": {"secondary": "b"}}`},
 			{servicedef.ContextBuildSingleParams{Key: "a", Private: []string{"b"}},
@@ -126,7 +126,7 @@ func doSDKContextConvertTests(t *ldtest.T) {
 		singleKindProps := []string{
 			``,
 			`"name": "b"`,
-			`"transient": true`,
+			`"anonymous": true`,
 			`"attr1": "first"`,                    // basic case of 1 custom attr
 			`"attr1": "first", "attr2": "second"`, // basic case of multiple custom attrs
 			`"_meta": {"secondary": "b"}`,
@@ -194,7 +194,7 @@ func doSDKContextConvertTests(t *ldtest.T) {
 		params := []contextConversionParams{
 			{`{"key": ""}`, `{"kind": "user", "key": ""}`}, // empty key *is* allowed for old user format only
 			{`{"key": "a"}`, `{"kind": "user", "key": "a"}`},
-			{`{"key": "a", "anonymous": true}`, `{"kind": "user", "key": "a", "transient": true}`},
+			{`{"key": "a", "anonymous": true}`, `{"kind": "user", "key": "a", "anonymous": true}`},
 			{`{"key": "a", "anonymous": false}`, `{"kind": "user", "key": "a"}`},
 			{`{"key": "a", "secondary": "b"}`, `{"kind": "user", "key": "a", "_meta": {"secondary": "b"}}`},
 			{`{"key": "a", "secondary": null}`, `{"kind": "user", "key": "a"}`},
@@ -243,8 +243,8 @@ func doSDKContextConvertTests(t *ldtest.T) {
 			`{"kind": "org", "key": null}`,
 			`{"kind": "org", "key": 3}`,
 			`{"kind": "org", "name": 3}`,
-			`{"kind": "org", "transient": null}`,
-			`{"kind": "org", "transient": "yes"}`,
+			`{"kind": "org", "anonymous": null}`,
+			`{"kind": "org", "anonymous": "yes"}`,
 			`{"kind": "org", "_meta": {"secondary": 3}}`,
 			`{"kind": "org", "_meta": {"privateAttributes": 3}}`,
 			`{"kind": "org", "_meta": {"privateAttributes": {}}}`,

--- a/servicedef/command_params.go
+++ b/servicedef/command_params.go
@@ -91,7 +91,7 @@ type ContextBuildSingleParams struct {
 	Kind      *string                  `json:"kind,omitempty"`
 	Key       string                   `json:"key"`
 	Name      *string                  `json:"name,omitempty"`
-	Transient *bool                    `json:"transient,omitempty"`
+	Anonymous *bool                    `json:"anonymous,omitempty"`
 	Secondary *string                  `json:"secondary,omitempty"`
 	Private   []string                 `json:"private,omitempty"`
 	Custom    map[string]ldvalue.Value `json:"custom,omitempty"`


### PR DESCRIPTION
Corresponds to https://github.com/launchdarkly/go-sdk-common-private/pull/83.