### PR TITLE
Segment test with weight and matching and non-matching key.

### DIFF
--- a/testdata/data-files/server-side-eval/segment-match.yml
+++ b/testdata/data-files/server-side-eval/segment-match.yml
@@ -42,6 +42,14 @@ sdkData:
           clauses:
             - { attribute: "", op: "segmentMatch", values: [ "segment99" ]}
 
+    flag-using-segment3:
+      <<: *boolean_flag_base
+      rules:
+        - id: ruleid
+          variation: 0
+          clauses:
+            - { attribute: "", op: "segmentMatch", values: [ "segment3" ]}
+
   segments:
     segment1:
       included: [ "user-included-in-segment" ]
@@ -54,6 +62,16 @@ sdkData:
       rules:
         - clauses:
             - { attribute: "segment2RuleShouldMatch", op: "in", values: [ true ] }
+
+    segment3:
+      salt: salty
+      rules:
+        - id: ruleid
+          clauses:
+            - { attribute: "segment3RuleShouldMatch", op: "in", values: [ true ] }
+          #Bucket value for segment3.salty.user-key + 5
+          #The value will be 36563 for segment3.salty.unmatching-key
+          weight: 14955
 
 evaluations:
   - name: user matches via include
@@ -94,3 +112,17 @@ evaluations:
     user:
       key: "user-key"
     expect: <IS_NOT_MATCH>
+
+  - name: key does not bucket into segment
+    flagKey: flag-using-segment3
+    user:
+      key: "unmatching-key"
+      custom: { "segment3RuleShouldMatch": true }
+    expect: <IS_NOT_MATCH>
+
+  - name: key does bucket into segment
+    flagKey: flag-using-segment3
+    user:
+      key: "user-key"
+      custom: { "segment3RuleShouldMatch": true }
+    expect: <IS_MATCH>


### PR DESCRIPTION
The bucketing consistency tests only test segments that match and then bucket into the segment. They never test that any  given segment is not bucketed into.

As such if your segment implementation always buckets 0, then all the existing contract tests pass. (The JS sever SDK was affected by this)

I looked into extending the bucketing consistency tests, but the set of tests is ran in too many different permutations, one if which is a non-bucket-able value. When you have such a value the bucket will be 0, which will always go into the segment.

So I added a parameterized test that has a fixed value that buckets into it, and another fixed value that doesn't bucket  into it. It uses the same margin of 5 as used in the bucketing consistency. 
