### PR TITLE
Add kind and array based matching operation checks

### DIFF
--- a/data/data-files/server-side-eval/clause-kind-matching.yml
+++ b/data/data-files/server-side-eval/clause-kind-matching.yml
@@ -37,6 +37,26 @@ parameters:
     CLAUSE: { attribute: "kind", op: "in", values: ["user"] }
     EXPECT: <IS_MATCH>
 
+  - NAME: kind match for single-kind context using matches operator
+    CONTEXT: { kind: "user", key: "a" }
+    CLAUSE: { attribute: "kind", op: "matches", values: ["^[uo]"] }
+    EXPECT: <IS_MATCH>
+
+  - NAME: kind non-match for single-kind context using matches operator
+    CONTEXT: { kind: "company", key: "a" }
+    CLAUSE: { attribute: "kind", op: "matches", values: ["^[uo]"] }
+    EXPECT: <IS_NOT_MATCH>
+
+  - NAME: kind match for multi-kind context using matches operator
+    CONTEXT: { kind: "multi", user: { key: "a" }, other: { key: "b" } }
+    CLAUSE: { attribute: "kind", op: "matches", values: ["^[uo]"] }
+    EXPECT: <IS_MATCH>
+
+  - NAME: kind non-match for multi-kind context using matches operator
+    CONTEXT: { kind: "multi", company: { key: "a" }, individual: { key: "b" } }
+    CLAUSE: { attribute: "kind", op: "matches", values: ["^[uo]"] }
+    EXPECT: <IS_NOT_MATCH>
+
   - NAME: kind non-match for single-kind context
     CONTEXT: { kind: "user", key: "a" }
     CLAUSE: { attribute: "kind", op: "in", values: ["org"] }

--- a/data/data-files/server-side-eval/operators-string.yml
+++ b/data/data-files/server-side-eval/operators-string.yml
@@ -140,3 +140,9 @@ evaluations:
     context: { key: "user-key", custom: { attrname: "<USER_VALUE>" } }
     default: false
     expect: <EXPECT>
+
+  - name: "[<USER_VALUE>] <OP> <CLAUSE_VALUE>"
+    flagKey: test-string
+    context: { key: "user-key", custom: { attrname: ["<USER_VALUE>"] } }
+    default: false
+    expect: <EXPECT>


### PR DESCRIPTION
There was an issue in the rust eval crate (sc-162733) where the match
operator was evaluating regexes incorrectly if:

1. It was testing against the context's kind, or
2. It was testing against an array of context values

This commit should add tests that cover both of the scenarios.