### PR TITLE
add tests for feature & debug events

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -7,7 +7,7 @@ linters:
     - bodyclose
     - deadcode
     - depguard
-    #- dupl  # we do have some duplicated lines of test logic, that's life
+    - dupl
     - errcheck
     - gochecknoglobals
     - gochecknoinits

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -7,7 +7,7 @@ linters:
     - bodyclose
     - deadcode
     - depguard
-    - dupl
+    #- dupl  # we do have some duplicated lines of test logic, that's life
     - errcheck
     - gochecknoglobals
     - gochecknoinits

--- a/mockld/sdk_data.go
+++ b/mockld/sdk_data.go
@@ -252,6 +252,11 @@ func (b *ClientSDKDataBuilder) Flag(key string, props ClientSDKFlag) *ClientSDKD
 	return b
 }
 
+func (b *ClientSDKDataBuilder) FullFlag(props ClientSDKFlagWithKey) *ClientSDKDataBuilder {
+	b.flags[props.Key] = props.ClientSDKFlag
+	return b
+}
+
 func (b *ClientSDKDataBuilder) FlagWithValue(
 	key string,
 	version int,

--- a/sdktests/client_side_events_all.go
+++ b/sdktests/client_side_events_all.go
@@ -11,6 +11,8 @@ import (
 func doClientSideEventTests(t *ldtest.T) {
 	t.Run("requests", doClientSideEventRequestTests)
 	t.Run("summary events", doClientSideSummaryEventTests)
+	t.Run("feature events", doClientSideFeatureEventTests)
+	t.Run("debug events", doClientSideDebugEventTests)
 	t.Run("experimentation", doClientSideExperimentationEventTests)
 	t.Run("identify events", doClientSideIdentifyEventTests)
 	t.Run("custom events", doClientSideCustomEventTests)

--- a/sdktests/client_side_events_eval.go
+++ b/sdktests/client_side_events_eval.go
@@ -228,43 +228,6 @@ func doClientSideDebugEventTests(t *ldtest.T) {
 			})
 		}
 	}
-	shouldSeeDebugEvent := func(t *ldtest.T, debugUntil time.Time, lastKnownTimeFromLD time.Time) {
-		doDebugTest(t, true, debugUntil, lastKnownTimeFromLD)
-	}
-	shouldNotSeeDebugEvent := func(t *ldtest.T, debugUntil time.Time, lastKnownTimeFromLD time.Time) {
-		doDebugTest(t, false, debugUntil, lastKnownTimeFromLD)
-	}
 
-	t.Run("should see debug event", func(t *ldtest.T) {
-		t.Run("debugEventsUntilDate is after SDK time", func(t *ldtest.T) {
-			futureDebugUntil := time.Now().Add(time.Hour)
-			t.Run("SDK does not know LD time", func(t *ldtest.T) {
-				shouldSeeDebugEvent(t, futureDebugUntil, time.Time{})
-			})
-			t.Run("SDK knows LD time is before debugEventsUntilDate", func(t *ldtest.T) {
-				shouldSeeDebugEvent(t, futureDebugUntil, futureDebugUntil.Add(-time.Minute))
-			})
-		})
-	})
-
-	t.Run("should not see debug event", func(t *ldtest.T) {
-		t.Run("debugEventsUntilDate is before SDK time", func(t *ldtest.T) {
-			pastDebugUntil := time.Now().Add(-time.Hour)
-			t.Run("SDK does not know LD time", func(t *ldtest.T) {
-				shouldNotSeeDebugEvent(t, pastDebugUntil, time.Time{})
-			})
-			t.Run("SDK knows LD time is before debugEventsUntilDate", func(t *ldtest.T) {
-				shouldNotSeeDebugEvent(t, pastDebugUntil, pastDebugUntil.Add(-time.Minute))
-			})
-			t.Run("SDK knows LD time is after debugEventsUntilDate", func(t *ldtest.T) {
-				shouldNotSeeDebugEvent(t, pastDebugUntil, pastDebugUntil.Add(time.Minute))
-			})
-		})
-		t.Run("debugEventsUntilDate is after SDK time", func(t *ldtest.T) {
-			futureDebugUntil := time.Now().Add(time.Hour)
-			t.Run("SDK knows LD time is after debugEventsUntilDate", func(t *ldtest.T) {
-				shouldNotSeeDebugEvent(t, futureDebugUntil, futureDebugUntil.Add(time.Minute))
-			})
-		})
-	})
+	doDebugEventTestCases(t, doDebugTest)
 }

--- a/sdktests/client_side_events_eval.go
+++ b/sdktests/client_side_events_eval.go
@@ -1,0 +1,270 @@
+package sdktests
+
+import (
+	"time"
+
+	h "github.com/launchdarkly/sdk-test-harness/framework/helpers"
+	"github.com/launchdarkly/sdk-test-harness/framework/ldtest"
+	o "github.com/launchdarkly/sdk-test-harness/framework/opt"
+	"github.com/launchdarkly/sdk-test-harness/mockld"
+	"github.com/launchdarkly/sdk-test-harness/servicedef"
+
+	m "github.com/launchdarkly/go-test-helpers/v2/matchers"
+	"gopkg.in/launchdarkly/go-sdk-common.v2/ldreason"
+	"gopkg.in/launchdarkly/go-sdk-common.v2/ldtime"
+
+	"github.com/stretchr/testify/require"
+)
+
+func doClientSideFeatureEventTests(t *ldtest.T) {
+	flagValues := FlagValueByTypeFactory()
+	defaultValues := DefaultValueByTypeFactory()
+	user := NewUserFactory("doClientSideFeatureEventTests").NextUniqueUser()
+	expectedReason := ldreason.NewEvalReasonFallthrough()
+	untrackedFlags := ClientSideFlagFactoryForValueTypes{
+		KeyPrefix:    "untracked-flag-",
+		ValueFactory: flagValues,
+		Reason:       expectedReason,
+	}
+	trackedFlags := ClientSideFlagFactoryForValueTypes{
+		KeyPrefix:      "tracked-flag-",
+		ValueFactory:   flagValues,
+		BuilderActions: func(f *mockld.ClientSDKFlagWithKey) { f.TrackEvents = true },
+		Reason:         expectedReason,
+	}
+
+	dataBuilder := mockld.NewClientSDKDataBuilder()
+	for _, valueType := range getValueTypesToTest(t) {
+		dataBuilder.FullFlag(untrackedFlags.ForType(valueType))
+		dataBuilder.FullFlag(trackedFlags.ForType(valueType))
+	}
+
+	dataSource := NewSDKDataSource(t, dataBuilder.Build())
+	events := NewSDKEventSink(t)
+
+	client := NewSDKClient(t,
+		WithClientSideConfig(servicedef.SDKConfigClientSideParams{
+			InitialUser: user,
+		}),
+		dataSource, events)
+
+	client.FlushEvents(t)
+	_ = events.ExpectAnalyticsEvents(t, defaultEventTimeout) // discard initial identify event
+
+	t.Run("only summary event for untracked flag", func(t *ldtest.T) {
+		for _, valueType := range getValueTypesToTest(t) {
+			t.Run(testDescFromType(valueType), func(t *ldtest.T) {
+				flag := untrackedFlags.ForType(valueType)
+
+				resp := client.EvaluateFlag(t, servicedef.EvaluateFlagParams{
+					FlagKey:      flag.Key,
+					ValueType:    valueType,
+					DefaultValue: defaultValues(valueType),
+				})
+
+				// If the evaluation didn't return the expected value, then the rest of the test is moot
+				if !m.In(t).Assert(flag.Value, m.JSONEqual(resp.Value)) {
+					require.Fail(t, "evaluation unexpectedly returned wrong value")
+				}
+
+				client.FlushEvents(t)
+				payload := events.ExpectAnalyticsEvents(t, defaultEventTimeout)
+				m.In(t).Assert(payload, m.ItemsInAnyOrder(
+					IsSummaryEvent(),
+				))
+			})
+		}
+	})
+
+	doFeatureEventTest := func(t *ldtest.T, withReason bool) {
+		for _, valueType := range getValueTypesToTest(t) {
+			t.Run(testDescFromType(valueType), func(t *ldtest.T) {
+				flag := trackedFlags.ForType(valueType)
+				expectedValue := flag.Value
+				expectedVariation := flag.Variation
+				resp := client.EvaluateFlag(t, servicedef.EvaluateFlagParams{
+					FlagKey:      flag.Key,
+					ValueType:    valueType,
+					DefaultValue: defaultValues(valueType),
+					Detail:       withReason,
+				})
+
+				// If the evaluation didn't return the expected value, then the rest of the test is moot
+				if !m.In(t).Assert(expectedValue, m.JSONEqual(resp.Value)) {
+					require.Fail(t, "evaluation unexpectedly returned wrong value")
+				}
+
+				client.FlushEvents(t)
+
+				matchFeatureEvent := IsValidFeatureEventWithConditions(
+					false, false, user,
+					m.JSONProperty("key").Should(m.Equal(flag.Key)),
+					m.JSONProperty("version").Should(m.Equal(flag.Version)),
+					m.JSONProperty("value").Should(m.JSONEqual(expectedValue)),
+					m.JSONOptProperty("variation").Should(m.JSONEqual(expectedVariation)),
+					maybeReason(withReason, expectedReason),
+					m.JSONProperty("default").Should(m.JSONEqual(defaultValues(valueType))),
+					JSONPropertyNullOrAbsent("prereqOf"),
+				)
+
+				payload := events.ExpectAnalyticsEvents(t, defaultEventTimeout)
+				m.In(t).Assert(payload, m.ItemsInAnyOrder(
+					matchFeatureEvent,
+					IsSummaryEvent(),
+				))
+			})
+		}
+	}
+
+	t.Run("full feature event for tracked flag", func(t *ldtest.T) {
+		for _, withReason := range []bool{false, true} {
+			t.Run(h.IfElse(withReason, "with reason", "without reason"), func(t *ldtest.T) {
+				doFeatureEventTest(t, withReason)
+			})
+		}
+	})
+
+	t.Run("evaluating all flags generates no events", func(t *ldtest.T) {
+		_ = client.EvaluateAllFlags(t, servicedef.EvaluateAllFlagsParams{})
+		client.FlushEvents(t)
+		events.ExpectNoAnalyticsEvents(t, time.Millisecond*200)
+	})
+}
+
+func doClientSideDebugEventTests(t *ldtest.T) {
+	// These tests could misbehave if the system clocks of the host that's running the test harness
+	// and the host that's running the test service are out of sync by at least an hour. However,
+	// in normal usage those are the same host.
+
+	flagValues := FlagValueByTypeFactory()
+	defaultValues := DefaultValueByTypeFactory()
+	users := NewUserFactory("doClientSideDebugEventTests")
+	expectedReason := ldreason.NewEvalReasonFallthrough()
+
+	doDebugTest := func(
+		t *ldtest.T,
+		shouldSeeDebugEvent bool,
+		flagDebugUntil time.Time,
+		lastKnownTimeFromLD time.Time,
+	) {
+		user := users.NextUniqueUser()
+		flags := ClientSideFlagFactoryForValueTypes{
+			KeyPrefix:    "flag",
+			ValueFactory: flagValues,
+			Reason:       expectedReason,
+			BuilderActions: func(f *mockld.ClientSDKFlagWithKey) {
+				f.DebugEventsUntilDate = o.Some(ldtime.UnixMillisFromTime(flagDebugUntil))
+			},
+		}
+		dataBuilder := mockld.NewClientSDKDataBuilder()
+		for _, valueType := range getValueTypesToTest(t) {
+			dataBuilder.FullFlag(flags.ForType(valueType))
+		}
+		dataSource := NewSDKDataSource(t, dataBuilder.Build())
+
+		events := NewSDKEventSink(t)
+		if !lastKnownTimeFromLD.IsZero() {
+			events.Service().SetHostTimeOverride(lastKnownTimeFromLD)
+		}
+
+		client := NewSDKClient(t,
+			WithClientSideConfig(servicedef.SDKConfigClientSideParams{
+				InitialUser: user,
+			}),
+			dataSource, events)
+
+		client.FlushEvents(t)
+		_ = events.ExpectAnalyticsEvents(t, defaultEventTimeout) // discard initial identify event
+		// note, this initial flush also causes the SDK to see the Date header in the mock event service's response
+
+		if !lastKnownTimeFromLD.IsZero() {
+			// Hacky arbitrary sleep to avoid a race condition where the test code runs fast enough
+			// that the SDK has not had a chance to process the HTTP response yet - the fact that
+			// we've received the event payload from them doesn't mean the SDK has done that work
+			time.Sleep(time.Millisecond * 10)
+		}
+
+		for _, withReasons := range []bool{false, true} {
+			t.Run(h.IfElse(withReasons, "with reasons", "without reasons"), func(t *ldtest.T) {
+				for _, valueType := range getValueTypesToTest(t) {
+					t.Run(testDescFromType(valueType), func(t *ldtest.T) {
+						flag := flags.ForType(valueType)
+						result := client.EvaluateFlag(t, servicedef.EvaluateFlagParams{
+							FlagKey:      flag.Key,
+							ValueType:    valueType,
+							DefaultValue: defaultValues(valueType),
+							Detail:       withReasons,
+						})
+						m.In(t).Assert(result.Value, m.JSONEqual(flag.Value))
+
+						client.FlushEvents(t)
+						payload := events.ExpectAnalyticsEvents(t, defaultEventTimeout)
+
+						if shouldSeeDebugEvent {
+							matchDebugEvent := m.AllOf(
+								JSONPropertyKeysCanOnlyBe("kind", "creationDate", "key", "user",
+									"version", "value", "variation", "reason", "default"),
+								IsDebugEvent(),
+								HasAnyCreationDate(),
+								m.JSONProperty("key").Should(m.Equal(flag.Key)),
+								HasUserObjectWithKey(user.GetKey()),
+								m.JSONProperty("version").Should(m.Equal(flag.Version)),
+								m.JSONProperty("value").Should(m.JSONEqual(result.Value)),
+								m.JSONProperty("variation").Should(m.JSONEqual(flag.Variation)),
+								maybeReason(withReasons, expectedReason),
+								m.JSONProperty("default").Should(m.JSONEqual(defaultValues(valueType))),
+							)
+							m.In(t).Assert(payload, m.ItemsInAnyOrder(
+								matchDebugEvent,
+								EventHasKind("summary"),
+							))
+						} else {
+							m.In(t).Assert(payload, m.ItemsInAnyOrder(
+								EventHasKind("summary"),
+							))
+						}
+					})
+				}
+			})
+		}
+	}
+	shouldSeeDebugEvent := func(t *ldtest.T, debugUntil time.Time, lastKnownTimeFromLD time.Time) {
+		doDebugTest(t, true, debugUntil, lastKnownTimeFromLD)
+	}
+	shouldNotSeeDebugEvent := func(t *ldtest.T, debugUntil time.Time, lastKnownTimeFromLD time.Time) {
+		doDebugTest(t, false, debugUntil, lastKnownTimeFromLD)
+	}
+
+	t.Run("should see debug event", func(t *ldtest.T) {
+		t.Run("debugEventsUntilDate is after SDK time", func(t *ldtest.T) {
+			futureDebugUntil := time.Now().Add(time.Hour)
+			t.Run("SDK does not know LD time", func(t *ldtest.T) {
+				shouldSeeDebugEvent(t, futureDebugUntil, time.Time{})
+			})
+			t.Run("SDK knows LD time is before debugEventsUntilDate", func(t *ldtest.T) {
+				shouldSeeDebugEvent(t, futureDebugUntil, futureDebugUntil.Add(-time.Minute))
+			})
+		})
+	})
+
+	t.Run("should not see debug event", func(t *ldtest.T) {
+		t.Run("debugEventsUntilDate is before SDK time", func(t *ldtest.T) {
+			pastDebugUntil := time.Now().Add(-time.Hour)
+			t.Run("SDK does not know LD time", func(t *ldtest.T) {
+				shouldNotSeeDebugEvent(t, pastDebugUntil, time.Time{})
+			})
+			t.Run("SDK knows LD time is before debugEventsUntilDate", func(t *ldtest.T) {
+				shouldNotSeeDebugEvent(t, pastDebugUntil, pastDebugUntil.Add(-time.Minute))
+			})
+			t.Run("SDK knows LD time is after debugEventsUntilDate", func(t *ldtest.T) {
+				shouldNotSeeDebugEvent(t, pastDebugUntil, pastDebugUntil.Add(time.Minute))
+			})
+		})
+		t.Run("debugEventsUntilDate is after SDK time", func(t *ldtest.T) {
+			futureDebugUntil := time.Now().Add(time.Hour)
+			t.Run("SDK knows LD time is after debugEventsUntilDate", func(t *ldtest.T) {
+				shouldNotSeeDebugEvent(t, futureDebugUntil, futureDebugUntil.Add(time.Minute))
+			})
+		})
+	})
+}

--- a/sdktests/client_side_events_eval.go
+++ b/sdktests/client_side_events_eval.go
@@ -16,6 +16,12 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+// This file is very similar to server_side_events_eval.go, except:
+//
+// - The test data generation works differently because of the different flag model.
+// - We're not using a unique user per evaluation.
+// - There are no prerequisite events.
+
 func doClientSideFeatureEventTests(t *ldtest.T) {
 	flagValues := FlagValueByTypeFactory()
 	defaultValues := DefaultValueByTypeFactory()

--- a/sdktests/client_side_events_summary.go
+++ b/sdktests/client_side_events_summary.go
@@ -11,6 +11,11 @@ import (
 	"gopkg.in/launchdarkly/go-sdk-common.v2/ldvalue"
 )
 
+// This file is very similar to server_side_events_summary.go, except that the preconditions have to be set up
+// differently because of the single-current-user model. That is, we can't do a bunch of evaluations for flag 1
+// with user A getting one value and mix them in with evaluations for flag 1 with user B getting a different
+// value, because there is just one current value for the flag at a time depending on the current user.
+
 func doClientSideSummaryEventTests(t *ldtest.T) {
 	t.Run("basic counter behavior", doClientSideSummaryEventBasicTest)
 	t.Run("unknown flag", doClientSideSummaryEventUnknownFlagTest)

--- a/sdktests/server_side_events_eval.go
+++ b/sdktests/server_side_events_eval.go
@@ -265,6 +265,19 @@ func doServerSideDebugEventTests(t *ldtest.T) {
 			})
 		}
 	}
+
+	doDebugEventTestCases(t, doDebugTest)
+}
+
+func doDebugEventTestCases(
+	t *ldtest.T,
+	doDebugTest func(
+		t *ldtest.T,
+		shouldSeeDebugEvent bool,
+		flagDebugUntil time.Time,
+		lastKnownTimeFromLD time.Time,
+	),
+) {
 	shouldSeeDebugEvent := func(t *ldtest.T, debugUntil time.Time, lastKnownTimeFromLD time.Time) {
 		doDebugTest(t, true, debugUntil, lastKnownTimeFromLD)
 	}

--- a/sdktests/testdata_factories.go
+++ b/sdktests/testdata_factories.go
@@ -3,6 +3,8 @@ package sdktests
 import (
 	"fmt"
 
+	o "github.com/launchdarkly/sdk-test-harness/framework/opt"
+	"github.com/launchdarkly/sdk-test-harness/mockld"
 	"github.com/launchdarkly/sdk-test-harness/servicedef"
 
 	"gopkg.in/launchdarkly/go-sdk-common.v2/ldreason"
@@ -44,14 +46,15 @@ func (f *UserFactory) NextUniqueUserMaybeAnonymous(shouldBeAnonymous bool) lduse
 	return user
 }
 
-type FlagFactory interface {
-	MakeFlag(param interface{}) ldmodel.FeatureFlag
+type GenericFactory[T any] interface {
+	Get(param any) T
 }
 
-type MemoizingFlagFactory struct {
-	factoryFn   func(interface{}) ldmodel.FeatureFlag
-	flags       map[interface{}]ldmodel.FeatureFlag
-	nextVersion int
+type MemoizingFactory[T any] struct {
+	factoryFn          func(any) T
+	transformVersionFn func(T, int) T
+	cache              map[any]T
+	nextVersion        int
 }
 
 type ValueFactory func(param interface{}) ldvalue.Value
@@ -96,27 +99,47 @@ func DefaultValueByTypeFactory() ValueFactory {
 	}
 }
 
-func NewMemoizingFlagFactory(startingVersion int, factoryFn func(interface{}) ldmodel.FeatureFlag) FlagFactory {
-	f := &MemoizingFlagFactory{
-		factoryFn:   factoryFn,
-		flags:       make(map[interface{}]ldmodel.FeatureFlag),
+func NewMemoizingFlagFactory(startingVersion int, factoryFn func(interface{}) ldmodel.FeatureFlag) *MemoizingFactory[ldmodel.FeatureFlag] {
+	f := &MemoizingFactory[ldmodel.FeatureFlag]{
+		factoryFn: factoryFn,
+		transformVersionFn: func(f ldmodel.FeatureFlag, v int) ldmodel.FeatureFlag {
+			f.Version = v
+			return f
+		},
 		nextVersion: startingVersion,
-	}
-	if f.nextVersion == 0 {
-		f.nextVersion = 1
 	}
 	return f
 }
 
-func (f *MemoizingFlagFactory) MakeFlag(param interface{}) ldmodel.FeatureFlag {
-	if flag, ok := f.flags[param]; ok {
-		return flag
+func NewMemoizingClientSideFlagFactory(startingVersion int, factoryFn func(interface{}) mockld.ClientSDKFlagWithKey) *MemoizingFactory[mockld.ClientSDKFlagWithKey] {
+	f := &MemoizingFactory[mockld.ClientSDKFlagWithKey]{
+		factoryFn: factoryFn,
+		transformVersionFn: func(f mockld.ClientSDKFlagWithKey, v int) mockld.ClientSDKFlagWithKey {
+			f.Version = v
+			return f
+		},
+		nextVersion: startingVersion,
 	}
-	flag := f.factoryFn(param)
+	return f
+}
+
+func (f *MemoizingFactory[T]) Get(param any) T {
+	if item, ok := f.cache[param]; ok {
+		return item
+	}
+	item := f.factoryFn(param)
+	version := f.nextVersion
+	if version == 0 {
+		version++
+	}
 	f.nextVersion++
-	flag.Version = f.nextVersion
-	f.flags[param] = flag
-	return flag
+	item = f.transformVersionFn(item, version)
+	f.nextVersion = version
+	if f.cache == nil {
+		f.cache = make(map[any]T)
+	}
+	f.cache[param] = item
+	return item
 }
 
 type FlagFactoryForValueTypes struct {
@@ -125,7 +148,7 @@ type FlagFactoryForValueTypes struct {
 	ValueFactory    ValueFactory
 	Reason          ldreason.EvaluationReason
 	StartingVersion int
-	factory         FlagFactory
+	factory         *MemoizingFactory[ldmodel.FeatureFlag]
 }
 
 func (f *FlagFactoryForValueTypes) ForType(valueType servicedef.ValueType) ldmodel.FeatureFlag {
@@ -150,5 +173,42 @@ func (f *FlagFactoryForValueTypes) ForType(valueType servicedef.ValueType) ldmod
 			return builder.Build()
 		})
 	}
-	return f.factory.MakeFlag(valueType)
+	return f.factory.Get(valueType)
+}
+
+type ClientSideFlagFactoryForValueTypes struct {
+	KeyPrefix       string
+	BuilderActions  func(*mockld.ClientSDKFlagWithKey)
+	ValueFactory    ValueFactory
+	Reason          ldreason.EvaluationReason
+	StartingVersion int
+	factory         *MemoizingFactory[mockld.ClientSDKFlagWithKey]
+	nextVariation   int
+}
+
+func (f *ClientSideFlagFactoryForValueTypes) ForType(valueType servicedef.ValueType) mockld.ClientSDKFlagWithKey {
+	if f.factory == nil {
+		if f.ValueFactory == nil {
+			f.ValueFactory = FlagValueByTypeFactory()
+		}
+		f.factory = NewMemoizingClientSideFlagFactory(f.StartingVersion, func(param interface{}) mockld.ClientSDKFlagWithKey {
+			valueType := param.(servicedef.ValueType)
+			ret := mockld.ClientSDKFlagWithKey{
+				Key: fmt.Sprintf("%s.%s", f.KeyPrefix, valueType),
+				ClientSDKFlag: mockld.ClientSDKFlag{
+					Value:     f.ValueFactory(valueType),
+					Variation: o.Some(f.nextVariation),
+				},
+			}
+			f.nextVariation = (f.nextVariation + 1) % 5 // arbitrary number of variations just so data isn't uniform
+			if f.Reason.IsDefined() {
+				ret.Reason = o.Some(f.Reason)
+			}
+			if f.BuilderActions != nil {
+				f.BuilderActions(&ret)
+			}
+			return ret
+		})
+	}
+	return f.factory.Get(valueType)
 }


### PR DESCRIPTION
This fills in the last remaining gaps in client-side SDK event test coverage as far as I know, in terms of the types of events being tested.

As with the previous PR, I didn't manage to come up with an abstraction to allow much common test logic to be shared between server-side and client-side tests here— the nature of the flag data is just too different.