### PR TITLE
feat: Add filtered environment tests 

### DIFF
--- a/docs/service_spec.md
+++ b/docs/service_spec.md
@@ -88,6 +88,14 @@ For tests that involve tags, the test harness will set the `tags` property of th
 
 This means that the SDK has a type corresponding to the old-style user model, and supports directly passing such user data to SDK methods as an alternative to context data. If this capability is present, the test harness may send a `user` property with old-style user JSON for test commands that would normally take a `context` property. If this capability is absent, `user` will never be set.
 
+#### Capability `"filtering"`
+
+This means that the SDK supports the "filter" configuration option for streaming/polling data sources,
+and will send a `?filter=name` query parameter along with streaming/polling requests.
+
+For tests that involve filtering, the test harness will set the `filter` property of the `streaming` or `polling` configuration
+object. The property will either be omitted if no filter is requested, or a non-empty string if requested.
+
 ### Stop test service: `DELETE /`
 
 The test harness sends this request at the end of a test run if you have specified `--stop-service-at-end` on the [command line](./running.md). The test service should simply quit. This is a convenience so CI scripts can simply start the test service in the background and assume it will be stopped for them.
@@ -106,9 +114,11 @@ A `POST` request indicates that the test harness wants to start an instance of t
   * `streaming` (object, optional): Enables streaming mode and provides streaming configuration. If this is omitted _and_ `polling` is also omitted, then the test service can use streaming as a default; but if `streaming` is omitted and `polling` is provided, then streaming should be disabled. Properties are:
     * `baseUri` (string, optional): The base URI for the streaming service. For contract testing, this will be the URI of a simulated streaming endpoint that the test harness provides. If it is null or an empty string, the SDK should default to the value from `serviceEndpoints.streaming` if any, or if that is not set either, connect to the real LaunchDarkly streaming service.
     * `initialRetryDelayMs` (number, optional): The initial stream retry delay in milliseconds. If omitted, use the SDK's default value.
+    * `filter` (string, optional): The key for a filtered environment. If omitted, do not configure the SDK with a filter.
   * `polling` (object, optional): Enables polling mode and provides polling configuration. Properties are:
     * `baseUri` (string, optional): The base URI for the polling service. For contract testing, this will be the URI of a simulated polling endpoint that the test harness provides. If it is null or an empty string, the SDK should default to the value from `serviceEndpoints.polling` if any, or if that is not set either, connect to the real LaunchDarkly polling service.
     * `pollIntervalMs` (number, optional): The polling interval in milliseconds. If omitted, use the SDK's default value. For mobile SDKs that are configured with both streaming and polling enabled, this should be interpreted as the _background_ polling interval.
+    * `filter` (string, optional): The key for a filtered environment. If omitted, do not configure the SDK with a filter.
   * `events` (object, optional): Enables events and provides events configuration, or disables events if it is omitted or null. Properties are:
     * `baseUri` (string, optional): The base URI for the events service. For contract testing, this will be the URI of a simulated event-recorder endpoint that the test harness provides.  If it is null or an empty string, the SDK should default to the value from `serviceEndpoints.events` if any, or if that is not set either, connect to the real LaunchDarkly events service.
     * `capacity` (number, optional): If specified and greater than zero, the event buffer capacity should be set to this value.

--- a/sdktests/custom_matchers_general.go
+++ b/sdktests/custom_matchers_general.go
@@ -4,6 +4,7 @@ import (
 	"encoding/base64"
 	"fmt"
 	"net/http"
+	"net/url"
 	"sort"
 	"strings"
 
@@ -20,6 +21,26 @@ import (
 // The functions in this file are for convenient use of the matchers API with complex
 // types. For more information, see matchers.Transform.
 
+// UniqueQueryParameters returns a MatcherTransform which parses a string representing a URL's
+// RawQuery field into a map from parameter key to parameter value. If there are multiple values
+// for a key, an error is returned.
+func UniqueQueryParameters() m.MatcherTransform {
+	return m.Transform("extract URL query parameter", func(i interface{}) (interface{}, error) {
+		values, err := url.ParseQuery(i.(string))
+		if err != nil {
+			return nil, err
+		}
+		out := make(map[string]string)
+		for k, v := range values {
+			if len(v) > 1 {
+				return nil, fmt.Errorf("parameter %s had %v values; expected 1", k, len(v))
+			}
+			out[k] = v[0]
+		}
+		return out, nil
+	}).
+		EnsureInputValueType("")
+}
 func Base64DecodedData() m.MatcherTransform {
 	return m.Transform(
 		"base64-decoded data",

--- a/servicedef/sdk_config.go
+++ b/servicedef/sdk_config.go
@@ -32,11 +32,13 @@ type SDKConfigServiceEndpointsParams struct {
 type SDKConfigStreamingParams struct {
 	BaseURI             string                              `json:"baseUri,omitempty"`
 	InitialRetryDelayMS o.Maybe[ldtime.UnixMillisecondTime] `json:"initialRetryDelayMs,omitempty"`
+	Filter              o.Maybe[string]                     `json:"filter,omitempty"`
 }
 
 type SDKConfigPollingParams struct {
 	BaseURI        string                              `json:"baseUri,omitempty"`
 	PollIntervalMS o.Maybe[ldtime.UnixMillisecondTime] `json:"pollIntervalMs,omitempty"`
+	Filter         o.Maybe[string]                     `json:"filter,omitempty"`
 }
 
 type SDKConfigEventParams struct {

--- a/servicedef/service_params.go
+++ b/servicedef/service_params.go
@@ -21,6 +21,7 @@ const (
 	CapabilityServiceEndpoints  = "service-endpoints"
 	CapabilityTags              = "tags"
 	CapabilityUserType          = "user-type"
+	CapabilityFiltering         = "filtering"
 )
 
 type StatusRep struct {


### PR DESCRIPTION
(This cherry-picks the tests from `main` to `v2`).

This PR introduces optional tests for filtered environment functionality. 

The framework passes in a new configuration option on the streaming/polling configs, named `Filter`. 

An SDK should setup its streaming/polling data source using this filter, and then append it to requests as a URL query parameter (example: `?filter=microservice-1`).

The tests are only run for server-side SDKs with the `filtering` capability.