### PR TITLE
chore: add v2 branch to releaser config

### DIFF
--- a/.ldrelease/config.yml
+++ b/.ldrelease/config.yml
@@ -1,5 +1,9 @@
 version: 2
 
+branches:
+  - main
+  - v2
+  
 jobs:
   - docker:
       image: cimg/go:1.18


### PR DESCRIPTION
Adds the `main` and `v2` branches to releaser config.