### PR TITLE
feat: Add polling test with large payload size

### DIFF
--- a/sdktests/common_tests_poll_request.go
+++ b/sdktests/common_tests_poll_request.go
@@ -37,11 +37,11 @@ func (c CommonPollingTests) RequestMethodAndHeaders(t *ldtest.T, credential stri
 }
 
 func (c CommonPollingTests) LargePayloads(t *ldtest.T) {
-	flags := make([]ldmodel.FeatureFlag, 100)
-	for i := 0; i < 100; i++ {
+	flags := make([]ldmodel.FeatureFlag, 1000)
+	for i := 0; i < 1000; i++ {
 		flag := ldmodel.FeatureFlag{
 			Key:          fmt.Sprintf("flag-key-%d", i),
-			On:           i == 99,
+			On:           i == 999,
 			Variations:   []ldvalue.Value{ldvalue.String("fallthrough"), ldvalue.String("off"), ldvalue.String("default")},
 			OffVariation: ldvalue.NewOptionalInt(1),
 			Fallthrough: ldmodel.VariationOrRollout{
@@ -71,7 +71,7 @@ func (c CommonPollingTests) LargePayloads(t *ldtest.T) {
 		}
 
 		resp = client.EvaluateFlag(t, servicedef.EvaluateFlagParams{
-			FlagKey:      "flag-key-99",
+			FlagKey:      "flag-key-999",
 			ValueType:    servicedef.ValueTypeString,
 			Context:      o.Some(ldcontext.New("user-key")),
 			DefaultValue: ldvalue.String("default"),

--- a/sdktests/common_tests_poll_request.go
+++ b/sdktests/common_tests_poll_request.go
@@ -5,6 +5,8 @@ import (
 	"strings"
 	"time"
 
+	"github.com/stretchr/testify/require"
+
 	"github.com/launchdarkly/go-server-sdk-evaluation/v2/ldmodel"
 	"github.com/launchdarkly/sdk-test-harness/v2/data"
 	h "github.com/launchdarkly/sdk-test-harness/v2/framework/helpers"
@@ -12,7 +14,6 @@ import (
 	o "github.com/launchdarkly/sdk-test-harness/v2/framework/opt"
 	"github.com/launchdarkly/sdk-test-harness/v2/mockld"
 	"github.com/launchdarkly/sdk-test-harness/v2/servicedef"
-	"github.com/stretchr/testify/require"
 
 	"github.com/launchdarkly/go-sdk-common/v3/ldcontext"
 	"github.com/launchdarkly/go-sdk-common/v3/ldvalue"

--- a/sdktests/common_tests_poll_request.go
+++ b/sdktests/common_tests_poll_request.go
@@ -5,14 +5,17 @@ import (
 	"strings"
 	"time"
 
+	"github.com/launchdarkly/go-server-sdk-evaluation/v2/ldmodel"
 	"github.com/launchdarkly/sdk-test-harness/v2/data"
 	h "github.com/launchdarkly/sdk-test-harness/v2/framework/helpers"
 	"github.com/launchdarkly/sdk-test-harness/v2/framework/ldtest"
 	o "github.com/launchdarkly/sdk-test-harness/v2/framework/opt"
 	"github.com/launchdarkly/sdk-test-harness/v2/mockld"
 	"github.com/launchdarkly/sdk-test-harness/v2/servicedef"
+	"github.com/stretchr/testify/require"
 
 	"github.com/launchdarkly/go-sdk-common/v3/ldcontext"
+	"github.com/launchdarkly/go-sdk-common/v3/ldvalue"
 	m "github.com/launchdarkly/go-test-helpers/v2/matchers"
 )
 
@@ -29,6 +32,53 @@ func (c CommonPollingTests) RequestMethodAndHeaders(t *ldtest.T, credential stri
 				m.In(t).For("request method").Assert(request.Method, m.Equal(string(method)))
 				m.In(t).For("request headers").Assert(request.Headers, c.authorizationHeaderMatcher(credential))
 			})
+		}
+	})
+}
+
+func (c CommonPollingTests) LargePayloads(t *ldtest.T) {
+	flags := make([]ldmodel.FeatureFlag, 100)
+	for i := 0; i < 100; i++ {
+		flag := ldmodel.FeatureFlag{
+			Key:          fmt.Sprintf("flag-key-%d", i),
+			On:           i == 99,
+			Variations:   []ldvalue.Value{ldvalue.String("fallthrough"), ldvalue.String("off"), ldvalue.String("default")},
+			OffVariation: ldvalue.NewOptionalInt(1),
+			Fallthrough: ldmodel.VariationOrRollout{
+				Variation: ldvalue.NewOptionalInt(0),
+			},
+		}
+		flags = append(flags, flag)
+	}
+
+	sdkData := mockld.NewServerSDKDataBuilder().Flag(flags...).Build()
+	dataSource := NewSDKDataSource(t, sdkData, DataSourceOptionPolling())
+
+	t.Run("large payloads", func(t *ldtest.T) {
+		client := NewSDKClient(t, c.baseSDKConfigurationPlus(dataSource)...)
+
+		dataSource.Endpoint().RequireConnection(t, time.Second)
+
+		resp := client.EvaluateFlag(t, servicedef.EvaluateFlagParams{
+			FlagKey:      "flag-key-0",
+			ValueType:    servicedef.ValueTypeString,
+			Context:      o.Some(ldcontext.New("user-key")),
+			DefaultValue: ldvalue.String("default"),
+		})
+
+		if !m.In(t).Assert(ldvalue.String("off"), m.JSONEqual(resp.Value)) {
+			require.Fail(t, "evaluation unexpectedly returned wrong value")
+		}
+
+		resp = client.EvaluateFlag(t, servicedef.EvaluateFlagParams{
+			FlagKey:      "flag-key-99",
+			ValueType:    servicedef.ValueTypeString,
+			Context:      o.Some(ldcontext.New("user-key")),
+			DefaultValue: ldvalue.String("default"),
+		})
+
+		if !m.In(t).Assert(ldvalue.String("fallthrough"), m.JSONEqual(resp.Value)) {
+			require.Fail(t, "evaluation unexpectedly returned wrong value")
 		}
 	})
 }

--- a/sdktests/server_side_poll_all.go
+++ b/sdktests/server_side_poll_all.go
@@ -12,6 +12,7 @@ func doServerSidePollTests(t *ldtest.T) {
 	t.RequireCapability(servicedef.CapabilityServerSidePolling)
 
 	t.Run("requests", doServerSidePollRequestTests)
+	t.Run("payload", doServerSidePollPayloadTests)
 }
 
 func doServerSidePollRequestTests(t *ldtest.T) {
@@ -27,4 +28,15 @@ func doServerSidePollRequestTests(t *ldtest.T) {
 	pollTests.RequestURLPath(t, func(flagRequestMethod) m.Matcher {
 		return m.Equal(mockld.PollingPathServerSide)
 	})
+}
+
+func doServerSidePollPayloadTests(t *ldtest.T) {
+	sdkKey := "my-sdk-key"
+
+	pollTests := NewCommonPollingTests(t, "doServerSidePollPayloadTests",
+		WithConfig(servicedef.SDKConfigParams{
+			Credential: sdkKey,
+		}))
+
+	pollTests.LargePayloads(t)
 }


### PR DESCRIPTION
We recently discovered a bug where one of our SDKs wasn't processing the
full payload message. To help combat that, we are introducing a new test
which contains a large payload.
