### PR TITLE
add secure mode hash tests

### DIFF
--- a/sdktests/server_side_secure_mode_hash.go
+++ b/sdktests/server_side_secure_mode_hash.go
@@ -1,0 +1,62 @@
+package sdktests
+
+import (
+	"fmt"
+
+	"github.com/launchdarkly/sdk-test-harness/framework/ldtest"
+	"github.com/launchdarkly/sdk-test-harness/servicedef"
+
+	"gopkg.in/launchdarkly/go-sdk-common.v2/lduser"
+	"gopkg.in/launchdarkly/go-sdk-common.v2/ldvalue"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func doServerSideSecureModeHashTests(t *ldtest.T) {
+	t.RequireCapability(servicedef.CapabilitySecureModeHash)
+
+	// These parameters were obtained by manual testing of a GA release of go-server-sdk that is
+	// being used as a reference implementation.
+	sdkKey1, sdkKey2 := "sdk-01234567-89ab-cdef-0123-456789abcdef", "sdk-11234567-89ab-cdef-0123-456789abcdef"
+	userKey1, userKey2 := "user-key-123", "user-key-456"
+	allParams := []struct {
+		sdkKey       string
+		user         lduser.User
+		expectedHash string
+	}{
+		{
+			sdkKey:       sdkKey1,
+			user:         lduser.NewUser(userKey1),
+			expectedHash: "73df666a13f2c474e50aa34ca5a761e89abb737fb139ff65fdde7fa85c9dcacd",
+		},
+		{
+			// same SDK key with same user key = same result, regardless of other user attributes
+			sdkKey: sdkKey1,
+			user: lduser.NewUserBuilder(userKey1).
+				Anonymous(true).Avatar("a").Country("b").Email("c").FirstName("d").IP("e").
+				LastName("f").Name("g").Secondary("h").Custom("i", ldvalue.String("j")).Build(),
+			expectedHash: "73df666a13f2c474e50aa34ca5a761e89abb737fb139ff65fdde7fa85c9dcacd",
+		},
+		{
+			// different SDK key with same user key = different result
+			sdkKey:       sdkKey2,
+			user:         lduser.NewUser(userKey1),
+			expectedHash: "63538426a9845721a5547b4715f4284b060c21743702a896e1ff8a9a5b57215d",
+		},
+		{
+			// same SDK key with different user key = different result
+			sdkKey:       sdkKey1,
+			user:         lduser.NewUser(userKey2),
+			expectedHash: "55be6b5ceb2a11acc6a7e9c60dbee5022d9c7084baf9ecd8cf69d12bce5a92fb",
+		},
+	}
+
+	dataSource := NewSDKDataSource(t, nil)
+	for i, p := range allParams {
+		t.Run(fmt.Sprintf("test case %d", i+1), func(t *ldtest.T) {
+			client := NewSDKClient(t, WithCredential(p.sdkKey), dataSource)
+			hash := client.GetSecureModeHash(t, p.user)
+			assert.Equal(t, p.expectedHash, hash)
+		})
+	}
+}

--- a/sdktests/testapi_sdk_client.go
+++ b/sdktests/testapi_sdk_client.go
@@ -286,3 +286,17 @@ func (c *SDKClient) GetBigSegmentStoreStatus(t *ldtest.T) servicedef.BigSegmentS
 		t.DebugLogger(), &resp))
 	return resp
 }
+
+// GetSecureModeHash tells the SDK client to calculate a secure mode hash for a user. The test
+// harness will only call this method if the test service has the "secure-mode-hash" capability.
+func (c *SDKClient) GetSecureModeHash(t *ldtest.T, user lduser.User) string {
+	var resp servicedef.SecureModeHashResponse
+	require.NoError(t, c.sdkClientEntity.SendCommandWithParams(
+		servicedef.CommandParams{
+			Command:        servicedef.CommandSecureModeHash,
+			SecureModeHash: o.Some(servicedef.SecureModeHashParams{User: user}),
+		},
+		t.DebugLogger(),
+		&resp))
+	return resp.Result
+}

--- a/sdktests/testsuite_entry_point.go
+++ b/sdktests/testsuite_entry_point.go
@@ -77,6 +77,7 @@ func doAllServerSideTests(t *ldtest.T) {
 	t.Run("big segments", doServerSideBigSegmentsTests)
 	t.Run("service endpoints", doServerSideServiceEndpointsTests)
 	t.Run("tags", doServerSideTagsTests)
+	t.Run("secure mode hash", doServerSideSecureModeHashTests)
 }
 
 func doAllClientSideTests(t *ldtest.T) {

--- a/servicedef/command_params.go
+++ b/servicedef/command_params.go
@@ -16,6 +16,7 @@ const (
 	CommandAliasEvent               = "aliasEvent"
 	CommandFlushEvents              = "flushEvents"
 	CommandGetBigSegmentStoreStatus = "getBigSegmentStoreStatus"
+	CommandSecureModeHash           = "secureModeHash"
 )
 
 type ValueType string
@@ -29,12 +30,13 @@ const (
 )
 
 type CommandParams struct {
-	Command       string                          `json:"command"`
-	Evaluate      o.Maybe[EvaluateFlagParams]     `json:"evaluate,omitempty"`
-	EvaluateAll   o.Maybe[EvaluateAllFlagsParams] `json:"evaluateAll,omitempty"`
-	CustomEvent   o.Maybe[CustomEventParams]      `json:"customEvent,omitempty"`
-	IdentifyEvent o.Maybe[IdentifyEventParams]    `json:"identifyEvent,omitempty"`
-	AliasEvent    o.Maybe[AliasEventParams]       `json:"aliasEvent,omitempty"`
+	Command        string                          `json:"command"`
+	Evaluate       o.Maybe[EvaluateFlagParams]     `json:"evaluate,omitempty"`
+	EvaluateAll    o.Maybe[EvaluateAllFlagsParams] `json:"evaluateAll,omitempty"`
+	CustomEvent    o.Maybe[CustomEventParams]      `json:"customEvent,omitempty"`
+	IdentifyEvent  o.Maybe[IdentifyEventParams]    `json:"identifyEvent,omitempty"`
+	AliasEvent     o.Maybe[AliasEventParams]       `json:"aliasEvent,omitempty"`
+	SecureModeHash o.Maybe[SecureModeHashParams]   `json:"secureModeHash,omitempty"`
 }
 
 type EvaluateFlagParams struct {
@@ -82,4 +84,12 @@ type AliasEventParams struct {
 type BigSegmentStoreStatusResponse struct {
 	Available bool `json:"available"`
 	Stale     bool `json:"stale"`
+}
+
+type SecureModeHashParams struct {
+	User lduser.User `json:"user"`
+}
+
+type SecureModeHashResponse struct {
+	Result string `json:"result"`
 }

--- a/servicedef/service_params.go
+++ b/servicedef/service_params.go
@@ -14,6 +14,7 @@ const (
 	CapabilityAllFlagsDetailsOnlyForTrackedFlags = "all-flags-details-only-for-tracked-flags"
 
 	CapabilityBigSegments       = "big-segments"
+	CapabilitySecureModeHash    = "secure-mode-hash"
 	CapabilityServerSidePolling = "server-side-polling"
 	CapabilityServiceEndpoints  = "service-endpoints"
 	CapabilityTags              = "tags"


### PR DESCRIPTION
This is pretty straightforward since there are only two inputs to the hash function (SDK key and user key).

It's an optional capability because not all server-side SDKs have this method: for instance, c-server-sdk doesn't. But for the majority of the SDKs that do have it, we should update the existing SDK contract test service implementations to support this, so we can be sure the SDKs are working consistently.