### PR TITLE
Scaffold location for open feature tests.

### DIFF
--- a/mockld/sdk_data.go
+++ b/mockld/sdk_data.go
@@ -25,7 +25,7 @@ const (
 )
 
 func (k SDKKind) IsServerSide() bool {
-	return k == ServerSideSDK
+	return k == ServerSideSDK || k == ServerSideOpenFeature
 }
 
 func (k SDKKind) IsClientSide() bool {

--- a/mockld/sdk_data.go
+++ b/mockld/sdk_data.go
@@ -18,9 +18,10 @@ import (
 type SDKKind string
 
 const (
-	ServerSideSDK SDKKind = "server"
-	MobileSDK     SDKKind = "mobile"
-	JSClientSDK   SDKKind = "jsclient"
+	ServerSideSDK         SDKKind = "server"
+	MobileSDK             SDKKind = "mobile"
+	JSClientSDK           SDKKind = "jsclient"
+	ServerSideOpenFeature SDKKind = "server-openfeature"
 )
 
 func (k SDKKind) IsServerSide() bool {

--- a/mockld/streaming_service.go
+++ b/mockld/streaming_service.go
@@ -78,6 +78,8 @@ func NewStreamingService(
 	streamHandler := streams.Handler(allDataChannel)
 	router := mux.NewRouter()
 	switch sdkKind {
+	case ServerSideOpenFeature:
+		fallthrough
 	case ServerSideSDK:
 		router.HandleFunc(StreamingPathServerSide, streamHandler).Methods("GET")
 	case MobileSDK:

--- a/sdktests/server_side_open_feature_eval.go
+++ b/sdktests/server_side_open_feature_eval.go
@@ -1,6 +1,27 @@
 package sdktests
 
-import "github.com/launchdarkly/sdk-test-harness/framework/ldtest"
+import (
+	"github.com/launchdarkly/sdk-test-harness/framework/ldtest"
+	"github.com/launchdarkly/sdk-test-harness/mockld"
+	"github.com/launchdarkly/sdk-test-harness/servicedef"
+	"gopkg.in/launchdarkly/go-sdk-common.v2/ldvalue"
+	"gopkg.in/launchdarkly/go-server-sdk-evaluation.v1/ldbuilders"
+)
 
 func doServerSideOpenFeatureEvalTests(t *ldtest.T) {
+	expectedValueV1 := ldvalue.Int(1)
+	flagKey := "flag"
+	flag := ldbuilders.NewFlagBuilder(flagKey).Version(1).
+		On(false).OffVariation(0).Variations(expectedValueV1).Build()
+	data := mockld.NewServerSDKDataBuilder().Flag(flag).Build()
+	dataSource := NewSDKDataSource(t, data)
+	client := NewSDKClient(t, dataSource)
+
+	client.EvaluateOpenFeatureFlag(t, servicedef.OpenFeatureEvaluateFlagParams{
+		FlagKey:           "flag",
+		EvaluationContext: map[string]string{"targetingKey": "key"},
+		ValueType:         servicedef.ValueTypeInt,
+		DefaultValue:      ldvalue.Int(0),
+		Detail:            true,
+	})
 }

--- a/sdktests/server_side_open_feature_eval.go
+++ b/sdktests/server_side_open_feature_eval.go
@@ -1,6 +1,7 @@
 package sdktests
 
 import (
+	"fmt"
 	"github.com/launchdarkly/sdk-test-harness/framework/ldtest"
 	"github.com/launchdarkly/sdk-test-harness/mockld"
 	"github.com/launchdarkly/sdk-test-harness/servicedef"
@@ -17,11 +18,13 @@ func doServerSideOpenFeatureEvalTests(t *ldtest.T) {
 	dataSource := NewSDKDataSource(t, data)
 	client := NewSDKClient(t, dataSource)
 
-	client.EvaluateOpenFeatureFlag(t, servicedef.OpenFeatureEvaluateFlagParams{
+	resolution := client.EvaluateOpenFeatureFlag(t, servicedef.OpenFeatureEvaluateFlagParams{
 		FlagKey:           "flag",
 		EvaluationContext: map[string]string{"targetingKey": "key"},
 		ValueType:         servicedef.ValueTypeInt,
 		DefaultValue:      ldvalue.Int(0),
 		Detail:            true,
 	})
+
+	fmt.Print("Val ", resolution.Value, " Reason ", resolution.Reason, " Variant ", resolution.Variant, " ErrorCode ", resolution.ErrorCode)
 }

--- a/sdktests/server_side_open_feature_eval.go
+++ b/sdktests/server_side_open_feature_eval.go
@@ -1,0 +1,6 @@
+package sdktests
+
+import "github.com/launchdarkly/sdk-test-harness/framework/ldtest"
+
+func doServerSideOpenFeatureEvalTests(t *ldtest.T) {
+}

--- a/sdktests/testapi_sdk_client.go
+++ b/sdktests/testapi_sdk_client.go
@@ -209,6 +209,22 @@ func (c *SDKClient) EvaluateFlag(t *ldtest.T, params servicedef.EvaluateFlagPara
 	return resp
 }
 
+func (c *SDKClient) EvaluateOpenFeatureFlag(t *ldtest.T, params servicedef.OpenFeatureEvaluateFlagParams) servicedef.OpenFeatureEvaluateFlagResponse {
+	if params.ValueType == "" {
+		params.ValueType = servicedef.ValueTypeAny // it'd be easy for a test to forget to set this
+	}
+	var resp servicedef.OpenFeatureEvaluateFlagResponse
+	require.NoError(t, c.sdkClientEntity.SendCommandWithParams(
+		servicedef.CommandParams{
+			Command:             servicedef.CommandOpenFeatureEvaluateFlag,
+			OpenFeatureEvaluate: o.Some(params),
+		},
+		t.DebugLogger(),
+		&resp,
+	))
+	return resp
+}
+
 // EvaluateAllFlags tells the SDK client to evaluate all feature flags. This corresponds to calling the SDK's
 // AllFlags or AllFlagsState method.
 //

--- a/sdktests/testsuite_entry_point.go
+++ b/sdktests/testsuite_entry_point.go
@@ -22,6 +22,9 @@ func RunSDKTestSuite(
 	var sdkKind mockld.SDKKind
 
 	switch {
+	case capabilities.Has(servicedef.CapabilityServerSideOpenFeature):
+		fmt.Println("Running server-side OpenFeature test suite")
+		sdkKind = mockld.ServerSideOpenFeature
 	case capabilities.Has(servicedef.CapabilityServerSide):
 		fmt.Println("Running server-side SDK test suite")
 		sdkKind = mockld.ServerSideSDK
@@ -61,6 +64,8 @@ func RunSDKTestSuite(
 
 	return ldtest.Run(config, func(t *ldtest.T) {
 		switch sdkKind {
+		case mockld.ServerSideOpenFeature:
+			doAllServerSideOpenFeatureTests(t)
 		case mockld.ServerSideSDK:
 			doAllServerSideTests(t)
 		default:
@@ -85,6 +90,10 @@ func doAllClientSideTests(t *ldtest.T) {
 	t.Run("streaming", doClientSideStreamTests)
 	t.Run("polling", doClientSidePollTests)
 	t.Run("tags", doClientSideTagsTests)
+}
+
+func doAllServerSideOpenFeatureTests(t *ldtest.T) {
+	t.Run("evaluation", doServerSideOpenFeatureEvalTests)
 }
 
 func allImportantServerSideCapabilities() framework.Capabilities {

--- a/servicedef/command_params.go
+++ b/servicedef/command_params.go
@@ -16,6 +16,7 @@ const (
 	CommandAliasEvent               = "aliasEvent"
 	CommandFlushEvents              = "flushEvents"
 	CommandGetBigSegmentStoreStatus = "getBigSegmentStoreStatus"
+	CommandOpenFeatureEvaluateFlag  = "openFeatureEvaluate"
 )
 
 type ValueType string
@@ -29,12 +30,13 @@ const (
 )
 
 type CommandParams struct {
-	Command       string                          `json:"command"`
-	Evaluate      o.Maybe[EvaluateFlagParams]     `json:"evaluate,omitempty"`
-	EvaluateAll   o.Maybe[EvaluateAllFlagsParams] `json:"evaluateAll,omitempty"`
-	CustomEvent   o.Maybe[CustomEventParams]      `json:"customEvent,omitempty"`
-	IdentifyEvent o.Maybe[IdentifyEventParams]    `json:"identifyEvent,omitempty"`
-	AliasEvent    o.Maybe[AliasEventParams]       `json:"aliasEvent,omitempty"`
+	Command             string                                 `json:"command"`
+	Evaluate            o.Maybe[EvaluateFlagParams]            `json:"evaluate,omitempty"`
+	EvaluateAll         o.Maybe[EvaluateAllFlagsParams]        `json:"evaluateAll,omitempty"`
+	CustomEvent         o.Maybe[CustomEventParams]             `json:"customEvent,omitempty"`
+	IdentifyEvent       o.Maybe[IdentifyEventParams]           `json:"identifyEvent,omitempty"`
+	AliasEvent          o.Maybe[AliasEventParams]              `json:"aliasEvent,omitempty"`
+	OpenFeatureEvaluate o.Maybe[OpenFeatureEvaluateFlagParams] `json:"openFeatureEvaluate"`
 }
 
 type EvaluateFlagParams struct {
@@ -82,4 +84,19 @@ type AliasEventParams struct {
 type BigSegmentStoreStatusResponse struct {
 	Available bool `json:"available"`
 	Stale     bool `json:"stale"`
+}
+
+type OpenFeatureEvaluateFlagResponse struct {
+	Value     ldvalue.Value   `json:"value"`
+	Variant   string          `json:"variant"`
+	Reason    string          `json:"reason"`
+	ErrorCode o.Maybe[string] `json:"errorCode"`
+}
+
+type OpenFeatureEvaluateFlagParams struct {
+	FlagKey           string            `json:"flagKey"`
+	EvaluationContext map[string]string `json:"evaluationContext"`
+	ValueType         ValueType         `json:"valueType"`
+	DefaultValue      ldvalue.Value     `json:"defaultValue"`
+	Detail            bool
 }

--- a/servicedef/command_params.go
+++ b/servicedef/command_params.go
@@ -98,5 +98,5 @@ type OpenFeatureEvaluateFlagParams struct {
 	EvaluationContext map[string]string `json:"evaluationContext"`
 	ValueType         ValueType         `json:"valueType"`
 	DefaultValue      ldvalue.Value     `json:"defaultValue"`
-	Detail            bool
+	Detail            bool              `json:"detail"`
 }

--- a/servicedef/service_params.go
+++ b/servicedef/service_params.go
@@ -13,10 +13,11 @@ const (
 	CapabilityAllFlagsClientSideOnly             = "all-flags-client-side-only"
 	CapabilityAllFlagsDetailsOnlyForTrackedFlags = "all-flags-details-only-for-tracked-flags"
 
-	CapabilityBigSegments       = "big-segments"
-	CapabilityServerSidePolling = "server-side-polling"
-	CapabilityServiceEndpoints  = "service-endpoints"
-	CapabilityTags              = "tags"
+	CapabilityBigSegments           = "big-segments"
+	CapabilityServerSidePolling     = "server-side-polling"
+	CapabilityServiceEndpoints      = "service-endpoints"
+	CapabilityTags                  = "tags"
+	CapabilityServerSideOpenFeature = "server-side-open-feature"
 )
 
 type StatusRep struct {


### PR DESCRIPTION
Drafting this for some questions.

I want to determine if this approach is favorable.

There are broadly a few ways to implement open feature tests.
- Implement them as a sdkKind similar to client/server. I think this makes the most sense from an external perspective. It is a different kind of thing. It is based on a server SDK though. What this PR does.
- Implement a capability that would exercise the open feature methods and could be ran in combination with other server tests.

Independent of this there are a couple ways to handle evaluation parameters/results. 
- Implement specific types for the parameters and result. The method I have taken so far. There is some duplicate work.
- Implement a translation that provides the results in a way compatible with the existing evaluation. Benefit being we could run single evaluations (not all flags) that are specified in existing suites. The big down side is most of OpenFeature work is converting these types, so it makes it hard to know if that is working completely correctly.


