### PR TITLE
use custom events instead of identify events when possible

### DIFF
--- a/sdktests/common_tests_base.go
+++ b/sdktests/common_tests_base.go
@@ -1,12 +1,14 @@
 package sdktests
 
 import (
-	m "github.com/launchdarkly/go-test-helpers/v2/matchers"
 	"github.com/launchdarkly/sdk-test-harness/framework/helpers"
 	"github.com/launchdarkly/sdk-test-harness/framework/ldtest"
 	o "github.com/launchdarkly/sdk-test-harness/framework/opt"
 	"github.com/launchdarkly/sdk-test-harness/mockld"
 	"github.com/launchdarkly/sdk-test-harness/servicedef"
+
+	m "github.com/launchdarkly/go-test-helpers/v2/matchers"
+	"gopkg.in/launchdarkly/go-sdk-common.v2/lduser"
 )
 
 type commonTestsBase struct {
@@ -76,4 +78,12 @@ func (c commonTestsBase) withFlagRequestMethod(method flagRequestMethod) SDKConf
 		configOut.ClientSide = o.Some(clientSideConfig)
 		return nil
 	})
+}
+
+func (c commonTestsBase) sendArbitraryEvent(t *ldtest.T, client *SDKClient) {
+	params := servicedef.CustomEventParams{EventKey: "arbitrary-event"}
+	if !c.isClientSide {
+		params.User = o.Some(lduser.NewUser("user-key"))
+	}
+	client.SendCustomEvent(t, params)
 }

--- a/sdktests/common_tests_events_request.go
+++ b/sdktests/common_tests_events_request.go
@@ -11,7 +11,6 @@ import (
 	"github.com/launchdarkly/sdk-test-harness/servicedef"
 
 	m "github.com/launchdarkly/go-test-helpers/v2/matchers"
-	"gopkg.in/launchdarkly/go-sdk-common.v2/lduser"
 )
 
 const currentEventSchema = 3
@@ -22,7 +21,7 @@ func (c CommonEventTests) RequestMethodAndHeaders(t *ldtest.T, credential string
 		events := NewSDKEventSink(t)
 		client := NewSDKClient(t, c.baseSDKConfigurationPlus(dataSource, events)...)
 
-		client.SendIdentifyEvent(t, lduser.NewUser("user-key"))
+		c.sendArbitraryEvent(t, client)
 		client.FlushEvents(t)
 
 		request := events.Endpoint().RequireConnection(t, time.Second)
@@ -57,7 +56,7 @@ func (c CommonEventTests) RequestURLPath(t *ldtest.T, pathMatcher m.Matcher) {
 						BaseURI: eventsURI,
 					}))...)
 
-				client.SendIdentifyEvent(t, lduser.NewUser("user-key"))
+				c.sendArbitraryEvent(t, client)
 				client.FlushEvents(t)
 
 				request := events.Endpoint().RequireConnection(t, time.Second)
@@ -73,13 +72,12 @@ func (c CommonEventTests) UniquePayloadIDs(t *ldtest.T) {
 		events := NewSDKEventSink(t)
 		client := NewSDKClient(t, c.baseSDKConfigurationPlus(dataSource, events)...,
 		)
-		users := NewUserFactory("UniquePayloadIDs")
 
 		numPayloads := 3
 		requests := make([]harness.IncomingRequestInfo, 0, numPayloads)
 
 		for i := 0; i < numPayloads; i++ {
-			client.SendIdentifyEvent(t, users.NextUniqueUser())
+			c.sendArbitraryEvent(t, client)
 			client.FlushEvents(t)
 			requests = append(requests, events.Endpoint().RequireConnection(t, time.Second))
 		}

--- a/sdktests/common_tests_tags.go
+++ b/sdktests/common_tests_tags.go
@@ -12,7 +12,6 @@ import (
 	"github.com/launchdarkly/sdk-test-harness/servicedef"
 
 	"github.com/launchdarkly/go-test-helpers/v2/jsonhelpers"
-	"gopkg.in/launchdarkly/go-sdk-common.v2/lduser"
 
 	"github.com/stretchr/testify/assert"
 )
@@ -100,7 +99,7 @@ func (c CommonTagsTests) Run(t *ldtest.T) {
 					dataSource,
 					events)...)
 
-				client.SendIdentifyEvent(t, lduser.NewUser("user-key"))
+				c.sendArbitraryEvent(t, client)
 				client.FlushEvents(t)
 
 				verifyRequestHeader(t, p, events.Endpoint())


### PR DESCRIPTION
If what matters in the test is just "we sent an event", we should use a `custom` event rather than `identify`. This is because in client-side SDKs, `identify()` doesn't just send an event, it also makes the SDK re-request flag data, which could make tests slow. For instance, the "event capacity" tests currently cause `identify()` to be called about 60 times.