### PR TITLE
completely remove tests for "secondary"

### DIFF
--- a/data/context_factory.go
+++ b/data/context_factory.go
@@ -140,7 +140,6 @@ func NewContextFactoriesForExercisingAllAttributes(
 ) []*ContextFactory {
 	setAllAttributes := func(b *ldcontext.Builder) {
 		b.Name("a").
-			Secondary("b").
 			Anonymous(true).
 			SetBool("c", true).
 			SetInt("d", 1).

--- a/data/context_factory_test.go
+++ b/data/context_factory_test.go
@@ -19,14 +19,14 @@ func equalsKind(kind ldcontext.Kind) m.Matcher { return m.Equal(kind) }
 func setContextName(name string) func(*ldcontext.Builder) {
 	return func(b *ldcontext.Builder) { b.Name(name) }
 }
-func setContextSecondary(value string) func(*ldcontext.Builder) {
-	return func(b *ldcontext.Builder) { b.Secondary(value) }
+func setContextAnonymous(value bool) func(*ldcontext.Builder) {
+	return func(b *ldcontext.Builder) { b.Anonymous(value) }
 }
 
 func TestContextFactory(t *testing.T) {
 	f := NewContextFactory("abcde",
 		setContextName("x"),
-		setContextSecondary("y"),
+		setContextAnonymous(true),
 	)
 
 	c1 := f.NextUniqueContext()
@@ -34,14 +34,14 @@ func TestContextFactory(t *testing.T) {
 	m.In(t).Assert(c1.Kind(), equalsKind(ldcontext.DefaultKind))
 	m.In(t).Assert(c1.Key(), m.StringHasPrefix("abcde."))
 	m.In(t).Assert(c1.Name(), equalsOptString("x"))
-	m.In(t).Assert(c1.Secondary(), equalsOptString("y"))
+	m.In(t).Assert(c1.Anonymous(), m.Equal(true))
 
 	c2 := f.NextUniqueContext()
 	assert.False(t, c2.Multiple())
 	m.In(t).Assert(c2.Kind(), equalsKind(ldcontext.DefaultKind))
 	m.In(t).Assert(c2.Key(), m.StringHasPrefix("abcde."))
 	m.In(t).Assert(c2.Name(), equalsOptString("x"))
-	m.In(t).Assert(c2.Secondary(), equalsOptString("y"))
+	m.In(t).Assert(c1.Anonymous(), m.Equal(true))
 }
 
 func TestContextFactoryKeyCollisions(t *testing.T) {
@@ -61,8 +61,8 @@ func TestContextFactoryKeyCollisions(t *testing.T) {
 
 func TestMultiContextFactory(t *testing.T) {
 	f := NewMultiContextFactory("abcde", []ldcontext.Kind{"org", "other"},
-		setContextName("x"),      // for MultiContextFactory, the first of these builderActions is only for the first kind
-		setContextSecondary("y"), // and the second is only for the second kind
+		setContextName("x"),       // for MultiContextFactory, the first of these builderActions is only for the first kind
+		setContextAnonymous(true), // and the second is only for the second kind
 	)
 
 	c1 := f.NextUniqueContext()
@@ -72,12 +72,12 @@ func TestMultiContextFactory(t *testing.T) {
 	m.In(t).Assert(c1a.Kind(), equalsKind("org"))
 	m.In(t).Assert(c1a.Key(), m.StringHasPrefix("abcde."))
 	m.In(t).Assert(c1a.Name(), equalsOptString("x"))
-	m.In(t).Assert(c1a.Secondary(), optStringEmpty())
+	m.In(t).Assert(c1.Anonymous(), m.Equal(false))
 	c1b := c1.IndividualContextByIndex(1)
 	m.In(t).Assert(c1b.Kind(), equalsKind("other"))
 	m.In(t).Assert(c1b.Key(), m.StringHasPrefix("abcde."))
 	m.In(t).Assert(c1b.Name(), optStringEmpty())
-	m.In(t).Assert(c1b.Secondary(), equalsOptString("y"))
+	m.In(t).Assert(c1.Anonymous(), m.Equal(true))
 
 	c2 := f.NextUniqueContext()
 	assert.True(t, c2.Multiple())
@@ -86,18 +86,18 @@ func TestMultiContextFactory(t *testing.T) {
 	m.In(t).Assert(c2a.Kind(), equalsKind("org"))
 	m.In(t).Assert(c2a.Key(), m.StringHasPrefix("abcde."))
 	m.In(t).Assert(c2a.Name(), equalsOptString("x"))
-	m.In(t).Assert(c2a.Secondary(), optStringEmpty())
+	m.In(t).Assert(c1.Anonymous(), m.Equal(false))
 	c2b := c2.IndividualContextByIndex(1)
 	m.In(t).Assert(c2b.Kind(), equalsKind("other"))
 	m.In(t).Assert(c2b.Key(), m.StringHasPrefix("abcde."))
 	m.In(t).Assert(c2b.Name(), optStringEmpty())
-	m.In(t).Assert(c2b.Secondary(), equalsOptString("y"))
+	m.In(t).Assert(c1.Anonymous(), m.Equal(true))
 }
 
 func TestNewContextFactoriesForSingleAndMultiKind(t *testing.T) {
 	fs := NewContextFactoriesForSingleAndMultiKind("abcde",
 		setContextName("x"),
-		setContextSecondary("y"),
+		setContextAnonymous(true),
 	)
 	require.Len(t, fs, 3)
 
@@ -112,10 +112,10 @@ func TestNewContextFactoriesForSingleAndMultiKind(t *testing.T) {
 				m.In(t).Assert(mc.Key(), m.StringHasPrefix("abcde"))
 				if i == 0 {
 					m.In(t).Assert(mc.Name(), equalsOptString("x"))
-					m.In(t).Assert(mc.Secondary(), optStringEmpty())
+					m.In(t).Assert(mc.Anonymous(), m.Equal(false))
 				} else {
 					m.In(t).Assert(mc.Name(), optStringEmpty())
-					m.In(t).Assert(mc.Secondary(), equalsOptString("y"))
+					m.In(t).Assert(mc.Anonymous(), m.Equal(true))
 				}
 			}
 		} else {

--- a/data/context_factory_test.go
+++ b/data/context_factory_test.go
@@ -72,12 +72,12 @@ func TestMultiContextFactory(t *testing.T) {
 	m.In(t).Assert(c1a.Kind(), equalsKind("org"))
 	m.In(t).Assert(c1a.Key(), m.StringHasPrefix("abcde."))
 	m.In(t).Assert(c1a.Name(), equalsOptString("x"))
-	m.In(t).Assert(c1.Anonymous(), m.Equal(false))
+	m.In(t).Assert(c1a.Anonymous(), m.Equal(false))
 	c1b := c1.IndividualContextByIndex(1)
 	m.In(t).Assert(c1b.Kind(), equalsKind("other"))
 	m.In(t).Assert(c1b.Key(), m.StringHasPrefix("abcde."))
 	m.In(t).Assert(c1b.Name(), optStringEmpty())
-	m.In(t).Assert(c1.Anonymous(), m.Equal(true))
+	m.In(t).Assert(c1b.Anonymous(), m.Equal(true))
 
 	c2 := f.NextUniqueContext()
 	assert.True(t, c2.Multiple())
@@ -86,12 +86,12 @@ func TestMultiContextFactory(t *testing.T) {
 	m.In(t).Assert(c2a.Kind(), equalsKind("org"))
 	m.In(t).Assert(c2a.Key(), m.StringHasPrefix("abcde."))
 	m.In(t).Assert(c2a.Name(), equalsOptString("x"))
-	m.In(t).Assert(c1.Anonymous(), m.Equal(false))
+	m.In(t).Assert(c2a.Anonymous(), m.Equal(false))
 	c2b := c2.IndividualContextByIndex(1)
 	m.In(t).Assert(c2b.Kind(), equalsKind("other"))
 	m.In(t).Assert(c2b.Key(), m.StringHasPrefix("abcde."))
 	m.In(t).Assert(c2b.Name(), optStringEmpty())
-	m.In(t).Assert(c1.Anonymous(), m.Equal(true))
+	m.In(t).Assert(c2b.Anonymous(), m.Equal(true))
 }
 
 func TestNewContextFactoriesForSingleAndMultiKind(t *testing.T) {

--- a/docs/service_spec.md
+++ b/docs/service_spec.md
@@ -238,7 +238,6 @@ The `contextBuild` property in the request body will be a JSON object with these
   * `key` (string, required)
   * `name` (string, optional)
   * `anonymous` (boolean, optional)
-  * `secondary` (string, optional)
   * `private` (array of strings, optional): These strings should be treated as attribute references, i.e. they may be slash-delimited paths.
   * `custom` (object, optional): If present, these are name-value pairs for custom attributes.
 * `multi` (array, optional): If present, this is an array of objects in the same format as shown for `single` above, for a multi-kind context. Only one of `single` or `multi` will be present.

--- a/sdktests/common_tests_events_contexts.go
+++ b/sdktests/common_tests_events_contexts.go
@@ -49,7 +49,6 @@ func makeEventContextTestParams() []eventContextTestParams {
 					b.Kind("org")
 					b.Name("a")
 					b.SetString("b", "c")
-					b.Secondary("s")
 					b.Anonymous(true)
 				})
 			},
@@ -62,7 +61,6 @@ func makeEventContextTestParams() []eventContextTestParams {
 				return data.NewContextFactory(prefix, func(b *ldcontext.Builder) {
 					b.Name("a")
 					b.SetString("b", "c")
-					b.Secondary("s")
 					b.Anonymous(true)
 				})
 			},

--- a/sdktests/custom_matchers_contexts.go
+++ b/sdktests/custom_matchers_contexts.go
@@ -53,12 +53,6 @@ func jsonMatchesContext(topLevelContext ldcontext.Context, isEventContext bool, 
 
 		var meta []m.Matcher
 		requireMeta := false
-		if c.Secondary().IsDefined() {
-			meta = append(meta, m.JSONProperty("secondary").Should(m.Equal(c.Secondary().String())))
-			requireMeta = true
-		} else {
-			meta = append(meta, m.JSONOptProperty("secondary").Should(m.BeNil()))
-		}
 		if isEventContext {
 			if len(redactedShouldBe) != 0 {
 				meta = append(meta, m.JSONProperty("redactedAttributes").Should(RedactedAttributesAre(redactedShouldBe...)))

--- a/sdktests/custom_matchers_contexts_test.go
+++ b/sdktests/custom_matchers_contexts_test.go
@@ -31,19 +31,11 @@ func TestJSONMatchesContext(t *testing.T) {
 			},
 			{
 				c:     ldcontext.NewWithKind("a", "b"),
-				input: `{"kind": "a", "key": "b", "_meta": {"secondary": null}}`,
-			},
-			{
-				c:     ldcontext.NewWithKind("a", "b"),
 				input: `{"kind": "a", "key": "b", "_meta": {"privateAttributes": null}}`,
 			},
 			{
 				c:     ldcontext.NewWithKind("a", "b"),
 				input: `{"kind": "a", "key": "b", "_meta": {"privateAttributes": []}}`,
-			},
-			{
-				c:     ldcontext.NewBuilder("a").Anonymous(true).Name("b").Secondary("c").Build(),
-				input: `{"kind": "user", "key": "a", "anonymous": true, "name": "b", "_meta": {"secondary": "c"}}`,
 			},
 			{
 				c:     ldcontext.NewBuilder("a").Name("b").Private("d", "c").Build(),
@@ -86,10 +78,6 @@ func TestJSONMatchesContext(t *testing.T) {
 			},
 			{
 				c:     ldcontext.NewWithKind("a", "b"),
-				input: `{"kind": "a", "key": "b", "_meta": {"secondary": "c"}}`,
-			},
-			{
-				c:     ldcontext.NewWithKind("a", "b"),
 				input: `{"kind": "a", "key": "b", "_meta": {"privateAttributes": ["c", "d"]}}`,
 			},
 			{
@@ -99,10 +87,6 @@ func TestJSONMatchesContext(t *testing.T) {
 			{
 				c:     ldcontext.NewBuilder("a").Anonymous(true).Build(),
 				input: `{"kind": "user", "key": "a", "anonymous": false}`,
-			},
-			{
-				c:     ldcontext.NewBuilder("a").Secondary("b").Build(),
-				input: `{"kind": "user", "key": "a", "anonymous": true, "name": "b", "_meta": {"secondary": "c"}}`,
 			},
 			{
 				c:     ldcontext.NewBuilder("a").Name("b").Private("c", "d", "e").Build(),

--- a/sdktests/helpers.go
+++ b/sdktests/helpers.go
@@ -53,7 +53,6 @@ func basicEvaluateFlag(
 func computeExpectedBucketValue(
 	userValue string,
 	flagOrSegmentKey, salt string,
-	secondary o.Maybe[string],
 	seed o.Maybe[int],
 ) int {
 	hashInput := ""
@@ -64,9 +63,6 @@ func computeExpectedBucketValue(
 		hashInput += flagOrSegmentKey + "." + salt
 	}
 	hashInput += "." + userValue
-	if secondary.IsDefined() {
-		hashInput += "." + secondary.Value()
-	}
 
 	hashOutputBytes := sha1.Sum([]byte(hashInput)) //nolint:gosec // this isn't for authentication
 	hexEncodedChars := make([]byte, 64)

--- a/sdktests/helpers_test.go
+++ b/sdktests/helpers_test.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 	"testing"
 
-	h "github.com/launchdarkly/sdk-test-harness/v2/framework/helpers"
 	o "github.com/launchdarkly/sdk-test-harness/v2/framework/opt"
 
 	"github.com/launchdarkly/go-sdk-common/v3/ldattr"
@@ -34,23 +33,9 @@ func TestComputeExpectedBucketValue(t *testing.T) {
 				p.userValue,
 				p.flagOrSegmentKey,
 				p.salt,
-				o.None[string](),
 				p.seed,
 			)
 			assert.Equal(t, p.expectedValue, computedValue, "computed value did not match expected value")
-
-			for _, secondary := range []string{"abcdef", ""} {
-				valueWithSecondaryKey := computeExpectedBucketValue(
-					p.userValue,
-					p.flagOrSegmentKey,
-					p.salt,
-					o.Some(secondary),
-					p.seed,
-				)
-				failureDesc := h.IfElse(secondary == "", "empty secondary key", "empty-but-not-undefined secondary key") +
-					" should have changed result, but did not"
-				assert.NotEqual(t, p.expectedValue, valueWithSecondaryKey, failureDesc)
-			}
 		})
 	}
 }

--- a/sdktests/server_side_secure_mode_hash.go
+++ b/sdktests/server_side_secure_mode_hash.go
@@ -32,7 +32,7 @@ func doServerSideSecureModeHashTests(t *ldtest.T) {
 			// same SDK key with same user key = same result, regardless of other context attributes
 			sdkKey: sdkKey1,
 			context: ldcontext.NewBuilder(userKey1).
-				Anonymous(true).Name("a").SetString("email", "b").Secondary("c").Build(),
+				Anonymous(true).Name("a").SetString("email", "b").Build(),
 			expectedHash: "73df666a13f2c474e50aa34ca5a761e89abb737fb139ff65fdde7fa85c9dcacd",
 		},
 		{

--- a/servicedef/command_params.go
+++ b/servicedef/command_params.go
@@ -94,7 +94,6 @@ type ContextBuildSingleParams struct {
 	Key       string                   `json:"key"`
 	Name      *string                  `json:"name,omitempty"`
 	Anonymous *bool                    `json:"anonymous,omitempty"`
-	Secondary *string                  `json:"secondary,omitempty"`
 	Private   []string                 `json:"private,omitempty"`
 	Custom    map[string]ldvalue.Value `json:"custom,omitempty"`
 }


### PR DESCRIPTION
This follows from https://github.com/launchdarkly/sdk-test-harness/pull/108 and goes further by removing all test logic related to this meta-attribute. It will still be supported in LD service code, but that is using the evaluation engine outside of the SDKs; the SDKs themselves will not enable it, so testing of that logic has to be done separately (like, in the unit tests for the evaluation engines) rather than here.