### PR TITLE
Ignore blank lines in external suppression file

### DIFF
--- a/main.go
+++ b/main.go
@@ -118,7 +118,12 @@ func loadSuppressions(params *commandParams) error {
 	defer func() { _ = file.Close() }()
 	scanner := bufio.NewScanner(file)
 	for scanner.Scan() {
-		escaped := regexp.QuoteMeta(scanner.Text())
+		line := scanner.Text()
+		// Ignore blank lines
+		if strings.TrimSpace(line) == "" {
+			continue
+		}
+		escaped := regexp.QuoteMeta(line)
 		if err := params.filters.MustNotMatch.Set(escaped); err != nil {
 			return fmt.Errorf("cannot parse suppression: %v", err)
 		}


### PR DESCRIPTION
When keeping a list of test suppressions for a given SDK, I have been reaching for comments and blank lines to make the file readable and informative, similarly to a `.gitignore`:
```sh
# bug in SDK: see ticket sc-12345
test/suppression/x
test/suppression/y

# another bug: see ticket sc-67890
test/suppression/z
```
Comments don't need special treatment for this to work, because the test harness will read in the commented lines as test names and match nothing. But blank lines currently make the test harness skip _everything_, because it thinks I'm skipping `""` which matches every test.

I'd like to add in the ability to skip over blank lines here, to enable that use case.