### PR TITLE
fix regression in client-side identify event test logic

### DIFF
--- a/sdktests/common_tests_events_contexts.go
+++ b/sdktests/common_tests_events_contexts.go
@@ -179,7 +179,10 @@ func (c CommonEventTests) EventContexts(t *ldtest.T) {
 		}
 
 		identifyEventForContext := func(context ldcontext.Context) m.Matcher {
-			return m.AllOf(IsIdentifyEventForContext(context), outputMatcher(context))
+			return m.AllOf(
+				IsIdentifyEventForContext(context),
+				m.JSONProperty("context").Should(outputMatcher(context)),
+			)
 		}
 
 		contexts := p.contextFactory("doServerSideEventContextTests")
@@ -201,8 +204,6 @@ func (c CommonEventTests) EventContexts(t *ldtest.T) {
 					m.In(t).Assert(payload, m.Items(identifyEventForContext(initialContext)))
 				})
 			}
-
-			c.discardIdentifyEventIfClientSide(t, client, events) // client-side SDKs always send an initial identify
 
 			if c.isPHP { // only the PHP SDK sends inline contexts in feature events
 				t.Run("feature event", func(t *ldtest.T) {


### PR DESCRIPTION
In the recent refactoring of event tests (to add the "old user" variants), I broke two things:

* When it tried to verify the contents of the initial `identify` event sent by a client-side SDK, it was trying to find the context properties in the top-level event object, rather than inside `context`.
* It was then doing a redundant event flush looking for _another_ initial `identify` event, which would not exist.

I clearly forgot to rerun the tests against a client-side SDK with the last PR— sorry. I have run them now and they work.