### PR TITLE
Ensure targets are evaluated before rules

### DIFF
--- a/data/data-files/server-side-eval/target-match.yml
+++ b/data/data-files/server-side-eval/target-match.yml
@@ -75,7 +75,7 @@ sdkData:
         - { contextKind: "user", variation: 2 }
         - { contextKind: "user", variation: 3 }
 
-    flag-with-targets-exclude-rules:
+    flag-targets-match-before-rules:
       on: true
       variations: [ <VALUE_OFF>, <VALUE_FALLTHROUGH>, <VALUE_A>, <VALUE_B> ]
       offVariation: 0
@@ -224,7 +224,7 @@ evaluations:
     expect: <IS_OFF>
 
   - name: target matching takes precedence over rules
-    flagKey: flag-with-targets-exclude-rules
+    flagKey: flag-targets-match-before-rules
     context: { "kind": "user", "key": "key1" }
     default: <VALUE_DEFAULT>
     expect: <IS_MATCH_A>

--- a/data/data-files/server-side-eval/target-match.yml
+++ b/data/data-files/server-side-eval/target-match.yml
@@ -75,6 +75,19 @@ sdkData:
         - { contextKind: "user", variation: 2 }
         - { contextKind: "user", variation: 3 }
 
+    flag-with-targets-exclude-rules:
+      on: true
+      variations: [ <VALUE_OFF>, <VALUE_FALLTHROUGH>, <VALUE_A>, <VALUE_B> ]
+      offVariation: 0
+      fallthrough: { variation: 1 }
+      targets:
+        - { variation: 2, values: [ "key1" ] }
+      rules:
+        - id: rule1
+          variation: 3
+          clauses:
+            - { "attribute": "key", "op": "in", "values": [ "key1" ] }
+
 evaluations:
   - name: user targets only, match user 1
     flagKey: flag-with-targets
@@ -209,3 +222,9 @@ evaluations:
     context: { "kind": "user", "key": "key1" }
     default: <VALUE_DEFAULT>
     expect: <IS_OFF>
+
+  - name: target matching takes precedence over rules
+    flagKey: flag-with-targets-exclude-rules
+    context: { "kind": "user", "key": "key1" }
+    default: <VALUE_DEFAULT>
+    expect: <IS_MATCH_A>

--- a/data/data-files/server-side-eval/variation-value-types.yml
+++ b/data/data-files/server-side-eval/variation-value-types.yml
@@ -54,19 +54,6 @@ sdkData:
         - { variation: 1, values: [ "key1" ] }
         - { variation: 2, values: [ "key2" ] }
 
-    flag-targets-match-before-rules:
-      on: true
-      variations: [ <TYPE_VALUE_OFF>, <TYPE_VALUE_FALLTHROUGH>, <TYPE_VALUE_1>, <TYPE_VALUE_2> ]
-      offVariation: 0
-      fallthrough: { variation: 1 }
-      targets:
-        - { variation: 2, values: [ "key1" ] }
-      rules:
-        - id: rule1
-          variation: 3
-          clauses:
-            - { "attribute": "key", "op": "in", "values": [ "key1" ] }
-
 evaluations:
   - name: off
     flagKey: off-flag


### PR DESCRIPTION
While reviewing a recent Haskell PR, Ryan noticed that the evaluation logic in Haskell was reversed. Namely, we were checking rules and then checking the targets.

This test ensures no other SDK will make the same silly mistake.