### PR TITLE
add more validation tests for user/context JSON

### DIFF
--- a/sdktests/sdk_context_type.go
+++ b/sdktests/sdk_context_type.go
@@ -172,6 +172,7 @@ func doSDKContextConvertTests(t *ldtest.T) {
 		for _, extraProps := range []string{
 			`"name": null`,
 			`"attr1": null`,
+			`"_meta": null`,
 			`"_meta": {}`,
 			`"_meta": {"secondary": null}`,
 			`"_meta": {"privateAttributes": null}`,
@@ -194,8 +195,19 @@ func doSDKContextConvertTests(t *ldtest.T) {
 		params := []contextConversionParams{
 			{`{"key": ""}`, `{"kind": "user", "key": ""}`}, // empty key *is* allowed for old user format only
 			{`{"key": "a"}`, `{"kind": "user", "key": "a"}`},
+			{`{"key": "a"}`, `{"kind": "user", "key": "a"}`},
+			{`{"key": "a", "custom": {"b": true}}`, `{"kind": "user", "key": "a", "b": true}`},
+			{`{"key": "a", "custom": {"b": 1}}`, `{"kind": "user", "key": "a", "b": 1}`},
+			{`{"key": "a", "custom": {"b": "c"}}`, `{"kind": "user", "key": "a", "b": "c"}`},
+			{`{"key": "a", "custom": {"b": [1, 2]}}`, `{"kind": "user", "key": "a", "b": [1, 2]}`},
+			{`{"key": "a", "custom": {"b": {"c": 1}}}`, `{"kind": "user", "key": "a", "b": {"c": 1}}`},
+			{`{"key": "a", "custom": {"b": 1, "c": 2}}`, `{"kind": "user", "key": "a", "b": 1, "c": 2}`},
+			{`{"key": "a", "custom": {"b": 1, "c": null}}`, `{"kind": "user", "key": "a", "b": 1}`},
+			{`{"key": "a", "custom": {}}`, `{"kind": "user", "key": "a"}`},
+			{`{"key": "a", "custom": null}`, `{"kind": "user", "key": "a"}`},
 			{`{"key": "a", "anonymous": true}`, `{"kind": "user", "key": "a", "anonymous": true}`},
 			{`{"key": "a", "anonymous": false}`, `{"kind": "user", "key": "a"}`},
+			{`{"key": "a", "anonymous": null}`, `{"kind": "user", "key": "a"}`},
 			{`{"key": "a", "secondary": "b"}`, `{"kind": "user", "key": "a", "_meta": {"secondary": "b"}}`},
 			{`{"key": "a", "secondary": null}`, `{"kind": "user", "key": "a"}`},
 			{`{"key": "a", "privateAttributeNames": ["b"]}`,
@@ -291,6 +303,8 @@ func doSDKContextConvertTests(t *ldtest.T) {
 		inputs := []string{
 			`{}`,
 			`{"key": true}`,
+			`{"key": "a", "custom": 3}`,
+			`{"key": "a", "custom": []}`,
 			`{"key": "a", "anonymous": 3}`,
 			`{"key": "a", "secondary": 3}`,
 			`{"key": "a", "privateAttributeNames": 3"}`,


### PR DESCRIPTION
* `"custom": null` in an old-style user is valid
* so is `"custom": {}`
* also add tests for custom properties with various value types, to make sure they're all migrated correctly to context attributes
* `"anonymous": null` in an old-style user is valid
* `"_meta": null` in a context is valid, treated as equivalent to `"meta": {}` (*)

(*) In general we need to tolerate nulls for both arrays & objects in our JSON schemas unless the property really is mandatory. JSON serializers in many languages can easily end up emitting a null for empty things, and there's no point in making it that easy to break parsing when the intention is clear.