### PR TITLE
Ensure targets are evaluated before rules

### DIFF
--- a/testdata/data-files/server-side-eval/target-match.yml
+++ b/testdata/data-files/server-side-eval/target-match.yml
@@ -60,6 +60,19 @@ sdkData:
         - { "variation": 2, "values": [ "user1", "user2" ] }
         - { "variation": 3, "values": [ "user3", "user4" ] }
 
+    flag-targets-match-before-rules:
+      on: true
+      variations: [ <TYPE_VALUE_OFF>, <TYPE_VALUE_FALLTHROUGH>, <TYPE_VALUE_1>, <TYPE_VALUE_2> ]
+      offVariation: 0
+      fallthrough: { variation: 1 }
+      targets:
+        - { variation: 2, values: [ "key1" ] }
+      rules:
+        - id: rule1
+          variation: 3
+          clauses:
+            - { "attribute": "key", "op": "in", "values": [ "key1" ] }
+
 evaluations:
   - name: user1 matches
     flagKey: flag-with-targets
@@ -120,3 +133,13 @@ evaluations:
       value: <TYPE_VALUE_OFF>
       variationIndex: 0
       reason: { "kind": "OFF" }
+
+  - name: target matching takes precedence over rules
+    flagKey: flag-targets-match-before-rules
+    user: { "key": "key1" }
+    valueType: <TYPE_NAME>
+    default: <TYPE_DEFAULT>
+    expect:
+      value: <TYPE_VALUE_1>
+      variationIndex: 2
+      reason: { "kind": "TARGET_MATCH" }


### PR DESCRIPTION
While reviewing a recent Haskell PR, Ryan noticed that the evaluation
logic in Haskell was reversed. Namely, we were checking rules and then
checking the targets.

This test ensures no other SDK will make the same silly mistake.
