### PR TITLE
Add Roku support

### DIFF
--- a/mockld/events_service.go
+++ b/mockld/events_service.go
@@ -46,6 +46,8 @@ func NewEventsService(sdkKind SDKKind, logger framework.Logger) *EventsService {
 	case ServerSideSDK, PHPSDK:
 		router.HandleFunc("/bulk", s.postEvents).Methods("POST")
 		router.HandleFunc("/diagnostic", s.postDiagnosticEvent).Methods("POST")
+	case RokuSDK:
+		fallthrough
 	case MobileSDK:
 		router.HandleFunc("/mobile", s.postEvents).Methods("POST")
 		router.HandleFunc("/mobile/events", s.postEvents).Methods("POST")

--- a/mockld/polling_service.go
+++ b/mockld/polling_service.go
@@ -48,6 +48,8 @@ func NewPollingService(
 	switch sdkKind {
 	case ServerSideSDK:
 		router.Handle(PollingPathServerSide, pollHandler).Methods("GET")
+	case RokuSDK:
+		fallthrough
 	case MobileSDK:
 		router.Handle(PollingPathMobileGet, pollHandler).Methods("GET")
 		router.Handle(PollingPathMobileReport, pollHandler).Methods("REPORT")

--- a/mockld/roku.go
+++ b/mockld/roku.go
@@ -1,0 +1,72 @@
+package mockld
+
+import (
+	"encoding/base64"
+	"encoding/json"
+	"io/ioutil"
+	"net/http"
+)
+
+// SDK expects these fields to be present, but it will ignore these fields when
+// running in plain text mode against the test harness.
+type handshakePublicBundle struct {
+	AuthenticationKey string `json:"authenticationKey"`
+	CipherKey         string `json:"cipherKey"`
+	ServerBundle      string `json:"serverBundle"`
+}
+
+type RokuServer struct {
+	user      *json.RawMessage
+	mobileKey *string
+}
+
+func (srv *RokuServer) Wrap(h http.Handler) http.Handler {
+	return http.HandlerFunc(func(baseWriter http.ResponseWriter, req *http.Request) {
+		userJSON, err := json.Marshal(srv.user)
+		if err != nil {
+			baseWriter.WriteHeader(http.StatusInternalServerError)
+			return
+		}
+
+		userJSONBase64 := base64.StdEncoding.EncodeToString(userJSON)
+
+		req.Method = "GET"
+		req.Header.Set("Authorization", *srv.mobileKey)
+		req.ContentLength = 0
+		req.Body = nil
+
+		req.URL.Path = "/meval/" + userJSONBase64
+
+		h.ServeHTTP(baseWriter, req)
+	})
+}
+
+func (srv *RokuServer) ServeHandshake(baseWriter http.ResponseWriter, req *http.Request) {
+	authorization := req.Header.Get("Authorization")
+	if authorization == "" {
+		baseWriter.WriteHeader(http.StatusUnauthorized)
+		return
+	}
+	// Save mobile key for use when client connects to stream
+	srv.mobileKey = &authorization
+
+	body, err := ioutil.ReadAll(req.Body)
+	if err != nil {
+		baseWriter.WriteHeader(http.StatusBadRequest)
+		return
+	}
+
+	// Save user for use when client connects to stream
+	user := json.RawMessage(body)
+	srv.user = &user
+
+	json, err := json.Marshal(handshakePublicBundle{})
+	if err != nil {
+		baseWriter.WriteHeader(http.StatusInternalServerError)
+		return
+	}
+
+	baseWriter.WriteHeader(http.StatusOK)
+
+	_, _ = baseWriter.Write(json)
+}

--- a/mockld/sdk_data.go
+++ b/mockld/sdk_data.go
@@ -22,6 +22,7 @@ const (
 	MobileSDK     SDKKind = "mobile"
 	JSClientSDK   SDKKind = "jsclient"
 	PHPSDK        SDKKind = "php"
+	RokuSDK       SDKKind = "roku"
 )
 
 func (k SDKKind) IsServerSide() bool {

--- a/mockld/streaming_service.go
+++ b/mockld/streaming_service.go
@@ -17,6 +17,8 @@ const (
 	StreamingPathServerSide      = "/all"
 	StreamingPathMobileGet       = "/meval/{user}"
 	StreamingPathMobileReport    = "/meval"
+	StreamingPathRokuHandshake   = "/handshake"
+	StreamingPathRokuEvaluate    = "/mevalalternate"
 	StreamingPathJSClientGet     = "/eval/{env}/{user}"
 	StreamingPathJSClientReport  = "/eval/{env}"
 	StreamingPathUserBase64Param = "{user}"
@@ -80,6 +82,12 @@ func NewStreamingService(
 	switch sdkKind {
 	case ServerSideSDK:
 		router.HandleFunc(StreamingPathServerSide, streamHandler).Methods("GET")
+	case RokuSDK:
+		rokuHandler := RokuServer{}
+
+		router.Path(StreamingPathRokuHandshake).Methods("POST").HandlerFunc(rokuHandler.ServeHandshake)
+		router.Path(StreamingPathRokuEvaluate).Methods("POST").Handler(rokuHandler.Wrap(s))
+		fallthrough
 	case MobileSDK:
 		router.HandleFunc(StreamingPathMobileGet, streamHandler).Methods("GET")
 		router.HandleFunc(StreamingPathMobileReport, streamHandler).Methods("REPORT")

--- a/sdktests/client_side_poll_all.go
+++ b/sdktests/client_side_poll_all.go
@@ -25,6 +25,8 @@ func doClientSidePollRequestTest(t *ldtest.T) {
 
 	requestPathMatcher := func(method flagRequestMethod) m.Matcher {
 		switch sdkKind {
+		case mockld.RokuSDK:
+			fallthrough
 		case mockld.MobileSDK:
 			mobileGetPathPrefix := strings.TrimSuffix(mockld.PollingPathMobileGet, mockld.PollingPathUserBase64Param)
 			return h.IfElse(method == flagRequestREPORT,
@@ -48,7 +50,7 @@ func doClientSidePollRequestTest(t *ldtest.T) {
 	}
 	pollTests.RequestURLPath(t, requestPathMatcher)
 
-	getPath := h.IfElse(sdkKind == mockld.MobileSDK,
+	getPath := h.IfElse(sdkKind == mockld.MobileSDK || sdkKind == mockld.RokuSDK,
 		mockld.PollingPathMobileGet,
 		strings.ReplaceAll(mockld.PollingPathJSClientGet, mockld.PollingPathEnvIDParam, envIDOrMobileKey))
 	pollTests.RequestUserProperties(t, getPath)

--- a/sdktests/client_side_stream_all.go
+++ b/sdktests/client_side_stream_all.go
@@ -26,6 +26,8 @@ func doClientSideStreamRequestTest(t *ldtest.T) {
 
 	requestPathMatcher := func(method flagRequestMethod) m.Matcher {
 		switch sdkKind {
+		case mockld.RokuSDK:
+			panic("invalid SDK kind")
 		case mockld.MobileSDK:
 			mobileGetPathPrefix := strings.TrimSuffix(mockld.StreamingPathMobileGet, mockld.StreamingPathUserBase64Param)
 			return h.IfElse(method == flagRequestREPORT,
@@ -50,7 +52,7 @@ func doClientSideStreamRequestTest(t *ldtest.T) {
 	}
 	streamTests.RequestURLPath(t, requestPathMatcher)
 
-	getPath := h.IfElse(sdkKind == mockld.MobileSDK,
+	getPath := h.IfElse(sdkKind == mockld.MobileSDK || sdkKind == mockld.RokuSDK,
 		mockld.StreamingPathMobileGet,
 		strings.ReplaceAll(mockld.StreamingPathJSClientGet, mockld.PollingPathEnvIDParam, envIDOrMobileKey))
 	streamTests.RequestUserProperties(t, getPath)

--- a/sdktests/common_tests_stream_base.go
+++ b/sdktests/common_tests_stream_base.go
@@ -40,6 +40,8 @@ func (c CommonStreamingTests) setupDataSources(
 	case mockld.ServerSideSDK:
 		break
 
+	case mockld.RokuSDK:
+		fallthrough
 	case mockld.MobileSDK:
 		emptyPollingDataSource := NewSDKDataSource(t, nil, DataSourceOptionPolling())
 		configurers = append(configurers, emptyPollingDataSource)

--- a/sdktests/testsuite_entry_point.go
+++ b/sdktests/testsuite_entry_point.go
@@ -29,6 +29,11 @@ func RunSDKTestSuite(
 		fmt.Println("Running server-side SDK test suite")
 		sdkKind = mockld.ServerSideSDK
 		importantCapabilities = allImportantServerSideCapabilities()
+	case capabilities.Has(servicedef.CapabilityClientSide) &&
+		capabilities.Has(servicedef.CapabilityMobile) &&
+		capabilities.Has(servicedef.CapabilityRoku):
+		fmt.Println("Running client-side (roku) SDK test suite")
+		sdkKind = mockld.RokuSDK
 	case capabilities.Has(servicedef.CapabilityClientSide) && capabilities.Has(servicedef.CapabilityMobile):
 		fmt.Println("Running client-side (mobile) SDK test suite")
 		sdkKind = mockld.MobileSDK

--- a/servicedef/service_params.go
+++ b/servicedef/service_params.go
@@ -8,6 +8,7 @@ const (
 	CapabilityStronglyTyped = "strongly-typed"
 	CapabilityMobile        = "mobile"
 	CapabilityPHP           = "php"
+	CapabilityRoku          = "roku"
 	CapabilitySingleton     = "singleton"
 
 	CapabilityAllFlagsWithReasons                = "all-flags-with-reasons"


### PR DESCRIPTION
Limitations with the Roku platform require the SDKs to connect to alternative streaming endpoints. These endpoints communicate using custom encryption, which we do not wish to replicate here.

Instead, the Roku SDK will connect to the same alternative endpoint, but the information will be transmitted in plain text. The SDK can be configured to operate in plain text mode, which should only be used for the contract tests.