### PR TITLE
implement PHP SDK event tests

### DIFF
--- a/sdktests/client_side_events_all.go
+++ b/sdktests/client_side_events_all.go
@@ -26,7 +26,10 @@ func doClientSideEventRequestTests(t *ldtest.T) {
 	eventTests := NewCommonEventTests(t, "doClientSideEventRequestTests",
 		WithCredential(envIDOrMobileKey))
 
-	eventTests.RequestMethodAndHeaders(t, envIDOrMobileKey)
+	eventTests.RequestMethodAndHeaders(t, envIDOrMobileKey, m.AllOf(
+		Header("X-LaunchDarkly-Event-Schema").Should(m.Equal(regularEventSchema)),
+		Header("X-LaunchDarkly-Payload-Id").Should(m.Not(m.Equal(""))),
+	))
 
 	requestPathMatcher := h.IfElse(
 		sdkKind == mockld.JSClientSDK,

--- a/sdktests/client_side_events_experimentation.go
+++ b/sdktests/client_side_events_experimentation.go
@@ -64,9 +64,8 @@ func doClientSideExperimentationEventTests(t *ldtest.T) {
 			payload := eventSink.ExpectAnalyticsEvents(t, time.Second)
 
 			matchFeatureEvent := IsValidFeatureEventWithConditions(
+				false, false, user,
 				m.JSONProperty("key").Should(m.Equal(flagKey)),
-				HasUserKeyProperty(user.GetKey()),
-				HasNoUserObject(),
 				m.JSONProperty("version").Should(m.Equal(flagVersion)),
 				m.JSONProperty("value").Should(m.JSONEqual(expectedValue)),
 				m.JSONProperty("variation").Should(m.Equal(expectedVariation)),

--- a/sdktests/common_tests_base.go
+++ b/sdktests/common_tests_base.go
@@ -15,6 +15,7 @@ type commonTestsBase struct {
 	sdkKind        mockld.SDKKind
 	isClientSide   bool
 	isMobile       bool
+	isPHP          bool
 	sdkConfigurers []SDKConfigurer
 	userFactory    *UserFactory
 }
@@ -33,6 +34,7 @@ func newCommonTestsBase(t *ldtest.T, testName string, baseSDKConfigurers ...SDKC
 	}
 	c.isClientSide = c.sdkKind.IsClientSide()
 	c.isMobile = t.Capabilities().Has(servicedef.CapabilityMobile)
+	c.isPHP = c.sdkKind == mockld.PHPSDK
 	if c.isClientSide {
 		c.sdkConfigurers = append(
 			[]SDKConfigurer{

--- a/sdktests/common_tests_events_custom.go
+++ b/sdktests/common_tests_events_custom.go
@@ -32,6 +32,9 @@ func (c CommonEventTests) CustomEvents(t *ldtest.T) {
 		}
 
 		for _, inlineUser := range []bool{false, true} {
+			if !inlineUser && c.isPHP {
+				continue // the PHP SDK always inlines users in events
+			}
 			t.Run(h.IfElse(inlineUser, "inline user", "non-inline user"), func(t *ldtest.T) {
 				for _, anonymousUser := range []bool{false, true} {
 					t.Run(h.IfElse(anonymousUser, "anonymous user", "non-anonymous user"), func(t *ldtest.T) {
@@ -43,6 +46,8 @@ func (c CommonEventTests) CustomEvents(t *ldtest.T) {
 						client := NewSDKClient(t, c.baseSDKConfigurationPlus(WithEventsConfig(eventsConfig), dataSource, events)...)
 
 						if c.isClientSide {
+							// For client-side SDKs, we do an identify first to set the current user; then we
+							// consume and ignore the identify event.
 							client.SendIdentifyEvent(t, user)
 							client.FlushEvents(t)
 							_ = events.ExpectAnalyticsEvents(t, defaultEventTimeout)

--- a/sdktests/common_tests_events_request.go
+++ b/sdktests/common_tests_events_request.go
@@ -1,7 +1,6 @@
 package sdktests
 
 import (
-	"strconv"
 	"strings"
 	"time"
 
@@ -13,9 +12,10 @@ import (
 	m "github.com/launchdarkly/go-test-helpers/v2/matchers"
 )
 
-const currentEventSchema = 3
+const regularEventSchema = "3"
+const phpEventSchema = "2"
 
-func (c CommonEventTests) RequestMethodAndHeaders(t *ldtest.T, credential string) {
+func (c CommonEventTests) RequestMethodAndHeaders(t *ldtest.T, credential string, headersMatcher m.Matcher) {
 	t.Run("method and headers", func(t *ldtest.T) {
 		dataSource := NewSDKDataSource(t, nil)
 		events := NewSDKEventSink(t)
@@ -28,13 +28,10 @@ func (c CommonEventTests) RequestMethodAndHeaders(t *ldtest.T, credential string
 
 		m.In(t).For("request method").Assert(request.Method, m.Equal("POST"))
 
-		m.In(t).For("request headers").Assert(request.Headers,
-			m.AllOf(
-				Header("X-LaunchDarkly-Event-Schema").Should(m.Equal(strconv.Itoa(currentEventSchema))),
-				Header("X-LaunchDarkly-Payload-Id").Should(m.Not(m.Equal(""))),
-				c.authorizationHeaderMatcher(credential),
-			),
-		)
+		m.In(t).For("request headers").Assert(request.Headers, m.AllOf(
+			headersMatcher,
+			c.authorizationHeaderMatcher(credential),
+		))
 	})
 }
 

--- a/sdktests/php_events_all.go
+++ b/sdktests/php_events_all.go
@@ -1,0 +1,41 @@
+package sdktests
+
+import (
+	m "github.com/launchdarkly/go-test-helpers/v2/matchers"
+	"github.com/launchdarkly/sdk-test-harness/framework/ldtest"
+	"github.com/launchdarkly/sdk-test-harness/servicedef"
+)
+
+// Although the PHP SDK is a server-side SDK, it has different analytics event behavior than
+// the other server-side SDKs due to its stateless nature. The events it produces use a
+// different schema in which there are no summary events, every evaluation causes a feature
+// event, and every event contains inline user properties.
+//
+// In most cases, we have not implemented completely different test methods; we call the
+// same server-side test methods, but the underlying implementations in common_tests_events_*
+// will use slightly different logic when they detect that we are testing the PHP SDK.
+
+func doPHPEventTests(t *ldtest.T) {
+	t.Run("requests", doPHPEventRequestTests)
+	t.Run("feature events", doPHPFeatureEventTests)
+	t.Run("feature prerequisite events", doServerSideFeaturePrerequisiteEventTests)
+	t.Run("experimentation", doServerSideExperimentationEventTests)
+	t.Run("identify events", doServerSideIdentifyEventTests)
+	t.Run("custom events", doServerSideCustomEventTests)
+	t.Run("alias events", doServerSideAliasEventTests)
+	t.Run("user properties", doServerSideEventUserTests)
+}
+
+func doPHPEventRequestTests(t *ldtest.T) {
+	sdkKey := "my-sdk-key"
+
+	eventTests := NewCommonEventTests(t, "doPHPEventRequestTests",
+		WithConfig(servicedef.SDKConfigParams{
+			Credential: sdkKey,
+		}))
+
+	eventTests.RequestMethodAndHeaders(t, sdkKey,
+		Header("X-LaunchDarkly-Event-Schema").Should(m.Equal(phpEventSchema)))
+
+	eventTests.RequestURLPath(t, m.Equal("/bulk"))
+}

--- a/sdktests/php_events_eval.go
+++ b/sdktests/php_events_eval.go
@@ -1,0 +1,163 @@
+package sdktests
+
+import (
+	"fmt"
+	"time"
+
+	h "github.com/launchdarkly/sdk-test-harness/framework/helpers"
+	"github.com/launchdarkly/sdk-test-harness/framework/ldtest"
+	o "github.com/launchdarkly/sdk-test-harness/framework/opt"
+	"github.com/launchdarkly/sdk-test-harness/mockld"
+	"github.com/launchdarkly/sdk-test-harness/servicedef"
+
+	m "github.com/launchdarkly/go-test-helpers/v2/matchers"
+	"gopkg.in/launchdarkly/go-sdk-common.v2/ldreason"
+	"gopkg.in/launchdarkly/go-sdk-common.v2/ldtime"
+	"gopkg.in/launchdarkly/go-sdk-common.v2/ldvalue"
+	"gopkg.in/launchdarkly/go-server-sdk-evaluation.v1/ldbuilders"
+
+	"github.com/stretchr/testify/require"
+)
+
+// The PHP's analytics event behavior regarding evaluations is different enough from the other
+// server-side SDKs that it would be hard to share the test implementation without having a
+// confusing amount of conditional behavior.
+//
+// - Every evaluation produces a "feature" event.
+// - There are never any "index" or "summary" events.
+// - The event always contains an inline user.
+// - The "trackEvents" and "debugEventsUntilDate" properties of the flag do not affect what
+//   kind of events are produced. Instead, the PHP SDK simply includes those properties in the
+//   event-- to be used when the Relay Proxy summarizes the event data.
+
+func doPHPFeatureEventTests(t *ldtest.T) {
+	flagValues := FlagValueByTypeFactory()
+	defaultValues := DefaultValueByTypeFactory()
+	users := NewUserFactory("doPHPFeatureEventTests")
+	expectedReason := ldreason.NewEvalReasonFallthrough()
+	debugDate := ldtime.UnixMillisecondTime(12345678)
+
+	type flagSelectors struct {
+		tracked, withDebug, malformed bool
+	}
+	describe := func(fs flagSelectors) string {
+		return fmt.Sprintf("%s-%s-%s",
+			h.IfElse(fs.tracked, "tracked", "untracked"),
+			h.IfElse(fs.withDebug, "debug", "nodebug"),
+			h.IfElse(fs.malformed, "malformed", "valid"))
+	}
+	var allFlagSelectors []flagSelectors
+	for _, tracked := range []bool{false, true} {
+		for _, withDebug := range []bool{false, true} {
+			for _, malformed := range []bool{false, true} {
+				allFlagSelectors = append(allFlagSelectors, flagSelectors{tracked, withDebug, malformed})
+			}
+		}
+	}
+	flagFactories := make(map[flagSelectors]*FlagFactoryForValueTypes)
+	for _, fs := range allFlagSelectors {
+		fs := fs
+		flagFactories[fs] = &FlagFactoryForValueTypes{
+			KeyPrefix: fmt.Sprintf("%s-flag", describe(fs)),
+			Reason:    expectedReason,
+			BuilderActions: func(b *ldbuilders.FlagBuilder) {
+				b.TrackEvents(fs.tracked)
+				if fs.withDebug {
+					b.DebugEventsUntilDate(debugDate)
+				}
+				if fs.malformed {
+					b.On(false).OffVariation(-1)
+				}
+			}}
+	}
+
+	dataBuilder := mockld.NewServerSDKDataBuilder()
+	for _, factory := range flagFactories {
+		for _, valueType := range getValueTypesToTest(t) {
+			dataBuilder.Flag(factory.ForType(valueType))
+		}
+	}
+
+	dataSource := NewSDKDataSource(t, dataBuilder.Build())
+	events := NewSDKEventSink(t)
+
+	client := NewSDKClient(t, dataSource, events)
+
+	doFeatureEventTest := func(t *ldtest.T, fs flagSelectors, withReason, isAnonymousUser bool) {
+		for _, valueType := range getValueTypesToTest(t) {
+			t.Run(testDescFromType(valueType), func(t *ldtest.T) {
+				flag := flagFactories[fs].ForType(valueType)
+				var expectedValue ldvalue.Value
+				var expectedVariation o.Maybe[int]
+				if fs.malformed {
+					expectedValue = defaultValues(valueType)
+					expectedVariation = o.None[int]()
+				} else {
+					expectedValue = flagValues(valueType)
+					expectedVariation = o.Some(0)
+				}
+				user := users.NextUniqueUserMaybeAnonymous(isAnonymousUser)
+				resp := client.EvaluateFlag(t, servicedef.EvaluateFlagParams{
+					FlagKey:      flag.Key,
+					User:         o.Some(user),
+					ValueType:    valueType,
+					DefaultValue: defaultValues(valueType),
+					Detail:       withReason,
+				})
+
+				// If the evaluation didn't return the expected value, then the rest of the test is moot
+				if !m.In(t).Assert(expectedValue, m.JSONEqual(resp.Value)) {
+					require.Fail(t, "evaluation unexpectedly returned wrong value")
+				}
+
+				client.FlushEvents(t)
+
+				reason := expectedReason
+				if fs.malformed {
+					reason = ldreason.NewEvalReasonError(ldreason.EvalErrorMalformedFlag)
+				}
+				propMatchers := []m.Matcher{
+					m.JSONProperty("key").Should(m.Equal(flag.Key)),
+					m.JSONProperty("version").Should(m.Equal(flag.Version)),
+					m.JSONProperty("value").Should(m.JSONEqual(expectedValue)),
+					m.JSONOptProperty("variation").Should(m.JSONEqual(expectedVariation)),
+					maybeReason(withReason, reason),
+					m.JSONProperty("default").Should(m.JSONEqual(defaultValues(valueType))),
+					JSONPropertyNullOrAbsent("prereqOf"),
+					m.JSONOptProperty("trackEvents").Should(
+						h.IfElse(fs.tracked, m.JSONEqual(true), m.AnyOf(m.BeNil(), m.JSONEqual(false))),
+					),
+					m.JSONOptProperty("debugEventsUntilDate").Should(
+						h.IfElse(fs.withDebug, m.JSONEqual(debugDate), m.BeNil()),
+					),
+				}
+				matchFeatureEvent := IsValidFeatureEventWithConditions(true, true, user, propMatchers...)
+
+				payload := events.ExpectAnalyticsEvents(t, defaultEventTimeout)
+				m.In(t).Assert(payload, m.Items(matchFeatureEvent))
+			})
+		}
+	}
+
+	for _, fs := range allFlagSelectors {
+		t.Run(describe(fs), func(t *ldtest.T) {
+			for _, withReason := range []bool{false, true} {
+				t.Run(h.IfElse(withReason, "with reason", "without reason"), func(t *ldtest.T) {
+					for _, isAnonymousUser := range []bool{false, true} {
+						t.Run(h.IfElse(isAnonymousUser, "anonymous user", "non-anonymous user"), func(t *ldtest.T) {
+							doFeatureEventTest(t, fs, withReason, isAnonymousUser)
+						})
+					}
+				})
+			}
+		})
+	}
+
+	t.Run("evaluating all flags generates no events", func(t *ldtest.T) {
+		_ = client.EvaluateAllFlags(t, servicedef.EvaluateAllFlagsParams{
+			User: o.Some(users.NextUniqueUser()),
+		})
+		client.FlushEvents(t)
+		events.ExpectNoAnalyticsEvents(t, time.Millisecond*200)
+	})
+}

--- a/sdktests/server_side_events_all.go
+++ b/sdktests/server_side_events_all.go
@@ -31,7 +31,10 @@ func doServerSideEventRequestTests(t *ldtest.T) {
 			Credential: sdkKey,
 		}))
 
-	eventTests.RequestMethodAndHeaders(t, sdkKey)
+	eventTests.RequestMethodAndHeaders(t, sdkKey, m.AllOf(
+		Header("X-LaunchDarkly-Event-Schema").Should(m.Equal(regularEventSchema)),
+		Header("X-LaunchDarkly-Payload-Id").Should(m.Not(m.Equal(""))),
+	))
 
 	eventTests.RequestURLPath(t, m.Equal("/bulk"))
 

--- a/sdktests/server_side_events_eval.go
+++ b/sdktests/server_side_events_eval.go
@@ -121,9 +121,8 @@ func doServerSideFeatureEventTests(t *ldtest.T) {
 					reason = ldreason.NewEvalReasonError(ldreason.EvalErrorMalformedFlag)
 				}
 				matchFeatureEvent := IsValidFeatureEventWithConditions(
+					false, false, user,
 					m.JSONProperty("key").Should(m.Equal(flag.Key)),
-					HasUserKeyProperty(user.GetKey()),
-					HasNoUserObject(),
 					m.JSONProperty("version").Should(m.Equal(flag.Version)),
 					m.JSONProperty("value").Should(m.JSONEqual(expectedValue)),
 					m.JSONOptProperty("variation").Should(m.JSONEqual(expectedVariation)),
@@ -308,6 +307,11 @@ func doServerSideDebugEventTests(t *ldtest.T) {
 }
 
 func doServerSideFeaturePrerequisiteEventTests(t *ldtest.T) {
+	// The test logic for this is *almost* exactly the same for PHP as for other server-side SDKs
+	// (the only difference is the absence of index and summary events), so we reuse the same
+	// function.
+	isPHP := t.Capabilities().Has(servicedef.CapabilityPHP)
+
 	user := lduser.NewUser("user-key")
 
 	expectedValue1 := ldvalue.String("value1")
@@ -356,12 +360,10 @@ func doServerSideFeaturePrerequisiteEventTests(t *ldtest.T) {
 			client.FlushEvents(t)
 			payload := events.ExpectAnalyticsEvents(t, defaultEventTimeout)
 
-			m.In(t).Assert(payload, m.ItemsInAnyOrder(
-				IsIndexEventForUserKey(user.GetKey()),
+			eventMatchers := []m.Matcher{
 				IsValidFeatureEventWithConditions(
+					isPHP, false, user,
 					m.JSONProperty("key").Should(m.Equal(flag1.Key)),
-					HasUserKeyProperty(user.GetKey()),
-					HasNoUserObject(),
 					m.JSONProperty("version").Should(m.Equal(flag1.Version)),
 					m.JSONProperty("value").Should(m.Equal("value1")),
 					m.JSONProperty("variation").Should(m.Equal(1)),
@@ -369,9 +371,8 @@ func doServerSideFeaturePrerequisiteEventTests(t *ldtest.T) {
 					JSONPropertyNullOrAbsent("prereqOf"),
 				),
 				IsValidFeatureEventWithConditions(
+					isPHP, false, user,
 					m.JSONProperty("key").Should(m.Equal(flag2.Key)),
-					HasUserKeyProperty(user.GetKey()),
-					HasNoUserObject(),
 					m.JSONProperty("version").Should(m.Equal(flag2.Version)),
 					m.JSONProperty("value").Should(m.Equal("ok2")),
 					m.JSONProperty("variation").Should(m.Equal(2)),
@@ -380,9 +381,8 @@ func doServerSideFeaturePrerequisiteEventTests(t *ldtest.T) {
 					m.JSONOptProperty("prereqOf").Should(m.Equal("flag1")),
 				),
 				IsValidFeatureEventWithConditions(
+					isPHP, false, user,
 					m.JSONProperty("key").Should(m.Equal(flag3.Key)),
-					HasUserKeyProperty(user.GetKey()),
-					HasNoUserObject(),
 					m.JSONProperty("version").Should(m.Equal(flag3.Version)),
 					m.JSONProperty("value").Should(m.Equal("ok3")),
 					m.JSONProperty("variation").Should(m.Equal(3)),
@@ -390,8 +390,11 @@ func doServerSideFeaturePrerequisiteEventTests(t *ldtest.T) {
 					JSONPropertyNullOrAbsent("default"),
 					m.JSONOptProperty("prereqOf").Should(m.Equal("flag2")),
 				),
-				IsSummaryEvent(),
-			))
+			}
+			if !isPHP {
+				eventMatchers = append(eventMatchers, IsIndexEventForUserKey(user.GetKey()), IsSummaryEvent())
+			}
+			m.In(t).Assert(payload, m.ItemsInAnyOrder(eventMatchers...))
 		})
 	}
 

--- a/sdktests/testsuite_entry_point.go
+++ b/sdktests/testsuite_entry_point.go
@@ -95,6 +95,8 @@ func doAllClientSideTests(t *ldtest.T) {
 
 func doAllPHPTests(t *ldtest.T) {
 	t.Run("evaluation", doPHPEvalTests)
+	t.Run("events", doPHPEventTests)
+	t.Run("secure mode hash", doServerSideSecureModeHashTests)
 }
 
 func allImportantServerSideCapabilities() framework.Capabilities {


### PR DESCRIPTION
This adds PHP equivalents of most of the server-side SDK analytics event tests. The ones that aren't supported are:

* summary events, index events - these don't exist in PHP.
* debug events - these don't exist in PHP; instead, the SDK passes the flag's debugEventsUntilDate property as part of the feature event, so test cases for that have been incorporated into the feature event tests.
* event capacity - the PHP SDK has no setting for this.
* disabling - the PHP SDK does let you disable events, but implementing this test would require a change in the test service (to let it accept a `serviceEndpoints` option).

These tests all pass against the current PHP SDK test service. Also, since the implementation involved adding conditional behavior to some existing test logic, I reran the tests against go-server-sdk and dotnet-client-sdk to make sure I hadn't broken tests for non-PHP server-side and client-side SDKs.