### PR TITLE
fix: ensure '/' path is included in streaming service PUTs

### DIFF
--- a/mockld/streaming_service.go
+++ b/mockld/streaming_service.go
@@ -137,6 +137,7 @@ func (s *StreamingService) makePutEvent() eventsource.Event {
 	if s.sdkKind.IsServerSide() {
 		// the schema of this message is slightly different for server-side vs. client-side
 		eventData = map[string]interface{}{
+			"path": "/",
 			"data": eventData,
 		}
 	}


### PR DESCRIPTION
This PR doesn't necessary need to be merged; rather, we can use this to make a decision on clarifying our existing streaming spec.

While testing C++ server, I found that server-side PUTs might not include the `/` path in the Server-Sent-Event payload. 

The [spec](https://launchdarkly.atlassian.net/wiki/spaces/PD/pages/521668284/SDK+streaming+specification#Server-side-%E2%80%9Cput%E2%80%9D-message) has some relevant lines:
> ”path”: Currently this is always the string ”/”, representing the root level of the data model.

> If the data property does not contain parseable JSON ... or the **path has an unexpected value**, see Error Handling.
(emphasis mine)

-----------------

- Looking at the Rust server for inspiration of why other SDKs pass the test, it [checks](https://github.com/launchdarkly/rust-server-sdk-private/blob/main/launchdarkly-server-sdk/src/data_source.rs#L343) that the path is either `/` _or_ an empty string. 
    - If not, I believe it will report an error and cause initialization to fail. But I think if another valid PUT came through, it would then be able to store it properly and recover.

- In .NET, I see an [illuminating comment](https://github.com/launchdarkly/dotnet-server-sdk-private/blob/main/src/LaunchDarkly.ServerSdk/Internal/DataSources/StreamProcessorEvents.cs#L43) that "some versions of Relay don't send it [_the path_]".

- In Go, it is [totally ignored](https://github.com/launchdarkly/go-server-sdk-private/blob/v6/internal/datasource/streaming_data_source_events.go#L41).

- In Erlang, it is [also ignored](https://github.com/launchdarkly/erlang-server-sdk/blob/main/src/ldclient_update_stream_server.erl#L228).


Considering backwards compatibility, in an ideal world we'd want to allow the possibility of other paths being sent in the initial PUT, containing different data shapes. 

But because (some) SDKs ignore it, that would cause unexpected behavior - for instance if we sent an incompatible data model, those SDKs would fail to deserialize it. If those SDKs were written to ignore data sent with a non-`/` path, they'd instead be safe for future expansion of the protocol. 

So for this major version of the protocol, I'd recommend we state that the path must be omitted, an empty string, or `/`, and that no other value is allowed. 