### PR TITLE
Add Attribute Reference construction tests

### DIFF
--- a/sdktests/sdk_attribute_reference_type.go
+++ b/sdktests/sdk_attribute_reference_type.go
@@ -1,0 +1,170 @@
+package sdktests
+
+import (
+	"github.com/stretchr/testify/require"
+
+	"github.com/launchdarkly/go-test-helpers/v2/jsonhelpers"
+	m "github.com/launchdarkly/go-test-helpers/v2/matchers"
+	"github.com/launchdarkly/sdk-test-harness/v2/framework/ldtest"
+	"github.com/launchdarkly/sdk-test-harness/v2/mockld"
+	"github.com/launchdarkly/sdk-test-harness/v2/servicedef"
+)
+
+func doSDKAttrRefTypeTests(t *ldtest.T) {
+	t.RequireCapability(servicedef.CapabilityAttrRefType)
+	t.Run("construct", doSDKAttrRefConstructionTests)
+	t.Run("convert", doSDKAttrRefConvertAttributeNameTests)
+}
+
+// Represents valid attribute names that don't start with a
+// leading slash. These are also valid references.
+func validAttrsWithoutLeadingSlash() []string {
+	return []string{
+		" ",
+		"a",
+		"ab",
+		"a~b",
+		"a~1b",
+		"a~0b",
+		"~1",
+		"~0",
+		"a/b",
+		"a b",
+		"~",
+		"~/",
+		"an attribute name",
+		"       a       ",
+	}
+}
+
+// Represents valid attributes that start with a leading slash.
+// These can be converted into valid (single component) references.
+func validAttrsWithLeadingSlash() []string {
+	return []string{
+		"/",
+		"/a",
+		"/a/",
+		"/a//",
+		"//a",
+		"/a~",
+		"//",
+		"/~",
+		"/~~",
+		"/~",
+		"/~/",
+		"/a/b/c",
+		"/a~1b~0c",
+		"/a/b/c",
+		"/~1/~0",
+		"/ an attribute name",
+	}
+}
+
+// Note: even though these tests don't involve an SDK client instance actually doing anything, so neither
+// the data source nor the client itself are really involved-- because it's just the SDK library manipulating
+// an Attribute Reference object-- the current test harness architecture requires all test service commands to be
+// directed at a client instance.
+
+func doSDKAttrRefConstructionTests(t *ldtest.T) {
+	dataSource := NewSDKDataSource(t, mockld.EmptyServerSDKData())
+	client := NewSDKClient(t, dataSource)
+
+	t.Run("valid", func(t *ldtest.T) {
+		t.Run("plain", func(t *ldtest.T) {
+			for _, p := range validAttrsWithoutLeadingSlash() {
+				t.Run(jsonhelpers.ToJSONString(p), func(t *ldtest.T) {
+					resp := client.AttrRefConstruct(t, servicedef.AttrRefConstructParams{Input: p})
+					require.True(t, resp.Valid)
+					m.In(t).Assert(resp.Components, m.Equal([]string{p}))
+				})
+			}
+		})
+		t.Run("pointer", func(t *ldtest.T) {
+			t.Run("no escapes", func(t *ldtest.T) {
+				type testCase struct {
+					input      string
+					components []string
+				}
+				testCases := []testCase{
+					{"/a", []string{"a"}},
+					{"/a/b/c", []string{"a", "b", "c"}},
+					{"/foo/bar/baz", []string{"foo", "bar", "baz"}},
+					{"/ ", []string{" "}},
+					{"/  /  ", []string{"  ", "  "}},
+					{"/ a / b ", []string{" a ", " b "}},
+				}
+				for _, p := range testCases {
+					t.Run(jsonhelpers.ToJSONString(p.input), func(t *ldtest.T) {
+						resp := client.AttrRefConstruct(t, servicedef.AttrRefConstructParams{Input: p.input})
+						require.True(t, resp.Valid)
+						m.In(t).Assert(resp.Components, m.Equal(p.components))
+					})
+				}
+			})
+
+			t.Run("escapes", func(t *ldtest.T) {
+				type testCase struct {
+					input      string
+					components []string
+				}
+				testCases := []testCase{
+					{"/~0", []string{"~"}},
+					{"/~1", []string{"/"}},
+					{"/~01", []string{"~1"}},
+					{"/~10", []string{"/0"}},
+					{"/a~1b", []string{"a/b"}},
+					{"/a~0b", []string{"a~b"}},
+					{"/~0~1/~1~0", []string{"~/", "/~"}},
+					{"/~1~1/~0~0", []string{"//", "~~"}},
+				}
+				for _, p := range testCases {
+					t.Run(jsonhelpers.ToJSONString(p.input), func(t *ldtest.T) {
+						resp := client.AttrRefConstruct(t, servicedef.AttrRefConstructParams{Input: p.input})
+						require.True(t, resp.Valid)
+						m.In(t).Assert(resp.Components, m.Equal(p.components))
+					})
+				}
+			})
+		})
+	})
+
+	t.Run("invalid", func(t *ldtest.T) {
+		testCases := []string{
+			"",
+			"/",
+			"/~2",
+			"/a~",
+			"/~~",
+			"/~/",
+			"/~",
+			"//",
+			"/a/",
+			"/a//",
+			"//a",
+		}
+		for _, p := range testCases {
+			t.Run(jsonhelpers.ToJSONString(p), func(t *ldtest.T) {
+				resp := client.AttrRefConstruct(t, servicedef.AttrRefConstructParams{Input: p})
+				require.False(t, resp.Valid)
+			})
+		}
+	})
+}
+
+func doSDKAttrRefConvertAttributeNameTests(t *ldtest.T) {
+	dataSource := NewSDKDataSource(t, mockld.EmptyServerSDKData())
+	client := NewSDKClient(t, dataSource)
+
+	t.Run("valid attribute names", func(t *ldtest.T) {
+		testCases := validAttrsWithoutLeadingSlash()
+		testCases = append(testCases, validAttrsWithLeadingSlash()...)
+		for _, p := range testCases {
+			t.Run(jsonhelpers.ToJSONString(p), func(t *ldtest.T) {
+				resp := client.AttrRefConstruct(t, servicedef.AttrRefConstructParams{Input: p, Literal: true})
+				require.True(t, resp.Valid)
+				require.Equal(t, 1, len(resp.Components))
+				m.In(t).Assert(resp.Components[0], m.Equal(p))
+			})
+		}
+	})
+}

--- a/sdktests/testapi_sdk_client.go
+++ b/sdktests/testapi_sdk_client.go
@@ -317,6 +317,24 @@ func (c *SDKClient) ContextConvert(
 	return resp
 }
 
+// AttrRefConstruct tells the test service to use the SDK's Attribute Reference constructor to make an
+// attribute reference and return its validity state and all components.
+func (c *SDKClient) AttrRefConstruct(
+	t *ldtest.T,
+	params servicedef.AttrRefConstructParams,
+) servicedef.AttrRefConstructResponse {
+	var resp servicedef.AttrRefConstructResponse
+	require.NoError(t, c.sdkClientEntity.SendCommandWithParams(
+		servicedef.CommandParams{
+			Command:          servicedef.CommandAttrRefConstruct,
+			AttrRefConstruct: o.Some(params),
+		},
+		t.DebugLogger(),
+		&resp,
+	))
+	return resp
+}
+
 // GetSecureModeHash tells the SDK client to calculate a secure mode hash for a context. The test
 // harness will only call this method if the test service has the "secure-mode-hash" capability.
 func (c *SDKClient) GetSecureModeHash(t *ldtest.T, context ldcontext.Context) string {

--- a/sdktests/testsuite_entry_point.go
+++ b/sdktests/testsuite_entry_point.go
@@ -84,6 +84,7 @@ func doAllServerSideTests(t *ldtest.T) {
 	t.Run("tags", doServerSideTagsTests)
 	t.Run("secure mode hash", doServerSideSecureModeHashTests)
 	t.Run("context type", doSDKContextTypeTests)
+	t.Run("attribute reference type", doSDKAttrRefTypeTests)
 }
 
 func doAllClientSideTests(t *ldtest.T) {
@@ -93,6 +94,7 @@ func doAllClientSideTests(t *ldtest.T) {
 	t.Run("polling", doClientSidePollTests)
 	t.Run("tags", doClientSideTagsTests)
 	t.Run("context type", doSDKContextTypeTests)
+	t.Run("attribute reference type", doSDKAttrRefTypeTests)
 }
 
 func doAllPHPTests(t *ldtest.T) {

--- a/servicedef/command_params.go
+++ b/servicedef/command_params.go
@@ -19,6 +19,8 @@ const (
 	CommandContextBuild             = "contextBuild"
 	CommandContextConvert           = "contextConvert"
 	CommandSecureModeHash           = "secureModeHash"
+	CommandAttrRefConstruct         = "attrRefConstruct"
+	CommandAttrRefConvert           = "attrRefConvert"
 )
 
 type ValueType string
@@ -32,14 +34,15 @@ const (
 )
 
 type CommandParams struct {
-	Command        string                          `json:"command"`
-	Evaluate       o.Maybe[EvaluateFlagParams]     `json:"evaluate,omitempty"`
-	EvaluateAll    o.Maybe[EvaluateAllFlagsParams] `json:"evaluateAll,omitempty"`
-	CustomEvent    o.Maybe[CustomEventParams]      `json:"customEvent,omitempty"`
-	IdentifyEvent  o.Maybe[IdentifyEventParams]    `json:"identifyEvent,omitempty"`
-	ContextBuild   o.Maybe[ContextBuildParams]     `json:"contextBuild,omitempty"`
-	ContextConvert o.Maybe[ContextConvertParams]   `json:"contextConvert,omitempty"`
-	SecureModeHash o.Maybe[SecureModeHashParams]   `json:"secureModeHash,omitempty"`
+	Command          string                          `json:"command"`
+	Evaluate         o.Maybe[EvaluateFlagParams]     `json:"evaluate,omitempty"`
+	EvaluateAll      o.Maybe[EvaluateAllFlagsParams] `json:"evaluateAll,omitempty"`
+	CustomEvent      o.Maybe[CustomEventParams]      `json:"customEvent,omitempty"`
+	IdentifyEvent    o.Maybe[IdentifyEventParams]    `json:"identifyEvent,omitempty"`
+	ContextBuild     o.Maybe[ContextBuildParams]     `json:"contextBuild,omitempty"`
+	ContextConvert   o.Maybe[ContextConvertParams]   `json:"contextConvert,omitempty"`
+	SecureModeHash   o.Maybe[SecureModeHashParams]   `json:"secureModeHash,omitempty"`
+	AttrRefConstruct o.Maybe[AttrRefConstructParams] `json:"attrRefConstruct,omitempty"`
 }
 
 type EvaluateFlagParams struct {
@@ -113,4 +116,14 @@ type SecureModeHashParams struct {
 
 type SecureModeHashResponse struct {
 	Result string `json:"result"`
+}
+
+type AttrRefConstructParams struct {
+	Input   string `json:"input"`
+	Literal bool   `json:"literal"`
+}
+
+type AttrRefConstructResponse struct {
+	Valid      bool     `json:"valid"`
+	Components []string `json:"components"`
 }

--- a/servicedef/service_params.go
+++ b/servicedef/service_params.go
@@ -16,6 +16,7 @@ const (
 
 	CapabilityBigSegments       = "big-segments"
 	CapabilityContextType       = "context-type"
+	CapabilityAttrRefType       = "attribute-reference-type"
 	CapabilitySecureModeHash    = "secure-mode-hash"
 	CapabilityServerSidePolling = "server-side-polling"
 	CapabilityServiceEndpoints  = "service-endpoints"


### PR DESCRIPTION
This commit introduces a new capability: `attribute-reference-type`. 

If present, the harness will ask the SDK to construct various attribute references (including literals), and assert that the returned reference contains the right components.

