### PR TITLE
use our own implementation of Eventually/Never assertions to avoid panics

### DIFF
--- a/framework/helpers/assertions.go
+++ b/framework/helpers/assertions.go
@@ -1,0 +1,100 @@
+package helpers
+
+import (
+	"time"
+)
+
+// Calls testFn repeatedly at intervals until the expected value is seen or the timeout elapses.
+// Returns true if the value was matched, false if timed out.
+func PollForSpecificResultValue[V comparable](
+	testFn func() V,
+	timeout time.Duration,
+	interval time.Duration,
+	expectedValue V,
+) bool {
+	ticker := time.NewTicker(interval)
+	defer ticker.Stop()
+	deadline := time.NewTimer(timeout)
+	defer deadline.Stop()
+	for {
+		select {
+		case <-deadline.C:
+			return false
+		case <-ticker.C:
+			if testFn() == expectedValue {
+				return true
+			}
+		}
+	}
+}
+
+// Equivalent to assert.Eventually from stretchr/testify/assert, except that it does not use a
+// separate goroutine so it does not cause problems with our test framework. It calls testFn
+// repeatedly at intervals until it gets a true value; if the timeout elapses, the test fails.
+func AssertEventually(
+	t TestContext,
+	testFn func() bool,
+	timeout time.Duration,
+	interval time.Duration,
+	failureMsgFormat string,
+	failureMsgArgs ...interface{},
+) bool {
+	if PollForSpecificResultValue(testFn, timeout, interval, true) {
+		return true
+	}
+	t.Errorf(failureMsgFormat, failureMsgArgs...)
+	return false
+}
+
+// Equivalent to require.Eventually from stretchr/testify/assert, except that it does not use a
+// separate goroutine so it does not cause problems with our test framework. It calls testFn
+// repeatedly at intervals until it gets a true value; if the timeout elapses, the test fails
+// and immediately exits.
+func RequireEventually(
+	t TestContext,
+	testFn func() bool,
+	timeout time.Duration,
+	interval time.Duration,
+	failureMsgFormat string,
+	failureMsgArgs ...interface{},
+) {
+	if !AssertEventually(t, testFn, timeout, interval, failureMsgFormat, failureMsgArgs...) {
+		t.FailNow()
+	}
+}
+
+// Equivalent to assert.Never from stretchr/testify/assert, except that it does not use a
+// separate goroutine so it does not cause problems with our test framework. It calls testFn
+// repeatedly at intervals until either the timeout elapses or it receives a true value; if
+// it receives a true value, the test fails.
+func AssertNever(
+	t TestContext,
+	testFn func() bool,
+	timeout time.Duration,
+	interval time.Duration,
+	failureMsgFormat string,
+	failureMsgArgs ...interface{},
+) bool {
+	if PollForSpecificResultValue(testFn, timeout, interval, true) {
+		t.Errorf(failureMsgFormat, failureMsgArgs...)
+		return false
+	}
+	return true
+}
+
+// Equivalent to require.Never from stretchr/testify/assert, except that it does not use a
+// separate goroutine so it does not cause problems with our test framework. It calls testFn
+// repeatedly at intervals until either the timeout elapses or it receives a true value; if
+// it receives a true value, the test fails and exits immediately
+func RequireNever(
+	t TestContext,
+	testFn func() bool,
+	timeout time.Duration,
+	interval time.Duration,
+	failureMsgFormat string,
+	failureMsgArgs ...interface{},
+) {
+	if !AssertNever(t, testFn, timeout, interval, failureMsgFormat, failureMsgArgs...) {
+		t.FailNow()
+	}
+}

--- a/framework/helpers/assertions_test.go
+++ b/framework/helpers/assertions_test.go
@@ -1,0 +1,94 @@
+package helpers
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func makePollTestFn[V any](initialValue, finalValue V, countBeforeFinalValue int) func() V {
+	counter := 0
+	return func() V {
+		counter++
+		if counter <= countBeforeFinalValue {
+			return initialValue
+		}
+		return finalValue
+	}
+
+}
+
+func TestPollForSpecificResultValue(t *testing.T) {
+	t.Run("value is seen", func(t *testing.T) {
+		assert.True(t, PollForSpecificResultValue(makePollTestFn("a", "b", 1), time.Second, time.Millisecond, "b"))
+	})
+
+	t.Run("value is not seen", func(t *testing.T) {
+		assert.False(t, PollForSpecificResultValue(makePollTestFn("a", "b", 100), time.Millisecond*10, time.Millisecond, "b"))
+	})
+}
+
+func TestEventually(t *testing.T) {
+	t.Run("value is seen", func(t *testing.T) {
+		var tr1 TestRecorder
+		result := AssertEventually(&tr1, makePollTestFn(false, true, 1), time.Second, time.Millisecond, "sorry %s", "no")
+		assert.True(t, result)
+		assert.Len(t, tr1.Errors, 0)
+		assert.False(t, tr1.Terminated)
+
+		var tr2 TestRecorder
+		RequireEventually(&tr2, makePollTestFn(false, true, 1), time.Second, time.Millisecond, "sorry %s", "no")
+		assert.Len(t, tr2.Errors, 0)
+		assert.False(t, tr2.Terminated)
+	})
+
+	t.Run("value is not seen", func(t *testing.T) {
+		var tr1 TestRecorder
+		result := AssertEventually(&tr1, makePollTestFn(false, true, 100), time.Millisecond*10, time.Millisecond, "sorry %s", "no")
+		assert.False(t, result)
+		if assert.Len(t, tr1.Errors, 1) {
+			assert.Equal(t, "sorry no", tr1.Errors[0])
+		}
+		assert.False(t, tr1.Terminated)
+
+		var tr2 TestRecorder
+		RequireEventually(&tr2, makePollTestFn(false, true, 100), time.Millisecond*10, time.Millisecond, "sorry %s", "no")
+		if assert.Len(t, tr2.Errors, 1) {
+			assert.Equal(t, "sorry no", tr2.Errors[0])
+		}
+		assert.True(t, tr2.Terminated)
+	})
+}
+
+func TestNever(t *testing.T) {
+	t.Run("value is seen", func(t *testing.T) {
+		var tr1 TestRecorder
+		result := AssertNever(&tr1, makePollTestFn(false, true, 1), time.Second, time.Millisecond, "sorry %s", "no")
+		assert.False(t, result)
+		if assert.Len(t, tr1.Errors, 1) {
+			assert.Equal(t, "sorry no", tr1.Errors[0])
+			assert.False(t, tr1.Terminated)
+		}
+
+		var tr2 TestRecorder
+		RequireNever(&tr2, makePollTestFn(false, true, 1), time.Second, time.Millisecond, "sorry %s", "no")
+		if assert.Len(t, tr2.Errors, 1) {
+			assert.Equal(t, "sorry no", tr2.Errors[0])
+		}
+		assert.True(t, tr2.Terminated)
+	})
+
+	t.Run("value is not seen", func(t *testing.T) {
+		var tr1 TestRecorder
+		result := AssertNever(&tr1, makePollTestFn(false, true, 100), time.Millisecond*10, time.Millisecond, "sorry %s", "no")
+		assert.True(t, result)
+		assert.Len(t, tr1.Errors, 0)
+		assert.False(t, tr1.Terminated)
+
+		var tr2 TestRecorder
+		RequireNever(&tr2, makePollTestFn(false, true, 100), time.Millisecond*10, time.Millisecond, "sorry %s", "no")
+		assert.Len(t, tr2.Errors, 0)
+		assert.False(t, tr2.Terminated)
+	})
+}

--- a/framework/ldtest/assertions.go
+++ b/framework/ldtest/assertions.go
@@ -1,0 +1,1 @@
+package ldtest

--- a/sdktests/common_tests_stream_updates.go
+++ b/sdktests/common_tests_stream_updates.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/launchdarkly/go-test-helpers/v2/jsonhelpers"
 	m "github.com/launchdarkly/go-test-helpers/v2/matchers"
+	"github.com/launchdarkly/sdk-test-harness/framework/helpers"
 	h "github.com/launchdarkly/sdk-test-harness/framework/helpers"
 	"github.com/launchdarkly/sdk-test-harness/framework/ldtest"
 	o "github.com/launchdarkly/sdk-test-harness/framework/opt"
@@ -174,7 +175,7 @@ func (c CommonStreamingTests) Updates(t *ldtest.T) {
 				// A delete for an unknown flag should be persisted by the SDK so it knows this version was
 				// deleted. A subsequent update for the same flag with an equal or lower version should be ignored.
 				stream.StreamingService().PushUpdate("flags", flagKey, updateData)
-				require.Never(
+				helpers.RequireNever(
 					t,
 					checkForUpdatedValue(t, client, flagKey, user, defaultValue, valueAfter, defaultValue),
 					time.Millisecond*100,

--- a/sdktests/helpers.go
+++ b/sdktests/helpers.go
@@ -11,18 +11,17 @@ import (
 	"strings"
 	"time"
 
+	"github.com/launchdarkly/sdk-test-harness/framework/helpers"
 	"github.com/launchdarkly/sdk-test-harness/framework/ldtest"
 	o "github.com/launchdarkly/sdk-test-harness/framework/opt"
 	"github.com/launchdarkly/sdk-test-harness/mockld"
 	"github.com/launchdarkly/sdk-test-harness/servicedef"
+	"github.com/stretchr/testify/require"
 
 	"gopkg.in/launchdarkly/go-sdk-common.v2/lduser"
 	"gopkg.in/launchdarkly/go-sdk-common.v2/ldvalue"
 	"gopkg.in/launchdarkly/go-server-sdk-evaluation.v1/ldbuilders"
 	"gopkg.in/launchdarkly/go-server-sdk-evaluation.v1/ldmodel"
-
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 )
 
 var dummyValue0, dummyValue1, dummyValue2, dummyValue3 ldvalue.Value = ldvalue.String("a"), //nolint:gochecknoglobals
@@ -202,7 +201,7 @@ func checkForUpdatedValue(
 			return true
 		}
 		if !actualValue.Equal(previousValue) {
-			assert.Fail(t, "SDK returned neither previous value nor updated value",
+			require.Fail(t, "SDK returned neither previous value nor updated value",
 				"previous: %s, updated: %s, actual: %s", previousValue, updatedValue, actualValue)
 		}
 		return false
@@ -225,9 +224,7 @@ func pollUntilFlagValueUpdated(
 	updatedValue ldvalue.Value,
 	defaultValue ldvalue.Value,
 ) {
-	// We can't assume that the SDK will immediately apply the new flag data as soon as it has
-	// reconnected, so we have to poll till the new data shows up
-	require.Eventually(
+	helpers.RequireEventually(
 		t,
 		checkForUpdatedValue(t, client, flagKey, user, previousValue, updatedValue, defaultValue),
 		time.Second, time.Millisecond*50, "timed out without seeing updated flag value")

--- a/sdktests/server_side_big_segments.go
+++ b/sdktests/server_side_big_segments.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/launchdarkly/sdk-test-harness/framework/helpers"
 	"github.com/launchdarkly/sdk-test-harness/framework/ldtest"
 	o "github.com/launchdarkly/sdk-test-harness/framework/opt"
 	"github.com/launchdarkly/sdk-test-harness/mockld"
@@ -270,7 +271,7 @@ func doBigSegmentsMembershipCachingTests(t *ldtest.T) {
 		bigSegmentStore.SetupMemberships(t, map[string]map[string]bool{
 			expectedUserHash1: {segmentRef1: false}})
 
-		assert.Eventually(
+		helpers.AssertEventually(
 			t,
 			func() bool {
 				value := basicEvaluateFlag(t, client, flag.Key, user1, ldvalue.Null())
@@ -385,7 +386,7 @@ func doBigSegmentsStatusPollingTests(t *ldtest.T) {
 				Available: newStatus != ldreason.BigSegmentsStoreError,
 				Stale:     newStatus == ldreason.BigSegmentsStale,
 			}
-			assert.Eventually(
+			helpers.AssertEventually(
 				t,
 				func() bool {
 					status := client.GetBigSegmentStoreStatus(t)

--- a/sdktests/server_side_events_summary.go
+++ b/sdktests/server_side_events_summary.go
@@ -3,6 +3,7 @@ package sdktests
 import (
 	"time"
 
+	"github.com/launchdarkly/sdk-test-harness/framework/helpers"
 	"github.com/launchdarkly/sdk-test-harness/framework/ldtest"
 	o "github.com/launchdarkly/sdk-test-harness/framework/opt"
 	"github.com/launchdarkly/sdk-test-harness/mockld"
@@ -14,8 +15,6 @@ import (
 	"gopkg.in/launchdarkly/go-sdk-common.v2/ldvalue"
 	"gopkg.in/launchdarkly/go-server-sdk-evaluation.v1/ldbuilders"
 	"gopkg.in/launchdarkly/go-server-sdk-evaluation.v1/ldmodel"
-
-	"github.com/stretchr/testify/require"
 )
 
 func doServerSideSummaryEventTests(t *ldtest.T) {
@@ -271,7 +270,7 @@ func doServerSideSummaryEventVersionTest(t *ldtest.T) {
 
 	dataSource.StreamingService().PushUpdate("flags", flagKey, jsonhelpers.ToJSON(flagAfter))
 
-	require.Eventually(
+	helpers.RequireEventually(
 		t,
 		checkForUpdatedValue(t, client, flagKey, user, valueBefore, valueAfter, defaultValue),
 		time.Second,


### PR DESCRIPTION
This is a more reliable fix for https://github.com/launchdarkly/sdk-test-harness/pull/29. It's desirable for us to have a way to force early test termination from within any helper function, regardless of where that function is being called from; doing so from within an `assert.Eventually` type of polling loop shouldn't inherently be bad. The problem is just that the actual implementation of `assert.Eventually` uses a separate goroutine— which has the benefit of making the function work as intended even if the function being polled just hangs or something, but it is not compatible with the idea of early termination. So, here I've implemented a simpler version of that logic and we're fine as long as we use that.