### PR TITLE
fix unreliable state management in client-side event context tests

### DIFF
--- a/sdktests/common_tests_events_contexts.go
+++ b/sdktests/common_tests_events_contexts.go
@@ -198,9 +198,9 @@ func (c CommonEventTests) EventContexts(t *ldtest.T) {
 				events)...)
 
 			if c.isClientSide {
+				client.FlushEvents(t)
+				payload := events.ExpectAnalyticsEvents(t, defaultEventTimeout)
 				t.Run("initial identify event", func(t *ldtest.T) {
-					client.FlushEvents(t)
-					payload := events.ExpectAnalyticsEvents(t, defaultEventTimeout)
 					m.In(t).Assert(payload, m.Items(identifyEventForContext(initialContext)))
 				})
 			}


### PR DESCRIPTION
When running the `events/context properties` tests against a client-side SDK, the tests for debug events could fail if a filter was used to run only a subset of tests. The symptom was that the test would complain about seeing an extra identify event.

The problem was that I had put the test logic for "consume the initial identify event that's always produced by starting the SDK" inside of a subtest. I did that so that I could make assertions about the properties of that event, and have any failures of those assertions show up as specifically failures of the "initial identify event" subtest. However, that meant that if we didn't actually run that subtest, the event would not get consumed and would pollute the state of the next subtest.

The solution is just to do the "consume the initial identify event" part always, and put only the _assertion_ about it inside the subtest.

This fix is only for the v2 branch, because the v1 tests don't have this subtest.