### PR TITLE
expect client-side U2C SDKs to use new endpoints

### DIFF
--- a/mockld/polling_service.go
+++ b/mockld/polling_service.go
@@ -10,11 +10,24 @@ import (
 )
 
 const (
-	PollingPathServerSide         = "/sdk/latest-all"
-	PollingPathMobileGet          = "/msdk/evalx/users/{context}"
-	PollingPathMobileReport       = "/msdk/evalx/user"
-	PollingPathJSClientGet        = "/sdk/evalx/{env}/users/{context}"
-	PollingPathJSClientReport     = "/sdk/evalx/{env}/user"
+	PollingPathServerSide     = "/sdk/latest-all"
+	PollingPathMobileGet      = "/msdk/evalx/contexts/{context}"
+	PollingPathMobileReport   = "/msdk/evalx/context"
+	PollingPathJSClientGet    = "/sdk/evalx/{env}/contexts/{context}"
+	PollingPathJSClientReport = "/sdk/evalx/{env}/context"
+
+	// The following endpoint paths were used by older SDKs based on the user model rather than
+	// the context model. New context-aware SDKs should always use the new paths. However, our
+	// mock service still supports the old paths (just as the real LD services do). We have
+	// specific tests to verify that the SDKs use the new paths; in all other tests, if the SDK
+	// uses an old path, it will still work so that we don't confusingly see every test fail.
+	// We do *not* support the very old "eval" (as opposed to "evalx") paths since the only SDKs
+	// that used them are long past EOL.
+	PollingPathMobileGetUser      = "/msdk/evalx/users/{context}"
+	PollingPathMobileReportUser   = "/msdk/evalx/user"
+	PollingPathJSClientGetUser    = "/sdk/evalx/{env}/users/{context}"
+	PollingPathJSClientReportUser = "/sdk/evalx/{env}/user"
+
 	PollingPathContextBase64Param = "{context}"
 	PollingPathEnvIDParam         = "{env}"
 )
@@ -47,10 +60,13 @@ func NewPollingService(
 	case MobileSDK:
 		router.HandleFunc(PollingPathMobileGet, pollHandler).Methods("GET")
 		router.HandleFunc(PollingPathMobileReport, pollHandler).Methods("REPORT")
-		// Note that we only support the "evalx", not the older "eval" which is used only by old unsupported SDKs
+		router.HandleFunc(PollingPathMobileGetUser, pollHandler).Methods("GET")
+		router.HandleFunc(PollingPathMobileReportUser, pollHandler).Methods("REPORT")
 	case JSClientSDK:
 		router.HandleFunc(PollingPathJSClientGet, pollHandler).Methods("GET")
 		router.HandleFunc(PollingPathJSClientReport, pollHandler).Methods("REPORT")
+		router.HandleFunc(PollingPathJSClientGetUser, pollHandler).Methods("GET")
+		router.HandleFunc(PollingPathJSClientReportUser, pollHandler).Methods("REPORT")
 	}
 	p.handler = router
 

--- a/mockld/polling_service_test.go
+++ b/mockld/polling_service_test.go
@@ -2,6 +2,7 @@ package mockld
 
 import (
 	"encoding/json"
+	"fmt"
 	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
@@ -30,33 +31,53 @@ func TestPollingServiceServerSide(t *testing.T) {
 }
 
 func TestPollingServiceMobile(t *testing.T) {
-	for _, useReport := range []bool{true, false} {
-		method := h.IfElse(useReport, "REPORT", "GET")
-		t.Run(method, func(t *testing.T) {
-			doPollingServiceTests(
-				t,
-				MobileSDK,
-				EmptyClientSDKData(),
-				NewClientSDKDataBuilder().FlagWithValue("flag1", 1, ldvalue.String("yes"), 0).Build(),
-				method,
-				h.IfElse(useReport, "/msdk/evalx/user", "/msdk/evalx/users/fakeuserdata"),
-			)
+	for _, oldUserPaths := range []bool{false, true} {
+		userOrContext := h.IfElse(oldUserPaths, "user", "context")
+		t.Run(userOrContext, func(t *testing.T) {
+			for _, useReport := range []bool{true, false} {
+				method := h.IfElse(useReport, "REPORT", "GET")
+				endpoint := h.IfElse(
+					useReport,
+					fmt.Sprintf("/msdk/evalx/%s", userOrContext),
+					fmt.Sprintf("/msdk/evalx/%ss/fakeuserdata", userOrContext),
+				)
+				t.Run(method, func(t *testing.T) {
+					doPollingServiceTests(
+						t,
+						MobileSDK,
+						EmptyClientSDKData(),
+						NewClientSDKDataBuilder().FlagWithValue("flag1", 1, ldvalue.String("yes"), 0).Build(),
+						method,
+						endpoint,
+					)
+				})
+			}
 		})
 	}
 }
 
 func TestPollingServiceJSClient(t *testing.T) {
-	for _, useReport := range []bool{true, false} {
-		method := h.IfElse(useReport, "REPORT", "GET")
-		t.Run(method, func(t *testing.T) {
-			doPollingServiceTests(
-				t,
-				JSClientSDK,
-				EmptyClientSDKData(),
-				NewClientSDKDataBuilder().FlagWithValue("flag1", 1, ldvalue.String("yes"), 0).Build(),
-				method,
-				h.IfElse(useReport, "/sdk/evalx/fakeid/user", "/sdk/evalx/fakeid/users/fakeuserdata"),
-			)
+	for _, oldUserPaths := range []bool{false, true} {
+		userOrContext := h.IfElse(oldUserPaths, "user", "context")
+		t.Run(userOrContext, func(t *testing.T) {
+			for _, useReport := range []bool{true, false} {
+				method := h.IfElse(useReport, "REPORT", "GET")
+				endpoint := h.IfElse(
+					useReport,
+					fmt.Sprintf("/sdk/evalx/fakeid/%s", userOrContext),
+					fmt.Sprintf("/sdk/evalx/fakeid/%ss/fakeuserdata", userOrContext),
+				)
+				t.Run(method, func(t *testing.T) {
+					doPollingServiceTests(
+						t,
+						JSClientSDK,
+						EmptyClientSDKData(),
+						NewClientSDKDataBuilder().FlagWithValue("flag1", 1, ldvalue.String("yes"), 0).Build(),
+						method,
+						endpoint,
+					)
+				})
+			}
 		})
 	}
 }


### PR DESCRIPTION
After this change, the `streaming/requests` and `polling/requests` tests will fail if a client-side SDK tries to use the endpoints with `user` in their name, rather than the ones with `context` in their name.