### PR TITLE
allow extra "device" & "os" attributes for mobile only

### DIFF
--- a/framework/helpers/generics.go
+++ b/framework/helpers/generics.go
@@ -1,5 +1,16 @@
 package helpers
 
+import (
+	"sort"
+
+	"golang.org/x/exp/constraints"
+)
+
+// CopyOf returns a shallow copy of a slice.
+func CopyOf[V any](slice []V) []V {
+	return append([]V(nil), slice...)
+}
+
 // IfElse returns valueIfTrue or valueIfFalse depending on isTrue.
 func IfElse[V any](isTrue bool, valueIfTrue, valueIfFalse V) V {
 	if isTrue {
@@ -16,4 +27,11 @@ func SliceContains[V comparable](value V, slice []V) bool {
 		}
 	}
 	return false
+}
+
+// Sorted returns a sorted copy of a slice.
+func Sorted[V constraints.Ordered](slice []V) []V {
+	ret := CopyOf(slice)
+	sort.Slice(ret, func(i, j int) bool { return ret[i] < ret[j] })
+	return ret
 }

--- a/framework/helpers/generics_test.go
+++ b/framework/helpers/generics_test.go
@@ -6,6 +6,14 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
+func TestCopyOf(t *testing.T) {
+	s := []string{"a", "b"}
+	s1 := CopyOf(s)
+	assert.Equal(t, s, s1)
+	s[0] = "x"
+	assert.Equal(t, "a", s1[0])
+}
+
 func TestIfElse(t *testing.T) {
 	assert.Equal(t, 3, IfElse(true, 3, 4))
 	assert.Equal(t, 4, IfElse(false, 3, 4))
@@ -18,4 +26,11 @@ func TestSliceContains(t *testing.T) {
 	assert.False(t, SliceContains(5, []int{1, 2, 3, 4}))
 	assert.True(t, SliceContains("c", []string{"a", "b", "c", "d"}))
 	assert.False(t, SliceContains("e", []string{"a", "b", "c", "d"}))
+}
+
+func TestSorted(t *testing.T) {
+	s := []string{"d", "a", "c", "b"}
+	s1 := Sorted(s)
+	assert.Equal(t, []string{"a", "b", "c", "d"}, s1)
+	assert.Equal(t, []string{"d", "a", "c", "b"}, s)
 }

--- a/go.mod
+++ b/go.mod
@@ -8,6 +8,7 @@ require (
 	github.com/launchdarkly/eventsource v1.6.2
 	github.com/launchdarkly/go-test-helpers/v2 v2.3.2
 	github.com/stretchr/testify v1.7.0
+	golang.org/x/exp v0.0.0-20220706164943-b4a6d9510983
 	gopkg.in/launchdarkly/go-jsonstream.v1 v1.0.1
 	gopkg.in/launchdarkly/go-sdk-common.v2 v2.4.0
 	gopkg.in/launchdarkly/go-server-sdk-evaluation.v1 v1.4.1

--- a/go.sum
+++ b/go.sum
@@ -37,6 +37,8 @@ github.com/stretchr/testify v1.6.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/
 github.com/stretchr/testify v1.6.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/stretchr/testify v1.7.0 h1:nwc3DEeHmmLAfoZucVR881uASk0Mfjw8xYJ99tb5CcY=
 github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
+golang.org/x/exp v0.0.0-20220706164943-b4a6d9510983 h1:sUweFwmLOje8KNfXAVqGGAsmgJ/F8jJ6wBLJDt4BTKY=
+golang.org/x/exp v0.0.0-20220706164943-b4a6d9510983/go.mod h1:Kr81I6Kryrl9sr8s2FK3vxD90NdsKWRuOIl2O4CvYbA=
 golang.org/x/sys v0.0.0-20200116001909-b77594299b42/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20200223170610-d5e6a3e2c0ae/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20210630005230-0f9fa26af87c/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=

--- a/sdktests/common_tests_base.go
+++ b/sdktests/common_tests_base.go
@@ -12,6 +12,7 @@ import (
 type commonTestsBase struct {
 	sdkKind        mockld.SDKKind
 	isClientSide   bool
+	isMobile       bool
 	sdkConfigurers []SDKConfigurer
 	userFactory    *UserFactory
 }
@@ -29,6 +30,7 @@ func newCommonTestsBase(t *ldtest.T, testName string, baseSDKConfigurers ...SDKC
 		userFactory: NewUserFactory(testName),
 	}
 	c.isClientSide = c.sdkKind.IsClientSide()
+	c.isMobile = t.Capabilities().Has(servicedef.CapabilityMobile)
 	if c.isClientSide {
 		c.sdkConfigurers = append(
 			[]SDKConfigurer{

--- a/sdktests/common_tests_poll_request.go
+++ b/sdktests/common_tests_poll_request.go
@@ -117,7 +117,7 @@ func (c CommonPollingTests) RequestUserProperties(t *ldtest.T, getPath string) {
 					Email("b").AsPrivateAttribute().
 					Custom("c", ldvalue.String("d")).
 					Build()
-				userJSONMatcher := JSONMatchesUser(user)
+				userJSONMatcher := JSONMatchesUser(user, t.Capabilities().Has(servicedef.CapabilityMobile))
 
 				_ = NewSDKClient(t, c.baseSDKConfigurationPlus(
 					WithClientSideConfig(servicedef.SDKConfigClientSideParams{

--- a/sdktests/common_tests_stream_request.go
+++ b/sdktests/common_tests_stream_request.go
@@ -120,7 +120,7 @@ func (c CommonStreamingTests) RequestUserProperties(t *ldtest.T, getPath string)
 					Email("b").AsPrivateAttribute().
 					Custom("c", ldvalue.String("d")).
 					Build()
-				userJSONMatcher := JSONMatchesUser(user)
+				userJSONMatcher := JSONMatchesUser(user, t.Capabilities().Has(servicedef.CapabilityMobile))
 
 				_ = NewSDKClient(t, c.baseSDKConfigurationPlus(
 					append(configurers,


### PR DESCRIPTION
This fixes the user matching logic to work correctly for mobile SDKs that add "device" and "os" custom attributes. It allows these attributes to have any values, and does not _require_ mobile SDKs to add them, but it does not allow any non-mobile SDKs to add them.

The logic for this is a bit convoluted, but it goes away in v2 because we won't be adding these attributes any more in upcoming major versions of the mobile SDKs.