### PR TITLE
Add environment filtering tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,5 @@
 .vscode/
 bin/
 dist/
-
+.idea
 sdk-test-harness

--- a/docs/service_spec.md
+++ b/docs/service_spec.md
@@ -76,6 +76,14 @@ This means that the SDK supports the "tags" configuration option and will send t
 
 For tests that involve tags, the test harness will set the `tags` property of the configuration object.
 
+#### Capability `"filtering"`
+
+This means that the SDK supports the "filter" configuration option for streaming/polling data sources,
+and will send a `?filter=name` query parameter along with streaming/polling requests.
+
+For tests that involve filtering, the test harness will set the `filter` property of the `streaming` or `polling` configuration
+object. The property will either be omitted if no filter is requested, or a non-empty string if requested.
+
 ### Stop test service: `DELETE /`
 
 The test harness sends this request at the end of a test run if you have specified `--stop-service-at-end` on the [command line](./running.md). The test service should simply quit. This is a convenience so CI scripts can simply start the test service in the background and assume it will be stopped for them.
@@ -94,9 +102,11 @@ A `POST` request indicates that the test harness wants to start an instance of t
   * `streaming` (object, optional): Enables streaming mode and provides streaming configuration. If this is omitted _and_ `polling` is also omitted, then the test service can use streaming as a default; but if `streaming` is omitted and `polling` is provided, then streaming should be disabled. Properties are:
     * `baseUri` (string, optional): The base URI for the streaming service. For contract testing, this will be the URI of a simulated streaming endpoint that the test harness provides. If it is null or an empty string, the SDK should default to the value from `serviceEndpoints.streaming` if any, or if that is not set either, connect to the real LaunchDarkly streaming service.
     * `initialRetryDelayMs` (number, optional): The initial stream retry delay in milliseconds. If omitted, use the SDK's default value.
+    * `filter` (string, optional): The key for a filtered environment. If omitted, do not configure the SDK with a filter.
   * `polling` (object, optional): Enables polling mode and provides polling configuration. Properties are:
     * `baseUri` (string, optional): The base URI for the polling service. For contract testing, this will be the URI of a simulated polling endpoint that the test harness provides. If it is null or an empty string, the SDK should default to the value from `serviceEndpoints.polling` if any, or if that is not set either, connect to the real LaunchDarkly polling service.
     * `pollIntervalMs` (number, optional): The polling interval in milliseconds. If omitted, use the SDK's default value. For mobile SDKs that are configured with both streaming and polling enabled, this should be interpreted as the _background_ polling interval.
+    * `filter` (string, optional): The key for a filtered environment. If omitted, do not configure the SDK with a filter.
   * `events` (object, optional): Enables events and provides events configuration, or disables events if it is omitted or null. Properties are:
     * `baseUri` (string, optional): The base URI for the events service. For contract testing, this will be the URI of a simulated event-recorder endpoint that the test harness provides.  If it is null or an empty string, the SDK should default to the value from `serviceEndpoints.events` if any, or if that is not set either, connect to the real LaunchDarkly events service.
     * `capacity` (number, optional): If specified and greater than zero, the event buffer capacity should be set to this value.

--- a/sdktests/common_tests_base.go
+++ b/sdktests/common_tests_base.go
@@ -41,9 +41,6 @@ type environmentFilter struct {
 //// String returns a human-readable representation of the filter key,
 //// suitable for test output.
 func (p environmentFilter) String() string {
-	if !p.IsDefined() {
-		return "no environment filter"
-	}
 	return fmt.Sprintf("environment_filter_key=\"%s\"", p.Value())
 }
 

--- a/sdktests/common_tests_base.go
+++ b/sdktests/common_tests_base.go
@@ -2,6 +2,7 @@ package sdktests
 
 import (
 	"fmt"
+
 	m "github.com/launchdarkly/go-test-helpers/v2/matchers"
 	"github.com/launchdarkly/sdk-test-harness/framework/helpers"
 	"github.com/launchdarkly/sdk-test-harness/framework/ldtest"
@@ -101,10 +102,9 @@ func (c commonTestsBase) availableFlagRequestMethods() []flagRequestMethod {
 	return []flagRequestMethod{flagRequestGET}
 }
 
+// Returns a set of environment filters for testing, along with a filter representing
+// "no filter".
 func (c commonTestsBase) environmentFilters() []environmentFilter {
-	if c.isClientSide {
-		return []environmentFilter{{o.None[string]()}}
-	}
 	return []environmentFilter{
 		{o.None[string]()},
 		{o.Some("encoding_not_necessary")},

--- a/sdktests/common_tests_base.go
+++ b/sdktests/common_tests_base.go
@@ -33,25 +33,17 @@ const (
 // named "filter".
 //
 // Example: "foo" -> "?filter=foo"
-type environmentFilter string
-
-const envFilterNone environmentFilter = ""
-
-// Key returns the filter's key, if any.
-func (p environmentFilter) Key() o.Maybe[string] {
-	if p == envFilterNone {
-		return o.None[string]()
-	}
-	return o.Some(string(p))
+type environmentFilter struct {
+	o.Maybe[string]
 }
 
-// String returns a human-readable representation of the filter key,
-// suitable for test output.
+//// String returns a human-readable representation of the filter key,
+//// suitable for test output.
 func (p environmentFilter) String() string {
-	if p == envFilterNone {
+	if !p.IsDefined() {
 		return "no environment filter"
 	}
-	return fmt.Sprintf("environment_filter_key=\"%s\"", string(p))
+	return fmt.Sprintf("environment_filter_key=\"%s\"", p.Value())
 }
 
 // Matcher checks that if the filter is present, then the query parameter map contains a parameter
@@ -60,9 +52,9 @@ func (p environmentFilter) String() string {
 // a parameter named "filter".
 func (p environmentFilter) Matcher() m.Matcher {
 	hasFilter := m.MapIncluding(
-		m.KV("filter", m.Equal(string(p))),
+		m.KV("filter", m.Equal(p.Value())),
 	)
-	if p == envFilterNone {
+	if !p.IsDefined() {
 		hasFilter = m.Not(hasFilter)
 	}
 	return QueryParameters().Should(hasFilter)
@@ -111,12 +103,12 @@ func (c commonTestsBase) availableFlagRequestMethods() []flagRequestMethod {
 
 func (c commonTestsBase) environmentFilters() []environmentFilter {
 	if c.isClientSide {
-		return []environmentFilter{envFilterNone}
+		return []environmentFilter{{o.None[string]()}}
 	}
 	return []environmentFilter{
-		envFilterNone,
-		"encoding_not_necessary",
-		"encoding necessary +! %& ( )",
+		{o.None[string]()},
+		{o.Some("encoding_not_necessary")},
+		{o.Some("encoding necessary +! %& ( )")},
 	}
 }
 

--- a/sdktests/common_tests_base.go
+++ b/sdktests/common_tests_base.go
@@ -38,8 +38,8 @@ type environmentFilter struct {
 	o.Maybe[string]
 }
 
-//// String returns a human-readable representation of the filter key,
-//// suitable for test output.
+// String returns a human-readable representation of the filter key,
+// suitable for test output.
 func (p environmentFilter) String() string {
 	return fmt.Sprintf("environment_filter_key=\"%s\"", p.Value())
 }

--- a/sdktests/common_tests_base.go
+++ b/sdktests/common_tests_base.go
@@ -1,13 +1,13 @@
 package sdktests
 
 import (
+	"fmt"
+	m "github.com/launchdarkly/go-test-helpers/v2/matchers"
 	"github.com/launchdarkly/sdk-test-harness/framework/helpers"
 	"github.com/launchdarkly/sdk-test-harness/framework/ldtest"
 	o "github.com/launchdarkly/sdk-test-harness/framework/opt"
 	"github.com/launchdarkly/sdk-test-harness/mockld"
 	"github.com/launchdarkly/sdk-test-harness/servicedef"
-
-	m "github.com/launchdarkly/go-test-helpers/v2/matchers"
 	"gopkg.in/launchdarkly/go-sdk-common.v2/lduser"
 )
 
@@ -26,6 +26,47 @@ const (
 	flagRequestGET    flagRequestMethod = "GET"
 	flagRequestREPORT flagRequestMethod = "REPORT"
 )
+
+// Represents a key identifying a filtered environment. This key is passed into
+// SDKs when configuring the polling or streaming data source, and should be
+// appended to the end of streaming/polling requests as a URL query parameter
+// named "filter".
+//
+// Example: "foo" -> "?filter=foo"
+type environmentFilter string
+
+const envFilterNone environmentFilter = ""
+
+// Key returns the filter's key, if any.
+func (p environmentFilter) Key() o.Maybe[string] {
+	if p == envFilterNone {
+		return o.None[string]()
+	}
+	return o.Some(string(p))
+}
+
+// String returns a human-readable representation of the filter key,
+// suitable for test output.
+func (p environmentFilter) String() string {
+	if p == envFilterNone {
+		return "no environment filter"
+	}
+	return fmt.Sprintf("environment_filter_key=\"%s\"", string(p))
+}
+
+// Matcher checks that if the filter is present, then the query parameter map contains a parameter
+// named "filter" with its value.
+// If the filter is not present (envFilterNone), checks that the query parameter map *does not* contain
+// a parameter named "filter".
+func (p environmentFilter) Matcher() m.Matcher {
+	hasFilter := m.MapIncluding(
+		m.KV("filter", m.Equal(string(p))),
+	)
+	if p == envFilterNone {
+		hasFilter = m.Not(hasFilter)
+	}
+	return QueryParameters().Should(hasFilter)
+}
 
 func newCommonTestsBase(t *ldtest.T, testName string, baseSDKConfigurers ...SDKConfigurer) commonTestsBase {
 	c := commonTestsBase{
@@ -66,6 +107,17 @@ func (c commonTestsBase) availableFlagRequestMethods() []flagRequestMethod {
 		return []flagRequestMethod{flagRequestGET, flagRequestREPORT}
 	}
 	return []flagRequestMethod{flagRequestGET}
+}
+
+func (c commonTestsBase) environmentFilters() []environmentFilter {
+	if c.isClientSide {
+		return []environmentFilter{envFilterNone}
+	}
+	return []environmentFilter{
+		envFilterNone,
+		"encoding_not_necessary",
+		"encoding necessary +! %& ( )",
+	}
 }
 
 func (c commonTestsBase) withFlagRequestMethod(method flagRequestMethod) SDKConfigurer {

--- a/sdktests/common_tests_base.go
+++ b/sdktests/common_tests_base.go
@@ -44,9 +44,9 @@ func (p environmentFilter) String() string {
 	return fmt.Sprintf("environment_filter_key=\"%s\"", p.Value())
 }
 
-// Matcher checks that if the filter is present, then the query parameter map contains a parameter
+// Matcher checks that if the filter is present, the query parameter map contains a parameter
 // named "filter" with its value.
-// If the filter is not present (envFilterNone), checks that the query parameter map *does not* contain
+// If the filter is not present, it checks that the query parameter map *does not* contain
 // a parameter named "filter".
 func (p environmentFilter) Matcher() m.Matcher {
 	hasFilter := m.MapIncluding(

--- a/sdktests/common_tests_base.go
+++ b/sdktests/common_tests_base.go
@@ -55,7 +55,7 @@ func (p environmentFilter) Matcher() m.Matcher {
 	if !p.IsDefined() {
 		hasFilter = m.Not(hasFilter)
 	}
-	return QueryParameters().Should(hasFilter)
+	return UniqueQueryParameters().Should(hasFilter)
 }
 
 func newCommonTestsBase(t *ldtest.T, testName string, baseSDKConfigurers ...SDKConfigurer) commonTestsBase {

--- a/sdktests/common_tests_stream_request.go
+++ b/sdktests/common_tests_stream_request.go
@@ -38,7 +38,7 @@ func (c CommonStreamingTests) RequestMethodAndHeaders(t *ldtest.T, credential st
 func (c CommonStreamingTests) RequestURLPath(t *ldtest.T, pathMatcher func(flagRequestMethod) m.Matcher) {
 	t.Run("URL path is computed correctly", func(t *ldtest.T) {
 		for _, filter := range c.environmentFilters() {
-			t.Run(filter.String(), func(t *ldtest.T) {
+			t.Run(h.IfElse(filter.IsDefined(), filter.String(), "no environment filter"), func(t *ldtest.T) {
 				// The environment filtering feature is only tested on server-side SDKs that support
 				// the "filtering" capability. All other SDKs should be tested against the
 				// "no filter" scenario (!filter.IsDefined()), since that was the default functionality

--- a/sdktests/common_tests_stream_request.go
+++ b/sdktests/common_tests_stream_request.go
@@ -40,7 +40,7 @@ func (c CommonStreamingTests) RequestURLPath(t *ldtest.T, pathMatcher func(flagR
 		for _, filter := range c.environmentFilters() {
 			t.Run(filter.String(), func(t *ldtest.T) {
 				if filter.IsDefined() {
-					t.RequireCapability(servicedef.CapabilityFilters)
+					t.RequireCapability(servicedef.CapabilityFiltering)
 				}
 				for _, trailingSlash := range []bool{false, true} {
 					t.Run(h.IfElse(trailingSlash, "base URI has a trailing slash", "base URI has no trailing slash"), func(t *ldtest.T) {

--- a/sdktests/common_tests_stream_request.go
+++ b/sdktests/common_tests_stream_request.go
@@ -39,11 +39,17 @@ func (c CommonStreamingTests) RequestURLPath(t *ldtest.T, pathMatcher func(flagR
 	t.Run("URL path is computed correctly", func(t *ldtest.T) {
 		for _, filter := range c.environmentFilters() {
 			t.Run(filter.String(), func(t *ldtest.T) {
+				// The environment filtering feature is only tested on server-side SDKs that support
+				// the "filtering" capability. All other SDKs should be tested against the
+				// "no filter" scenario (!filter.IsDefined()), since that was the default functionality
+				// previous to the introduction of filtering.
 				if filter.IsDefined() {
 					t.RequireCapability(servicedef.CapabilityFiltering)
+					t.RequireCapability(servicedef.CapabilityServerSide)
 				}
 				for _, trailingSlash := range []bool{false, true} {
-					t.Run(h.IfElse(trailingSlash, "base URI has a trailing slash", "base URI has no trailing slash"), func(t *ldtest.T) {
+					t.Run(h.IfElse(trailingSlash, "base URI has a trailing slash",
+						"base URI has no trailing slash"), func(t *ldtest.T) {
 						for _, method := range c.availableFlagRequestMethods() {
 							t.Run(string(method), func(t *ldtest.T) {
 								dataSource, configurers := c.setupDataSources(t, nil)

--- a/sdktests/common_tests_stream_request.go
+++ b/sdktests/common_tests_stream_request.go
@@ -39,7 +39,7 @@ func (c CommonStreamingTests) RequestURLPath(t *ldtest.T, pathMatcher func(flagR
 	t.Run("URL path is computed correctly", func(t *ldtest.T) {
 		for _, filter := range c.environmentFilters() {
 			t.Run(filter.String(), func(t *ldtest.T) {
-				if filter.Key().IsDefined() {
+				if filter.IsDefined() {
 					t.RequireCapability(servicedef.CapabilityFilters)
 				}
 				for _, trailingSlash := range []bool{false, true} {
@@ -57,7 +57,7 @@ func (c CommonStreamingTests) RequestURLPath(t *ldtest.T, pathMatcher func(flagR
 									append(configurers,
 										WithStreamingConfig(servicedef.SDKConfigStreamingParams{
 											BaseURI: streamURI,
-											Filter:  filter.Key(),
+											Filter:  filter.Maybe,
 										}),
 										c.withFlagRequestMethod(method),
 									)...)...)

--- a/sdktests/common_tests_stream_request.go
+++ b/sdktests/common_tests_stream_request.go
@@ -37,27 +37,36 @@ func (c CommonStreamingTests) RequestMethodAndHeaders(t *ldtest.T, credential st
 
 func (c CommonStreamingTests) RequestURLPath(t *ldtest.T, pathMatcher func(flagRequestMethod) m.Matcher) {
 	t.Run("URL path is computed correctly", func(t *ldtest.T) {
-		for _, trailingSlash := range []bool{false, true} {
-			t.Run(h.IfElse(trailingSlash, "base URI has a trailing slash", "base URI has no trailing slash"), func(t *ldtest.T) {
-				for _, method := range c.availableFlagRequestMethods() {
-					t.Run(string(method), func(t *ldtest.T) {
-						dataSource, configurers := c.setupDataSources(t, nil)
+		for _, filter := range c.environmentFilters() {
+			t.Run(filter.String(), func(t *ldtest.T) {
+				if filter.Key().IsDefined() {
+					t.RequireCapability(servicedef.CapabilityFilters)
+				}
+				for _, trailingSlash := range []bool{false, true} {
+					t.Run(h.IfElse(trailingSlash, "base URI has a trailing slash", "base URI has no trailing slash"), func(t *ldtest.T) {
+						for _, method := range c.availableFlagRequestMethods() {
+							t.Run(string(method), func(t *ldtest.T) {
+								dataSource, configurers := c.setupDataSources(t, nil)
 
-						streamURI := strings.TrimSuffix(dataSource.Endpoint().BaseURL(), "/")
-						if trailingSlash {
-							streamURI += "/"
+								streamURI := strings.TrimSuffix(dataSource.Endpoint().BaseURL(), "/")
+								if trailingSlash {
+									streamURI += "/"
+								}
+
+								_ = NewSDKClient(t, c.baseSDKConfigurationPlus(
+									append(configurers,
+										WithStreamingConfig(servicedef.SDKConfigStreamingParams{
+											BaseURI: streamURI,
+											Filter:  filter.Key(),
+										}),
+										c.withFlagRequestMethod(method),
+									)...)...)
+
+								request := dataSource.Endpoint().RequireConnection(t, time.Second)
+								m.In(t).For("request path").Assert(request.URL.Path, pathMatcher(method))
+								m.In(t).For("filter key").Assert(request.URL.RawQuery, filter.Matcher())
+							})
 						}
-
-						_ = NewSDKClient(t, c.baseSDKConfigurationPlus(
-							append(configurers,
-								WithStreamingConfig(servicedef.SDKConfigStreamingParams{
-									BaseURI: streamURI,
-								}),
-								c.withFlagRequestMethod(method),
-							)...)...)
-
-						request := dataSource.Endpoint().RequireConnection(t, time.Second)
-						m.In(t).For("request path").Assert(request.URL.Path, pathMatcher(method))
 					})
 				}
 			})

--- a/sdktests/custom_matchers_general.go
+++ b/sdktests/custom_matchers_general.go
@@ -22,10 +22,10 @@ import (
 // The functions in this file are for convenient use of the matchers API with complex
 // types. For more information, see matchers.Transform.
 
-// QueryParameters returns a MatcherTransform which parses a string representing a URL's
+// UniqueQueryParameters returns a MatcherTransform which parses a string representing a URL's
 // RawQuery field into a map from parameter key to parameter value. If there are multiple values
-// for a key, the first is used.
-func QueryParameters() m.MatcherTransform {
+// for a key, an error is returned.
+func UniqueQueryParameters() m.MatcherTransform {
 	return m.Transform("extract URL query parameter", func(i interface{}) (interface{}, error) {
 		values, err := url.ParseQuery(i.(string))
 		if err != nil {
@@ -33,6 +33,9 @@ func QueryParameters() m.MatcherTransform {
 		}
 		out := make(map[string]string)
 		for k, v := range values {
+			if len(v) > 1 {
+				return nil, fmt.Errorf("parameter %s had %v values; expected 1", k, len(v))
+			}
 			out[k] = v[0]
 		}
 		return out, nil

--- a/sdktests/custom_matchers_general.go
+++ b/sdktests/custom_matchers_general.go
@@ -4,6 +4,7 @@ import (
 	"encoding/base64"
 	"fmt"
 	"net/http"
+	"net/url"
 	"sort"
 	"strings"
 
@@ -21,6 +22,20 @@ import (
 // The functions in this file are for convenient use of the matchers API with complex
 // types. For more information, see matchers.Transform.
 
+func QueryParameters() m.MatcherTransform {
+	return m.Transform("extract URL query parameter", func(i interface{}) (interface{}, error) {
+		values, err := url.ParseQuery(i.(string))
+		if err != nil {
+			return nil, err
+		}
+		out := make(map[string]string)
+		for k, v := range values {
+			out[k] = v[0]
+		}
+		return out, nil
+	}).
+		EnsureInputValueType("")
+}
 func Base64DecodedData() m.MatcherTransform {
 	return m.Transform(
 		"base64-decoded data",

--- a/sdktests/custom_matchers_general.go
+++ b/sdktests/custom_matchers_general.go
@@ -22,6 +22,9 @@ import (
 // The functions in this file are for convenient use of the matchers API with complex
 // types. For more information, see matchers.Transform.
 
+// QueryParameters returns a MatcherTransform which parses a string representing a URL's
+// RawQuery field into a map from parameter key to parameter value. If there are multiple values
+// for a key, the first is used.
 func QueryParameters() m.MatcherTransform {
 	return m.Transform("extract URL query parameter", func(i interface{}) (interface{}, error) {
 		values, err := url.ParseQuery(i.(string))

--- a/servicedef/sdk_config.go
+++ b/servicedef/sdk_config.go
@@ -30,11 +30,13 @@ type SDKConfigServiceEndpointsParams struct {
 type SDKConfigStreamingParams struct {
 	BaseURI             string                              `json:"baseUri,omitempty"`
 	InitialRetryDelayMS o.Maybe[ldtime.UnixMillisecondTime] `json:"initialRetryDelayMs,omitempty"`
+	Filter              o.Maybe[string]                     `json:"filter,omitempty"`
 }
 
 type SDKConfigPollingParams struct {
 	BaseURI        string                              `json:"baseUri,omitempty"`
 	PollIntervalMS o.Maybe[ldtime.UnixMillisecondTime] `json:"pollIntervalMs,omitempty"`
+	Filter         o.Maybe[string]                     `json:"filter,omitempty"`
 }
 
 type SDKConfigEventParams struct {

--- a/servicedef/service_params.go
+++ b/servicedef/service_params.go
@@ -19,7 +19,7 @@ const (
 	CapabilityServerSidePolling = "server-side-polling"
 	CapabilityServiceEndpoints  = "service-endpoints"
 	CapabilityTags              = "tags"
-	CapabilityFilters           = "filters"
+	CapabilityFiltering         = "filtering"
 )
 
 type StatusRep struct {

--- a/servicedef/service_params.go
+++ b/servicedef/service_params.go
@@ -19,6 +19,7 @@ const (
 	CapabilityServerSidePolling = "server-side-polling"
 	CapabilityServiceEndpoints  = "service-endpoints"
 	CapabilityTags              = "tags"
+	CapabilityFilters           = "filters"
 )
 
 type StatusRep struct {


### PR DESCRIPTION
This PR introduces optional tests for filtered environment functionality. 

The framework passes in a new configuration option on the streaming/polling configs, named `Filter`. 

An SDK should setup its streaming/polling data source using this filter, and then append it to requests as a URL query parameter (example: `?filter=microservice-1`).

The tests are only run for server-side SDKs with the `filtering` capability.

- [x] Go Server SDK passes tests (locally)