### PR TITLE
add tests for using an old-style user

### DIFF
--- a/docs/service_spec.md
+++ b/docs/service_spec.md
@@ -119,7 +119,8 @@ A `POST` request indicates that the test harness wants to start an instance of t
     * `applicationId` (string, optional): If present and non-null, the SDK should set the "application ID" property to this string.
     * `applicationVersion` (string, optional): If present and non-null, the SDK should set the "application version" property to this string.
   * `clientSide` (object): This is omitted for server-side SDKs, and required for client-side SDKs. Properties are:
-    * `initialContext` (object, required): The context properties to initialize the SDK with. The test service for a client-side SDK can assume that the test harness will _always_ set this: if the test logic does not explicitly provide a value, the test harness will add a default one.
+    * `initialContext` (object, optional): The context properties to initialize the SDK with (unless `initialUser` is specified instead). The test service for a client-side SDK can assume that the test harness will _always_ set this: if the test logic does not explicitly provide a value, the test harness will add a default one.
+    * `initialUser` (object, optional): Can be specified instead of `initialContext` to use an old-style user JSON representation.
     * `evaluationReasons`, `useReport` (boolean, optional): These correspond to the SDK configuration properties of the same names.
 
 The response to a valid request is any HTTP `2xx` status, with a `Location` header whose value is the URL of the test service resource representing this SDK client instance (that is, the one that would be used for "Close client" or "Send command" as described below).

--- a/docs/service_spec.md
+++ b/docs/service_spec.md
@@ -60,6 +60,10 @@ For tests that involve Big Segments, the test harness will provide parameters in
 
 This means that the SDK has its own type for evaluation contexts (as opposed to just representing them as a JSON-equivalent generic data structure) and convert that type to and from JSON.
 
+#### Capability `"secure-mode-hash"`
+
+This means that the SDK has a function/method for computing a secure mode hash from a context.
+
 #### Capability `"server-side-polling"`
 
 For a server-side SDK, this means that the SDK can be configured to use polling mode instead of streaming mode.
@@ -143,7 +147,10 @@ If `command` is `"evaluate"`, the test service should perform a single feature f
 The `evaluate` property in the request body will be a JSON object with these properties:
 
 * `flagKey` (string): The flag key.
-* `context` (object): The context properties. This is required for server-side SDKs, and omitted for client-side SDKs.
+* `context` (object, optional): The context properties.
+  * For client-side SDKs, this is always omitted.
+  * For server-side SDKs, this is required unless `user` is provided instead.
+* `user` (object, optional): Can be sent instead of `context` to use an old-style user JSON representation.
 * `valueType` (string): For strongly-typed SDKs, this can be `"bool"`, `"int"`, `"double"`, `"string"`, or `"any"`, indicating which typed `Variation` or `VariationDetail` method to use (`any` is called "JSON" in most SDKs). For weakly-typed SDKs, it can be ignored.
 * `defaultValue` (any): A JSON value whose type corresponds to `valueType`. This should be used as the application default/fallback parameter for the `Variation` or `VariationDetail` method.
 * `detail` (boolean): If true, use `VariationDetail`. If false or omitted, use `Variation`.
@@ -160,7 +167,10 @@ If `command` is `"evaluateAll"`, the test service should call the SDK method tha
 
 The `evaluateAll` property in the request body will be a JSON object with these properties:
 
-* `context` (object): The context properties. This is required for server-side SDKs, and omitted for client-side SDKs.
+* `context` (object, optional): The context properties.
+  * For client-side SDKs, this is always omitted.
+  * For server-side SDKs, this is required unless `user` is provided instead.
+* `user` (object, optional): Can be sent instead of `context` to use an old-style user JSON representation.
 * `withReasons` (boolean, optional): If true, enables the SDK option for including evaluation reasons in the result. The test harness will only set this option if the test service has the capability `"all-flags-with-reasons"`.
 * `clientSideOnly` (boolean, optional): If true, enables the SDK option for filtering the result to only include flags that are enabled for client-side use. The test harness will only set this option if the test service has the capability `"all-flags-client-side-only"`.
 * `detailsOnlyForTrackedFlags` (boolean, optional): If true, enables the SDK option for filtering the result to only include evaluation reason data if the SDK will need it for events (due to event tracking or debugging or an experiment). The test harness will only set this option if the test service has the capability `"all-flags-details-only-for-tracked-flags"`.
@@ -187,7 +197,8 @@ If `command` is `"identifyEvent"`, the test service should call the SDK's `Ident
 
 The `identifyEvent` property in the request body will be a JSON object with these properties:
 
-* `context` (object): The context properties. This is always provided for both server-side and client-side SDKs.
+* `context` (object, optional): The context properties. This is always required unless `user` is provided instead.
+* `user` (object, optional): Can be sent instead of `context` to use an old-style user JSON representation.
 
 The response should be an empty 2xx response.
 
@@ -198,7 +209,10 @@ If `command` is `"customEvent"`, the test service should tell the SDK to send a 
 The `customEvent` property in the request body will be a JSON object with these properties:
 
 * `eventKey` (string): The event key.
-* `context` (object): The context properties. This is required for server-side SDKs, and omitted for client-side SDKs.
+* `context` (object, optional): The context properties.
+  * For client-side SDKs, this is always omitted.
+  * For server-side SDKs, this is required unless `user` is provided instead.
+* `user` (object, optional): Can be sent instead of `context` to use an old-style user JSON representation.
 * `data` (any): If present, a JSON value for the `data` parameter.
 * `omitNullData` (boolean or null): See below.
 * `metricValue` (number or null): If present, a metric value.
@@ -218,6 +232,19 @@ If `command` is `"flush"`, the test service should tell the SDK to initiate an e
 The request body, if any, is irrelevant.
 
 The response should be an empty 2xx response.
+
+#### Compute a secure mode hash
+
+If `command` is `"secureModeHash"`, the test service should ask the SDK to compute a secure mode hash for a context.
+
+The test harness will only send this command if the test service has the `"secure-mode-hash"` capability.
+
+The `secureModeHash` property in the request body will be a JSON object with these properties:
+
+* `context` (object, optional): The context properties. This is required unless `user` is provided instead.
+* `user` (object, optional): Can be sent instead of `context` to use an old-style user JSON representation.
+
+The response should be a JSON object with a single property, `result`, which is the computed hash as a string.
 
 #### Get big segment store status
 

--- a/docs/service_spec.md
+++ b/docs/service_spec.md
@@ -84,6 +84,10 @@ This means that the SDK supports the "tags" configuration option and will send t
 
 For tests that involve tags, the test harness will set the `tags` property of the configuration object.
 
+#### Capability `"user-type"`
+
+This means that the SDK has a type corresponding to the old-style user model, and supports directly passing such user data to SDK methods as an alternative to context data. If this capability is present, the test harness may send a `user` property with old-style user JSON for test commands that would normally take a `context` property. If this capability is absent, `user` will never be set.
+
 ### Stop test service: `DELETE /`
 
 The test harness sends this request at the end of a test run if you have specified `--stop-service-at-end` on the [command line](./running.md). The test service should simply quit. This is a convenience so CI scripts can simply start the test service in the background and assume it will be stopped for them.

--- a/sdktests/common_tests_eval.go
+++ b/sdktests/common_tests_eval.go
@@ -113,7 +113,7 @@ func (c CommonEvalParameterizedTestRunner[SDKDataType]) runTestEval(
 
 	// *If* the context for this test can be represented in the old user model, then we will also do
 	// the test with an equivalent old-style user representation.
-	user := representContextAsOldUser(test.Context.Value())
+	user := representContextAsOldUser(t, test.Context.Value())
 
 	t.Run(name, func(t *ldtest.T) {
 		t.Run("evaluate flag without detail", func(t *ldtest.T) {

--- a/sdktests/common_tests_events_contexts.go
+++ b/sdktests/common_tests_events_contexts.go
@@ -223,7 +223,7 @@ func (c CommonEventTests) EventContexts(t *ldtest.T) {
 					_ = basicEvaluateFlag(t, client, flagKey, context, defaultValue)
 					verifyResult(t)
 
-					if user := representContextAsOldUser(context); user != nil {
+					if user := representContextAsOldUser(t, context); user != nil {
 						t.Run("with old user", func(t *ldtest.T) {
 							_ = basicEvaluateFlagWithOldUser(t, client, flagKey, user, defaultValue)
 							verifyResult(t)
@@ -256,7 +256,7 @@ func (c CommonEventTests) EventContexts(t *ldtest.T) {
 					}
 					m.In(t).Assert(payload, m.ItemsInAnyOrder(eventMatchers...))
 
-					if user := representContextAsOldUser(context); user != nil {
+					if user := representContextAsOldUser(t, context); user != nil {
 						t.Run("with old user", func(t *ldtest.T) {
 							if c.isClientSide {
 								client.SendIdentifyEventWithOldUser(t, user)
@@ -288,7 +288,7 @@ func (c CommonEventTests) EventContexts(t *ldtest.T) {
 				client.SendIdentifyEvent(t, context)
 				verifyResult(t)
 
-				if user := representContextAsOldUser(context); user != nil {
+				if user := representContextAsOldUser(t, context); user != nil {
 					t.Run("with old user", func(t *ldtest.T) {
 						client.SendIdentifyEventWithOldUser(t, user)
 						verifyResult(t)
@@ -322,7 +322,7 @@ func (c CommonEventTests) EventContexts(t *ldtest.T) {
 					// Before we try converting the context to a user, we need to make sure it has a different key
 					// since the index event test depends on it being a never-before-seen key
 					context2 := contextWithTransformedKeys(context, func(key string) string { return key + ".olduser" })
-					if user := representContextAsOldUser(context2); user != nil {
+					if user := representContextAsOldUser(t, context2); user != nil {
 						t.Run("with old user", func(t *ldtest.T) {
 							basicEvaluateFlagWithOldUser(t, client, "arbitrary-flag-key", user, ldvalue.Null())
 							verifyResult(t, context2)
@@ -343,7 +343,7 @@ func (c CommonEventTests) EventContexts(t *ldtest.T) {
 					verifyResult(t, context)
 
 					context2 := contextWithTransformedKeys(context, func(key string) string { return key + ".olduser" })
-					if user := representContextAsOldUser(context2); user != nil {
+					if user := representContextAsOldUser(t, context2); user != nil {
 						t.Run("with old user", func(t *ldtest.T) {
 							client.SendCustomEvent(t, servicedef.CustomEventParams{EventKey: "event-key", User: user})
 							verifyResult(t, context2)
@@ -355,7 +355,7 @@ func (c CommonEventTests) EventContexts(t *ldtest.T) {
 
 		if c.isClientSide {
 			initialContext2 := contexts.NextUniqueContext()
-			if user := representContextAsOldUser(initialContext2); user != nil {
+			if user := representContextAsOldUser(t, initialContext2); user != nil {
 				t.Run("initial identify event with old user", func(t *ldtest.T) {
 					events := NewSDKEventSink(t)
 

--- a/sdktests/helpers.go
+++ b/sdktests/helpers.go
@@ -266,7 +266,10 @@ func pollUntilFlagValueUpdated(
 
 // Attempts to build an old-style user JSON representation that is equivalent to the given context.
 // Returns the JSON data, or nil if there is no equivalent to this context in the old user model.
-func representContextAsOldUser(c ldcontext.Context) json.RawMessage {
+func representContextAsOldUser(t *ldtest.T, c ldcontext.Context) json.RawMessage {
+	if !t.Capabilities().Has(servicedef.CapabilityUserType) {
+		return nil
+	}
 	if c.Kind() != ldcontext.DefaultKind {
 		return nil
 	}

--- a/sdktests/helpers.go
+++ b/sdktests/helpers.go
@@ -46,6 +46,22 @@ func basicEvaluateFlag(
 	return result.Value
 }
 
+func basicEvaluateFlagWithOldUser(
+	t *ldtest.T,
+	client *SDKClient,
+	flagKey string,
+	user json.RawMessage,
+	defaultValue ldvalue.Value,
+) ldvalue.Value {
+	result := client.EvaluateFlag(t, servicedef.EvaluateFlagParams{
+		FlagKey:      flagKey,
+		User:         user,
+		ValueType:    servicedef.ValueTypeAny,
+		DefaultValue: defaultValue,
+	})
+	return result.Value
+}
+
 // computeExpectedBucketValue implements the bucketing hash value calculation as per the evaluation spec,
 // except that it returns the value as an integer in the range [0, 100000] - currently the SDKs convert
 // this to a floating-point fraction by in effect dividing it by 100000, but this test code needs an
@@ -74,6 +90,17 @@ func computeExpectedBucketValue(
 	product.Mul(big.NewInt(hashVal), big.NewInt(100000))
 	result.Div(&product, big.NewInt(0xFFFFFFFFFFFFFFF))
 	return int(result.Int64())
+}
+
+func contextWithTransformedKeys(context ldcontext.Context, keyFn func(string) string) ldcontext.Context {
+	if context.Multiple() {
+		b := ldcontext.NewMultiBuilder()
+		for _, c := range context.GetAllIndividualContexts(nil) {
+			b.Add(contextWithTransformedKeys(c, keyFn))
+		}
+		return b.Build()
+	}
+	return ldcontext.NewBuilderFromContext(context).Key(keyFn(context.Key())).Build()
 }
 
 func evaluateFlagDetail(
@@ -235,6 +262,47 @@ func pollUntilFlagValueUpdated(
 		t,
 		checkForUpdatedValue(t, client, flagKey, context, previousValue, updatedValue, defaultValue),
 		time.Second, time.Millisecond*50, "timed out without seeing updated flag value")
+}
+
+// Attempts to build an old-style user JSON representation that is equivalent to the given context.
+// Returns the JSON data, or nil if there is no equivalent to this context in the old user model.
+func representContextAsOldUser(c ldcontext.Context) json.RawMessage {
+	if c.Kind() != ldcontext.DefaultKind {
+		return nil
+	}
+	o := ldvalue.ObjectBuild().SetString("key", c.Key())
+	if c.Anonymous() {
+		o.SetBool("anonymous", true)
+	}
+	custom := ldvalue.ObjectBuild()
+	for _, a := range c.GetOptionalAttributeNames(nil) {
+		value := c.GetValue(a)
+		switch a {
+		case "name", "firstName", "lastName", "email", "avatar", "country", "ip":
+			if !value.IsString() {
+				return nil // not a valid user - these built-in attrs must be strings
+			}
+			o.Set(a, value)
+		default:
+			custom.Set(a, value)
+		}
+	}
+	if custom.Build().Count() != 0 {
+		o.Set("custom", custom.Build())
+	}
+	if c.PrivateAttributeCount() != 0 {
+		pas := ldvalue.ArrayBuild()
+		for i := 0; i < c.PrivateAttributeCount(); i++ {
+			if pa, ok := c.PrivateAttributeByIndex(i); ok {
+				if pa.Depth() != 1 {
+					return nil // not a valid user - users don't support attribute references
+				}
+				pas.Add(ldvalue.String(pa.Component(0)))
+			}
+		}
+		o.Set("privateAttributeNames", pas.Build())
+	}
+	return json.RawMessage(o.Build().JSONString())
 }
 
 // Configures a (single-kind) context to have the specified value for a particular attribute-- or, if the

--- a/sdktests/server_side_secure_mode_hash.go
+++ b/sdktests/server_side_secure_mode_hash.go
@@ -62,7 +62,7 @@ func doServerSideSecureModeHashTests(t *ldtest.T) {
 			hash := client.GetSecureModeHash(t, p.context)
 			assert.Equal(t, p.expectedHash, hash)
 
-			if user := representContextAsOldUser(p.context); user != nil {
+			if user := representContextAsOldUser(t, p.context); user != nil {
 				t.Run("with old user", func(t *ldtest.T) {
 					hash := client.GetSecureModeHashWithOldUser(t, user)
 					assert.Equal(t, p.expectedHash, hash)

--- a/sdktests/server_side_secure_mode_hash.go
+++ b/sdktests/server_side_secure_mode_hash.go
@@ -61,6 +61,13 @@ func doServerSideSecureModeHashTests(t *ldtest.T) {
 			client := NewSDKClient(t, WithCredential(p.sdkKey), dataSource)
 			hash := client.GetSecureModeHash(t, p.context)
 			assert.Equal(t, p.expectedHash, hash)
+
+			if user := representContextAsOldUser(p.context); user != nil {
+				t.Run("with old user", func(t *ldtest.T) {
+					hash := client.GetSecureModeHashWithOldUser(t, user)
+					assert.Equal(t, p.expectedHash, hash)
+				})
+			}
 		})
 	}
 }

--- a/sdktests/testapi_sdk_client.go
+++ b/sdktests/testapi_sdk_client.go
@@ -1,6 +1,7 @@
 package sdktests
 
 import (
+	"encoding/json"
 	"errors"
 	"sync/atomic"
 
@@ -249,7 +250,19 @@ func (c *SDKClient) SendIdentifyEvent(t *ldtest.T, context ldcontext.Context) {
 	require.NoError(t, c.sdkClientEntity.SendCommandWithParams(
 		servicedef.CommandParams{
 			Command:       servicedef.CommandIdentifyEvent,
-			IdentifyEvent: o.Some(servicedef.IdentifyEventParams{Context: context}),
+			IdentifyEvent: o.Some(servicedef.IdentifyEventParams{Context: o.Some(context)}),
+		},
+		t.DebugLogger(),
+		nil,
+	))
+}
+
+// SendIdentifyEventWithOldUser is equivalent to SendIdentifyEvent, but with old-style user data.
+func (c *SDKClient) SendIdentifyEventWithOldUser(t *ldtest.T, user json.RawMessage) {
+	require.NoError(t, c.sdkClientEntity.SendCommandWithParams(
+		servicedef.CommandParams{
+			Command:       servicedef.CommandIdentifyEvent,
+			IdentifyEvent: o.Some(servicedef.IdentifyEventParams{User: user}),
 		},
 		t.DebugLogger(),
 		nil,
@@ -325,6 +338,19 @@ func (c *SDKClient) GetSecureModeHash(t *ldtest.T, context ldcontext.Context) st
 		servicedef.CommandParams{
 			Command:        servicedef.CommandSecureModeHash,
 			SecureModeHash: o.Some(servicedef.SecureModeHashParams{Context: context}),
+		},
+		t.DebugLogger(),
+		&resp))
+	return resp.Result
+}
+
+// GetSecureModeHashWithOldUser is equivalent to GetSecureModeHash, but with old-style user JSON data.
+func (c *SDKClient) GetSecureModeHashWithOldUser(t *ldtest.T, user json.RawMessage) string {
+	var resp servicedef.SecureModeHashResponse
+	require.NoError(t, c.sdkClientEntity.SendCommandWithParams(
+		servicedef.CommandParams{
+			Command:        servicedef.CommandSecureModeHash,
+			SecureModeHash: o.Some(servicedef.SecureModeHashParams{User: user}),
 		},
 		t.DebugLogger(),
 		&resp))

--- a/servicedef/command_params.go
+++ b/servicedef/command_params.go
@@ -1,6 +1,8 @@
 package servicedef
 
 import (
+	"encoding/json"
+
 	o "github.com/launchdarkly/sdk-test-harness/v2/framework/opt"
 
 	"github.com/launchdarkly/go-sdk-common/v3/ldcontext"
@@ -45,6 +47,7 @@ type CommandParams struct {
 type EvaluateFlagParams struct {
 	FlagKey      string                     `json:"flagKey"`
 	Context      o.Maybe[ldcontext.Context] `json:"context,omitempty"`
+	User         json.RawMessage            `json:"user,omitempty"`
 	ValueType    ValueType                  `json:"valueType"`
 	DefaultValue ldvalue.Value              `json:"defaultValue"`
 	Detail       bool                       `json:"detail"`
@@ -58,6 +61,7 @@ type EvaluateFlagResponse struct {
 
 type EvaluateAllFlagsParams struct {
 	Context                    o.Maybe[ldcontext.Context] `json:"context,omitempty"`
+	User                       json.RawMessage            `json:"user,omitempty"`
 	WithReasons                bool                       `json:"withReasons"`
 	ClientSideOnly             bool                       `json:"clientSideOnly"`
 	DetailsOnlyForTrackedFlags bool                       `json:"detailsOnlyForTrackedFlags"`
@@ -70,13 +74,15 @@ type EvaluateAllFlagsResponse struct {
 type CustomEventParams struct {
 	EventKey     string                     `json:"eventKey"`
 	Context      o.Maybe[ldcontext.Context] `json:"context,omitempty"`
+	User         json.RawMessage            `json:"user,omitempty"`
 	Data         ldvalue.Value              `json:"data,omitempty"`
 	OmitNullData bool                       `json:"omitNullData"`
 	MetricValue  o.Maybe[float64]           `json:"metricValue,omitempty"`
 }
 
 type IdentifyEventParams struct {
-	Context ldcontext.Context `json:"context"`
+	Context o.Maybe[ldcontext.Context] `json:"context"`
+	User    json.RawMessage            `json:"user,omitempty"`
 }
 
 type BigSegmentStoreStatusResponse struct {
@@ -109,6 +115,7 @@ type ContextConvertParams struct {
 
 type SecureModeHashParams struct {
 	Context ldcontext.Context `json:"context"`
+	User    json.RawMessage   `json:"user,omitempty"`
 }
 
 type SecureModeHashResponse struct {

--- a/servicedef/sdk_config.go
+++ b/servicedef/sdk_config.go
@@ -1,6 +1,8 @@
 package servicedef
 
 import (
+	"encoding/json"
+
 	o "github.com/launchdarkly/sdk-test-harness/v2/framework/opt"
 
 	"github.com/launchdarkly/go-sdk-common/v3/ldcontext"
@@ -65,6 +67,7 @@ type SDKConfigTagsParams struct {
 
 type SDKConfigClientSideParams struct {
 	InitialContext    ldcontext.Context `json:"initialContext"`
+	InitialUser       json.RawMessage   `json:"initialUser,omitempty"`
 	EvaluationReasons o.Maybe[bool]     `json:"evaluationReasons,omitempty"`
 	UseReport         o.Maybe[bool]     `json:"useReport,omitempty"`
 }

--- a/servicedef/service_params.go
+++ b/servicedef/service_params.go
@@ -20,6 +20,7 @@ const (
 	CapabilityServerSidePolling = "server-side-polling"
 	CapabilityServiceEndpoints  = "service-endpoints"
 	CapabilityTags              = "tags"
+	CapabilityUserType          = "user-type"
 )
 
 type StatusRep struct {


### PR DESCRIPTION
These tests are gated by a new "user-type" capability, because not all of the U2C SDKs will have a user type: the Rust SDK won't, since it never had a GA release with a user type in it.

Note that I added a new `user` property to the service commands instead of just passing old-style user JSON in the existing `context` property. That's deliberate; the issue is that in SDKs that have a specific context type, unmarshaling that property would cause the user to be translated into a context— but just because SDKs are able to do that _in JSON unmarshaling_ doesn't prove that they work correctly if you pass an instance of the actual user type directly to an SDK method.