### PR TITLE
fix client-side summary event tests to work properly for non-mobile SDKs

### DIFF
--- a/sdktests/client_side_events_summary.go
+++ b/sdktests/client_side_events_summary.go
@@ -66,7 +66,7 @@ func doClientSideSummaryEventBasicTest(t *ldtest.T) {
 
 	// Now change the user to userB, causing a flag data update, and do 1 more evaluation of flag1
 	dataBuilder.Flag(flag1Key, flag1Result2)
-	dataSource.streamingService.SetInitialData(dataBuilder.Build())
+	dataSource.SetInitialData(dataBuilder.Build())
 	client.SendIdentifyEvent(t, userB)
 
 	_ = client.EvaluateFlag(t, servicedef.EvaluateFlagParams{FlagKey: flag1Key, DefaultValue: default1})
@@ -182,7 +182,7 @@ func doClientSideSummaryEventResetTest(t *ldtest.T) {
 	)
 
 	dataBuilder.Flag(flagKey, flag1Result2)
-	dataSource.streamingService.SetInitialData(dataBuilder.Build())
+	dataSource.SetInitialData(dataBuilder.Build())
 	client.SendIdentifyEvent(t, userB)
 
 	for i := 0; i < 3; i++ {

--- a/sdktests/testapi_sdk_data.go
+++ b/sdktests/testapi_sdk_data.go
@@ -110,6 +110,17 @@ func (d *SDKDataSource) StreamingService() *mockld.StreamingService { return d.s
 // streaming data source.
 func (d *SDKDataSource) PollingService() *mockld.PollingService { return d.pollingService }
 
+// SetInitialData configures whichever kind of data source this is (streaming or polling) to use
+// the specified data set the next time it receives an SDK connection.
+func (d *SDKDataSource) SetInitialData(data mockld.SDKData) {
+	if d.streamingService != nil {
+		d.streamingService.SetInitialData(data)
+	}
+	if d.pollingService != nil {
+		d.pollingService.SetData(data)
+	}
+}
+
 // Handler returns the HTTP handler for the service. Since StreamingService implements http.Handler
 // already, this is the same as Service() but makes the purpose clearer.
 func (d *SDKDataSource) Handler() http.Handler { return d.streamingService }


### PR DESCRIPTION
I made an incorrect assumption in these tests that client-side SDKs have streaming turned on by default, and don't use polling and streaming together. That's only true for mobile SDKs; JS-based SDKs use polling for the initial request even if you also enable streaming. The result was a nil pointer panic when the test tried to manipulate the default data source as if it had a stream, and it didn't. I hadn't noticed this because I had only been testing against mobile SDKs.

This bug is in both the v1 and v2 logic, so after merging this, I'll merge forward to v2.