### PR TITLE
implement evaluation tests for PHP

### DIFF
--- a/docs/service_spec.md
+++ b/docs/service_spec.md
@@ -21,11 +21,11 @@ This resource should return a 200 status to indicate that the service has starte
 
 The test harness will use the `capabilities` information to decide whether to run optional parts of the test suite that relate to those capabilities.
 
-#### SDK type capabilities: `"server-side"`, `"client-side"`, `"mobile"`
+#### SDK type capabilities: `"server-side"`, `"client-side"`, `"mobile"`, `"php"`
 
 The most basic decision in this regard is what type of SDK is being tested: server-side, mobile client-side, or JavaScript-based client-side. The server-side test suite is much more detailed, since client-side SDKs do not have their own evaluation logic. In the client-side test suite, the two variants (mobile and JavaScript-based) mostly receive the same tests, but each variant uses somewhat different simulated LaunchDarkly services.
 
-* If `"server-side"` is present, this is a server-side SDK.
+* If `"server-side"` is present, this is a server-side SDK. If `"php"` is also present, it is the PHP SDK which is a special case of server-side SDKs.
 * Otherwise, if `"client-side"` and `"mobile"` are present, this is a mobile client-side SDK.
 * Otherwise, if `"client-side"` is present without `"mobile"`, this is a JavaScript-based client-side SDK.
 * If none of the above are true, no tests can be run.

--- a/mockld/events_service.go
+++ b/mockld/events_service.go
@@ -43,7 +43,7 @@ func NewEventsService(sdkKind SDKKind, logger framework.Logger) *EventsService {
 
 	router := mux.NewRouter()
 	switch sdkKind {
-	case ServerSideSDK:
+	case ServerSideSDK, PHPSDK:
 		router.HandleFunc("/bulk", s.postEvents).Methods("POST")
 		router.HandleFunc("/diagnostic", s.postDiagnosticEvent).Methods("POST")
 	case MobileSDK:

--- a/mockld/polling_service.go
+++ b/mockld/polling_service.go
@@ -1,6 +1,7 @@
 package mockld
 
 import (
+	"encoding/json"
 	"net/http"
 	"sync"
 
@@ -15,6 +16,9 @@ const (
 	PollingPathMobileReport    = "/msdk/evalx/user"
 	PollingPathJSClientGet     = "/sdk/evalx/{env}/users/{user}"
 	PollingPathJSClientReport  = "/sdk/evalx/{env}/user"
+	PollingPathPHPAllFlags     = "/sdk/flags"
+	PollingPathPHPFlag         = "/sdk/flags/{key}"
+	PollingPathPHPSegment      = "/sdk/segments/{key}"
 	PollingPathUserBase64Param = "{user}"
 	PollingPathEnvIDParam      = "{env}"
 )
@@ -39,18 +43,22 @@ func NewPollingService(
 		debugLogger: debugLogger,
 	}
 
-	pollHandler := p.servePollRequest
+	pollHandler := p.standardPollingHandler()
 	router := mux.NewRouter()
 	switch sdkKind {
 	case ServerSideSDK:
-		router.HandleFunc(PollingPathServerSide, pollHandler).Methods("GET")
+		router.Handle(PollingPathServerSide, pollHandler).Methods("GET")
 	case MobileSDK:
-		router.HandleFunc(PollingPathMobileGet, pollHandler).Methods("GET")
-		router.HandleFunc(PollingPathMobileReport, pollHandler).Methods("REPORT")
+		router.Handle(PollingPathMobileGet, pollHandler).Methods("GET")
+		router.Handle(PollingPathMobileReport, pollHandler).Methods("REPORT")
 		// Note that we only support the "evalx", not the older "eval" which is used only by old unsupported SDKs
 	case JSClientSDK:
-		router.HandleFunc(PollingPathJSClientGet, pollHandler).Methods("GET")
-		router.HandleFunc(PollingPathJSClientReport, pollHandler).Methods("REPORT")
+		router.Handle(PollingPathJSClientGet, pollHandler).Methods("GET")
+		router.Handle(PollingPathJSClientReport, pollHandler).Methods("REPORT")
+	case PHPSDK:
+		router.Handle(PollingPathPHPFlag, p.phpFlagHandler()).Methods("GET")
+		router.Handle(PollingPathPHPSegment, p.phpSegmentHandler()).Methods("GET")
+		router.Handle(PollingPathPHPAllFlags, p.phpAllFlagsHandler()).Methods("GET")
 	}
 	p.handler = router
 
@@ -61,25 +69,65 @@ func (p *PollingService) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	p.handler.ServeHTTP(w, r)
 }
 
-func (p *PollingService) servePollRequest(w http.ResponseWriter, r *http.Request) {
-	p.lock.Lock()
-	etag := p.currentEtag
-	if matchEtag := r.Header.Get("If-None-Match"); matchEtag != "" && matchEtag == etag {
+func (p *PollingService) pollingHandler(getDataFn func(*PollingService, *http.Request) []byte) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		p.lock.Lock()
+		etag := p.currentEtag
+		if matchEtag := r.Header.Get("If-None-Match"); matchEtag != "" && matchEtag == etag {
+			p.lock.Unlock()
+			w.WriteHeader(http.StatusNotModified)
+			return
+		}
+
+		if p.currentData == nil || p.currentData.Serialize() == nil {
+			// This means we've deliberately configured the data source to be unavailable
+			w.WriteHeader(http.StatusNotFound)
+			return
+		}
+		data := getDataFn(p, r)
 		p.lock.Unlock()
-		w.WriteHeader(http.StatusNotModified)
-		return
-	}
-	data := p.currentData.Serialize()
-	p.lock.Unlock()
+		if data == nil {
+			w.WriteHeader(http.StatusNotFound)
+			return
+		}
 
-	p.debugLogger.Printf("Sending poll data: %s", string(data))
+		p.debugLogger.Printf("Sending poll data for %s: %s", r.URL.Path, string(data))
 
-	w.Header().Add("Content-Type", "application/json")
-	if etag != "" {
-		w.Header().Add("Etag", etag)
-	}
-	w.WriteHeader(http.StatusOK)
-	_, _ = w.Write(data)
+		w.Header().Add("Content-Type", "application/json")
+		if etag != "" {
+			w.Header().Add("Etag", etag)
+		}
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write(data)
+	})
+}
+
+func (p *PollingService) standardPollingHandler() http.Handler {
+	return p.pollingHandler(func(p *PollingService, r *http.Request) []byte {
+		return p.currentData.Serialize()
+	})
+}
+
+func (p *PollingService) phpFlagHandler() http.Handler {
+	return p.pollingHandler(func(p *PollingService, r *http.Request) []byte {
+		data, _ := p.currentData.(ServerSDKData)
+		return data["flags"][mux.Vars(r)["key"]]
+	})
+}
+
+func (p *PollingService) phpSegmentHandler() http.Handler {
+	return p.pollingHandler(func(p *PollingService, r *http.Request) []byte {
+		data, _ := p.currentData.(ServerSDKData)
+		return data["segments"][mux.Vars(r)["key"]]
+	})
+}
+
+func (p *PollingService) phpAllFlagsHandler() http.Handler {
+	return p.pollingHandler(func(p *PollingService, r *http.Request) []byte {
+		data, _ := p.currentData.(ServerSDKData)
+		flagsJSON, _ := json.Marshal(data["flags"])
+		return flagsJSON
+	})
 }
 
 func (p *PollingService) SetData(data SDKData) {

--- a/mockld/sdk_data.go
+++ b/mockld/sdk_data.go
@@ -21,10 +21,11 @@ const (
 	ServerSideSDK SDKKind = "server"
 	MobileSDK     SDKKind = "mobile"
 	JSClientSDK   SDKKind = "jsclient"
+	PHPSDK        SDKKind = "php"
 )
 
 func (k SDKKind) IsServerSide() bool {
-	return k == ServerSideSDK
+	return k == ServerSideSDK || k == PHPSDK
 }
 
 func (k SDKKind) IsClientSide() bool {
@@ -55,6 +56,8 @@ func (b blockingUnavailableSDKData) Serialize() []byte { return nil }
 //
 // This includes the full JSON configuration of every flag and segment, in the same format that is used in
 // streaming and polling responses.
+//
+// We use this for both regular server-side SDKs and the PHP SDK.
 type ServerSDKData map[DataItemKind]map[string]json.RawMessage
 
 // ClientSDKData contains simulated LaunchDarkly environment data for a client-side SDK.

--- a/sdktests/php_eval.go
+++ b/sdktests/php_eval.go
@@ -1,0 +1,18 @@
+package sdktests
+
+import (
+	"github.com/launchdarkly/sdk-test-harness/framework/ldtest"
+)
+
+func doPHPEvalTests(t *ldtest.T) {
+	// There's no special PHP version of the evaluation tests - we're just calling the regular
+	// server-side versions of those tests. The special behavior that applies for PHP is in
+	// how we set up the polling endpoints in the mock data source, and that is handled
+	// transparently by the logic in mockld/polling_service.go based on the fact that the
+	// "SDK kind" configured for test suite is PHP.
+	t.Run("parameterized", runParameterizedServerSideEvalTests)
+	t.Run("bucketing", runServerSideEvalBucketingTests)
+	t.Run("all flags state", runServerSideEvalAllFlagsTests)
+
+	// t.Run("client not ready", runParameterizedServerSideClientNotReadyEvalTests)
+}

--- a/sdktests/testapi_sdk_data.go
+++ b/sdktests/testapi_sdk_data.go
@@ -86,7 +86,7 @@ func NewSDKDataSourceWithoutEndpoint(t *ldtest.T, data mockld.SDKData, options .
 		data = mockld.EmptyData(sdkKind)
 	}
 
-	defaultIsPolling := sdkKind == mockld.JSClientSDK
+	defaultIsPolling := sdkKind == mockld.JSClientSDK || sdkKind == mockld.PHPSDK
 	d := &SDKDataSource{}
 	if config.polling.Value() || (!config.polling.IsDefined() && defaultIsPolling) {
 		d.pollingService = mockld.NewPollingService(data, sdkKind, t.DebugLogger())

--- a/sdktests/testsuite_entry_point.go
+++ b/sdktests/testsuite_entry_point.go
@@ -22,6 +22,9 @@ func RunSDKTestSuite(
 	var sdkKind mockld.SDKKind
 
 	switch {
+	case capabilities.Has(servicedef.CapabilityServerSide) && capabilities.Has(servicedef.CapabilityPHP):
+		fmt.Println("Running PHP SDK test suite")
+		sdkKind = mockld.PHPSDK
 	case capabilities.Has(servicedef.CapabilityServerSide):
 		fmt.Println("Running server-side SDK test suite")
 		sdkKind = mockld.ServerSideSDK
@@ -63,6 +66,8 @@ func RunSDKTestSuite(
 		switch sdkKind {
 		case mockld.ServerSideSDK:
 			doAllServerSideTests(t)
+		case mockld.PHPSDK:
+			doAllPHPTests(t)
 		default:
 			doAllClientSideTests(t)
 		}
@@ -86,6 +91,10 @@ func doAllClientSideTests(t *ldtest.T) {
 	t.Run("streaming", doClientSideStreamTests)
 	t.Run("polling", doClientSidePollTests)
 	t.Run("tags", doClientSideTagsTests)
+}
+
+func doAllPHPTests(t *ldtest.T) {
+	t.Run("evaluation", doPHPEvalTests)
 }
 
 func allImportantServerSideCapabilities() framework.Capabilities {

--- a/servicedef/service_params.go
+++ b/servicedef/service_params.go
@@ -7,6 +7,7 @@ const (
 	CapabilityServerSide    = "server-side"
 	CapabilityStronglyTyped = "strongly-typed"
 	CapabilityMobile        = "mobile"
+	CapabilityPHP           = "php"
 	CapabilitySingleton     = "singleton"
 
 	CapabilityAllFlagsWithReasons                = "all-flags-with-reasons"


### PR DESCRIPTION
This is the first step in adding contract test support for the PHP SDK. Due to the PHP SDK's atypical requirements and architecture, many of the contract tests aren't applicable to it, but we do want to at least verify its evaluation engine and event behavior; this PR is just for the evaluation tests.

Fortunately, the architecture of sdk-test-harness makes this a not-huge task. The server-side evaluation tests can actually be reused in their entirety; the special behavior for PHP only needs to be implemented in the fake data source component. Basically, each of the evaluation tests is configured with a full set of flag/segment data (like: `{"flags": {"flag1": {...}, "flag2": {...}}, "segments": {...}}`), and if we were testing a regular server-side SDK, the data source endpoint would return literally that data. But if we're testing the PHP SDK, we instead create multiple data source endpoints (`/flags`, `/flags/{key}`, `/segments/{key}`), corresponding to the request paths used by the PHP SDK, and each is configured to extract the appropriate subset of the configured data.

In the development repo for the PHP SDK, there is a WIP branch for the test service implementation to make this work.