### PR TITLE
chore: merge forward releaser branch changes from main

### DIFF
--- a/.ldrelease/config.yml
+++ b/.ldrelease/config.yml
@@ -1,5 +1,9 @@
 version: 2
 
+branches:
+  - name: main
+  - name: v2
+  
 jobs:
   - docker:
       image: cimg/go:1.18


### PR DESCRIPTION
Pulls in addition of `v2` branch to releaser configuration, in preparation of v2.0.0 releaser.