### PR TITLE
feat: Add initial migration related tests

### DIFF
--- a/data/value_factory.go
+++ b/data/value_factory.go
@@ -87,3 +87,15 @@ func MakeStandardTestValues() []ldvalue.Value {
 		ldvalue.ObjectBuild().Set("a", ldvalue.Int(1)).Build(),
 	}
 }
+
+// MakeStandardMigrationStages returns a list of all valid migration stages in the order of progression.
+func MakeStandardMigrationStages() []ldvalue.Value {
+	return []ldvalue.Value{
+		ldvalue.String("off"),
+		ldvalue.String("dualwrite"),
+		ldvalue.String("shadow"),
+		ldvalue.String("live"),
+		ldvalue.String("rampdown"),
+		ldvalue.String("complete"),
+	}
+}

--- a/mockld/migration_callback_service.go
+++ b/mockld/migration_callback_service.go
@@ -1,0 +1,84 @@
+package mockld
+
+import (
+	"net/http"
+	"sync"
+
+	"github.com/launchdarkly/go-sdk-common/v3/ldmigration"
+	"github.com/launchdarkly/sdk-test-harness/v2/framework"
+	"github.com/launchdarkly/sdk-test-harness/v2/framework/harness"
+)
+
+type CallHistory struct {
+	callOrder int
+	origin    ldmigration.MigrationOrigin
+}
+
+func (c *CallHistory) GetOrigin() ldmigration.MigrationOrigin {
+	return c.origin
+}
+
+func (c *CallHistory) GetCallOrder() int {
+	return c.callOrder
+}
+
+type MigrationCallbackService struct {
+	lock        sync.Mutex
+	callHistory []CallHistory
+	callCount   int
+
+	oldEndpoint *harness.MockEndpoint
+	newEndpoint *harness.MockEndpoint
+}
+
+func NewMigrationCallbackService(
+	testHarness *harness.TestHarness,
+	logger framework.Logger,
+	oldHandler func(w http.ResponseWriter, req *http.Request),
+	newHandler func(w http.ResponseWriter, req *http.Request),
+) *MigrationCallbackService {
+	m := &MigrationCallbackService{
+		callHistory: make([]CallHistory, 0),
+		callCount:   0,
+	}
+
+	oldReadHandler := http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+		m.trackCallHistory(ldmigration.Old)
+		oldHandler(w, req)
+	})
+
+	newReadHandler := http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+		m.trackCallHistory(ldmigration.New)
+		newHandler(w, req)
+	})
+
+	m.oldEndpoint = testHarness.NewMockEndpoint(oldReadHandler, logger, harness.MockEndpointDescription("old endpoint"))
+	m.newEndpoint = testHarness.NewMockEndpoint(newReadHandler, logger, harness.MockEndpointDescription("new endpoint"))
+
+	return m
+}
+
+func (m *MigrationCallbackService) trackCallHistory(origin ldmigration.MigrationOrigin) {
+	m.lock.Lock()
+	defer m.lock.Unlock()
+
+	m.callCount += 1
+	m.callHistory = append(m.callHistory, CallHistory{callOrder: m.callCount, origin: origin})
+}
+
+func (m *MigrationCallbackService) Close() {
+	m.oldEndpoint.Close()
+	m.newEndpoint.Close()
+}
+
+func (m *MigrationCallbackService) GetCallHistory() []CallHistory {
+	return m.callHistory
+}
+
+func (m *MigrationCallbackService) OldEndpoint() *harness.MockEndpoint {
+	return m.oldEndpoint
+}
+
+func (m *MigrationCallbackService) NewEndpoint() *harness.MockEndpoint {
+	return m.newEndpoint
+}

--- a/mockld/migration_callback_service.go
+++ b/mockld/migration_callback_service.go
@@ -11,10 +11,10 @@ import (
 
 type CallHistory struct {
 	callOrder int
-	origin    ldmigration.MigrationOrigin
+	origin    ldmigration.Origin
 }
 
-func (c *CallHistory) GetOrigin() ldmigration.MigrationOrigin {
+func (c *CallHistory) GetOrigin() ldmigration.Origin {
 	return c.origin
 }
 
@@ -58,7 +58,7 @@ func NewMigrationCallbackService(
 	return m
 }
 
-func (m *MigrationCallbackService) trackCallHistory(origin ldmigration.MigrationOrigin) {
+func (m *MigrationCallbackService) trackCallHistory(origin ldmigration.Origin) {
 	m.lock.Lock()
 	defer m.lock.Unlock()
 

--- a/sdktests/custom_matchers_events.go
+++ b/sdktests/custom_matchers_events.go
@@ -58,12 +58,13 @@ func HasNoContextObject() m.Matcher {
 	return JSONPropertyNullOrAbsent("context")
 }
 
-func IsIndexEvent() m.Matcher    { return EventHasKind("index") }
-func IsIdentifyEvent() m.Matcher { return EventHasKind("identify") }
-func IsFeatureEvent() m.Matcher  { return EventHasKind("feature") }
-func IsDebugEvent() m.Matcher    { return EventHasKind("debug") }
-func IsCustomEvent() m.Matcher   { return EventHasKind("custom") }
-func IsSummaryEvent() m.Matcher  { return EventHasKind("summary") }
+func IsIndexEvent() m.Matcher       { return EventHasKind("index") }
+func IsIdentifyEvent() m.Matcher    { return EventHasKind("identify") }
+func IsFeatureEvent() m.Matcher     { return EventHasKind("feature") }
+func IsDebugEvent() m.Matcher       { return EventHasKind("debug") }
+func IsCustomEvent() m.Matcher      { return EventHasKind("custom") }
+func IsSummaryEvent() m.Matcher     { return EventHasKind("summary") }
+func IsMigrationOpEvent() m.Matcher { return EventHasKind("migration_op") }
 
 func IsIndexEventForContext(context ldcontext.Context) m.Matcher {
 	return m.AllOf(IsIndexEvent(), HasContextObjectWithMatchingKeys(context))
@@ -102,4 +103,18 @@ func IsValidSummaryEventWithFlags(keyValueMatchers ...m.KeyValueMatcher) m.Match
 		JSONPropertyKeysCanOnlyBe("kind", "startDate", "endDate", "features"),
 		m.JSONProperty("features").Should(m.MapOf(keyValueMatchers...)),
 	)
+}
+
+func IsValidMigrationOpEventWithConditions(context ldcontext.Context, matchers ...m.Matcher) m.Matcher {
+	propertyKeys := []string{"kind", "operation", "creationDate", "samplingRatio", "contextKeys", "evaluation", "measurements"}
+
+	return m.AllOf(
+		append(
+			[]m.Matcher{
+				IsMigrationOpEvent(),
+				HasAnyCreationDate(),
+				JSONPropertyKeysCanOnlyBe(propertyKeys...),
+				HasContextKeys(context),
+			},
+			matchers...)...)
 }

--- a/sdktests/server_side_migrations.go
+++ b/sdktests/server_side_migrations.go
@@ -50,7 +50,7 @@ func runMigrationVariationTests(t *ldtest.T) {
 			IsSummaryEvent(),
 		))
 
-		assert.Equal(t, string(stage), response.Result)
+		assert.EqualValues(t, stage, response.Result)
 	}
 }
 

--- a/sdktests/server_side_migrations.go
+++ b/sdktests/server_side_migrations.go
@@ -1,0 +1,370 @@
+package sdktests
+
+import (
+	"fmt"
+	"net/http"
+	"time"
+
+	"github.com/launchdarkly/go-sdk-common/v3/ldcontext"
+	"github.com/launchdarkly/go-sdk-common/v3/ldmigration"
+	"github.com/launchdarkly/go-server-sdk-evaluation/v2/ldbuilders"
+	m "github.com/launchdarkly/go-test-helpers/v2/matchers"
+	"github.com/launchdarkly/sdk-test-harness/v2/data"
+	"github.com/launchdarkly/sdk-test-harness/v2/framework/ldtest"
+	"github.com/launchdarkly/sdk-test-harness/v2/mockld"
+	"github.com/launchdarkly/sdk-test-harness/v2/servicedef"
+	"github.com/stretchr/testify/assert"
+	"golang.org/x/exp/slices"
+)
+
+func doServerSideMigrationTests(t *ldtest.T) {
+	t.RequireCapability(servicedef.CapabilityMigrations)
+
+	t.Run("migration variation", runMigrationVariationTests)
+	t.Run("use correct origins", runUseCorrectOriginsTests)
+	t.Run("track latency correctly", runTrackLatencyTests)
+	t.Run("track errors correctly", runTrackErrorsTests)
+}
+
+func runMigrationVariationTests(t *ldtest.T) {
+	stages := []ldmigration.MigrationStage{ldmigration.Off, ldmigration.DualWrite, ldmigration.Shadow, ldmigration.Live, ldmigration.RampDown, ldmigration.Complete}
+
+	for _, stage := range stages {
+		client, events := createClient(t, int(stage))
+		context := ldcontext.New("key")
+
+		params := servicedef.MigrationVariationParams{
+			Key:          "migration-key",
+			Context:      context,
+			DefaultStage: ldmigration.Off,
+		}
+		response := client.MigrationVariation(t, params)
+
+		client.FlushEvents(t)
+
+		payload := events.ExpectAnalyticsEvents(t, defaultEventTimeout)
+		m.In(t).Assert(payload, m.ItemsInAnyOrder(
+			IsIndexEventForContext(context),
+			IsSummaryEvent(),
+		))
+
+		assert.Equal(t, stage.String(), response.Result)
+	}
+}
+
+func runUseCorrectOriginsTests(t *ldtest.T) {
+	testParams := []struct {
+		Operation        ldmigration.MigrationOp
+		Stage            ldmigration.MigrationStage
+		ExpectedResult   string
+		ExpectedRequests []ldmigration.MigrationOrigin
+	}{
+		// Read operations
+		{Operation: ldmigration.Read, Stage: ldmigration.Off, ExpectedResult: "old read", ExpectedRequests: []ldmigration.MigrationOrigin{ldmigration.Old}},
+		{Operation: ldmigration.Read, Stage: ldmigration.DualWrite, ExpectedResult: "old read", ExpectedRequests: []ldmigration.MigrationOrigin{ldmigration.Old}},
+		{Operation: ldmigration.Read, Stage: ldmigration.Shadow, ExpectedResult: "old read", ExpectedRequests: []ldmigration.MigrationOrigin{ldmigration.Old, ldmigration.New}},
+		{Operation: ldmigration.Read, Stage: ldmigration.Live, ExpectedResult: "new read", ExpectedRequests: []ldmigration.MigrationOrigin{ldmigration.New, ldmigration.Old}},
+		{Operation: ldmigration.Read, Stage: ldmigration.RampDown, ExpectedResult: "new read", ExpectedRequests: []ldmigration.MigrationOrigin{ldmigration.New}},
+		{Operation: ldmigration.Read, Stage: ldmigration.Complete, ExpectedResult: "new read", ExpectedRequests: []ldmigration.MigrationOrigin{ldmigration.New}},
+
+		// Write operations
+		{Operation: ldmigration.Write, Stage: ldmigration.Off, ExpectedResult: "old read", ExpectedRequests: []ldmigration.MigrationOrigin{ldmigration.Old}},
+		{Operation: ldmigration.Write, Stage: ldmigration.DualWrite, ExpectedResult: "old read", ExpectedRequests: []ldmigration.MigrationOrigin{ldmigration.Old, ldmigration.New}},
+		{Operation: ldmigration.Write, Stage: ldmigration.Shadow, ExpectedResult: "old read", ExpectedRequests: []ldmigration.MigrationOrigin{ldmigration.Old, ldmigration.New}},
+		{Operation: ldmigration.Write, Stage: ldmigration.Live, ExpectedResult: "new read", ExpectedRequests: []ldmigration.MigrationOrigin{ldmigration.New, ldmigration.Old}},
+		{Operation: ldmigration.Write, Stage: ldmigration.RampDown, ExpectedResult: "new read", ExpectedRequests: []ldmigration.MigrationOrigin{ldmigration.New, ldmigration.Old}},
+		{Operation: ldmigration.Write, Stage: ldmigration.Complete, ExpectedResult: "new read", ExpectedRequests: []ldmigration.MigrationOrigin{ldmigration.New}},
+	}
+
+	for _, testParam := range testParams {
+		t.Run(fmt.Sprintf("%s %s", testParam.Operation, testParam.Stage), func(t *ldtest.T) {
+			client, _ := createClient(t, int(testParam.Stage))
+
+			service := mockld.NewMigrationCallbackService(
+				requireContext(t).harness,
+				t.DebugLogger(),
+				func(w http.ResponseWriter, req *http.Request) {
+					w.WriteHeader(http.StatusOK)
+					w.Write([]byte("old read"))
+				},
+				func(w http.ResponseWriter, req *http.Request) {
+					w.WriteHeader(http.StatusOK)
+					w.Write([]byte("new read"))
+				},
+			)
+			t.Defer(service.Close)
+
+			context := ldcontext.New("key")
+
+			params := servicedef.MigrationOperationParams{
+				Key:                "migration-key",
+				Context:            context,
+				DefaultStage:       ldmigration.Off,
+				ReadExecutionOrder: ldmigration.Serial, // NOTE: Execute this in serial so we can verify request order as well
+				Operation:          testParam.Operation,
+				OldEndpoint:        service.OldEndpoint().BaseURL(),
+				NewEndpoint:        service.NewEndpoint().BaseURL(),
+			}
+
+			response := client.MigrationOperation(t, params)
+
+			if slices.Contains(testParam.ExpectedRequests, ldmigration.Old) {
+				service.OldEndpoint().RequireConnection(t, 10*time.Millisecond)
+			} else {
+				service.OldEndpoint().RequireNoMoreConnections(t, 10*time.Millisecond)
+			}
+
+			if slices.Contains(testParam.ExpectedRequests, ldmigration.New) {
+				service.NewEndpoint().RequireConnection(t, 10*time.Millisecond)
+			} else {
+				service.NewEndpoint().RequireNoMoreConnections(t, 10*time.Millisecond)
+			}
+
+			for idx, callHistory := range service.GetCallHistory() {
+				assert.Equal(t, testParam.ExpectedRequests[idx], callHistory.GetOrigin())
+			}
+
+			assert.Equal(t, testParam.ExpectedResult, response.Result)
+		})
+	}
+}
+
+func runTrackLatencyTests(t *ldtest.T) {
+	onlyOld := []m.Matcher{m.JSONOptProperty("old").Should(m.Not(m.BeNil())), m.JSONOptProperty("new").Should(m.BeNil())}
+	both := []m.Matcher{m.JSONOptProperty("old").Should(m.Not(m.BeNil())), m.JSONOptProperty("new").Should(m.Not(m.BeNil()))}
+	onlyNew := []m.Matcher{m.JSONOptProperty("old").Should(m.BeNil()), m.JSONOptProperty("new").Should(m.Not(m.BeNil()))}
+
+	testParams := []struct {
+		Operation      ldmigration.MigrationOp
+		Stage          ldmigration.MigrationStage
+		ValuesMatchers []m.Matcher
+	}{
+		// Read operations
+		{Operation: ldmigration.Read, Stage: ldmigration.Off, ValuesMatchers: onlyOld},
+		{Operation: ldmigration.Read, Stage: ldmigration.DualWrite, ValuesMatchers: onlyOld},
+		{Operation: ldmigration.Read, Stage: ldmigration.Shadow, ValuesMatchers: both},
+		{Operation: ldmigration.Read, Stage: ldmigration.Live, ValuesMatchers: both},
+		{Operation: ldmigration.Read, Stage: ldmigration.RampDown, ValuesMatchers: onlyNew},
+		{Operation: ldmigration.Read, Stage: ldmigration.Complete, ValuesMatchers: onlyNew},
+
+		// Write operations
+		{Operation: ldmigration.Write, Stage: ldmigration.Off, ValuesMatchers: onlyOld},
+		{Operation: ldmigration.Write, Stage: ldmigration.DualWrite, ValuesMatchers: both},
+		{Operation: ldmigration.Write, Stage: ldmigration.Shadow, ValuesMatchers: both},
+		{Operation: ldmigration.Write, Stage: ldmigration.Live, ValuesMatchers: both},
+		{Operation: ldmigration.Write, Stage: ldmigration.RampDown, ValuesMatchers: both},
+		{Operation: ldmigration.Write, Stage: ldmigration.Complete, ValuesMatchers: onlyNew},
+	}
+
+	for _, testParam := range testParams {
+		t.Run(fmt.Sprintf("%s latency for %s", testParam.Operation, testParam.Stage), func(t *ldtest.T) {
+			client, events := createClient(t, int(testParam.Stage))
+
+			callback := func(w http.ResponseWriter, req *http.Request) {
+				time.Sleep(10 * time.Millisecond)
+				w.WriteHeader(http.StatusOK)
+				w.Write([]byte("result"))
+			}
+
+			service := mockld.NewMigrationCallbackService(requireContext(t).harness, t.DebugLogger(), callback, callback)
+			t.Defer(service.Close)
+
+			context := ldcontext.New("key")
+
+			params := servicedef.MigrationOperationParams{
+				Key:                "migration-key",
+				Context:            context,
+				DefaultStage:       ldmigration.DualWrite,
+				ReadExecutionOrder: ldmigration.Concurrently,
+				OldEndpoint:        service.OldEndpoint().BaseURL(),
+				NewEndpoint:        service.NewEndpoint().BaseURL(),
+				Operation:          testParam.Operation,
+				TrackLatency:       true,
+			}
+
+			_ = client.MigrationOperation(t, params)
+			client.FlushEvents(t)
+
+			opEventMatchers := []m.Matcher{
+				m.JSONOptProperty("samplingRatio").Should(m.BeNil()),
+				m.JSONProperty("operation").Should(m.Equal(testParam.Operation.String())),
+				m.JSONProperty("evaluation").Should(
+					m.AllOf(
+						m.JSONProperty("key").Should(m.Equal("migration-key")),
+						m.JSONProperty("default").Should(m.Equal("dualwrite")),
+						m.JSONProperty("value").Should(m.Equal(testParam.Stage.String())),
+						m.JSONProperty("variation").Should(m.Equal(int(testParam.Stage))),
+						m.JSONProperty("reason").Should(
+							m.JSONProperty("kind").Should(m.Equal("FALLTHROUGH")),
+						),
+					),
+				),
+				m.JSONProperty("measurements").Should(
+					m.ItemsInAnyOrder(
+						m.AllOf(
+							m.JSONProperty("key").Should(m.Equal("latency_ms")),
+							m.JSONProperty("values").Should(
+								m.AllOf(
+									testParam.ValuesMatchers...,
+								),
+							),
+						),
+					),
+				),
+			}
+
+			payload := events.ExpectAnalyticsEvents(t, defaultEventTimeout)
+			m.In(t).Assert(payload, m.ItemsInAnyOrder(
+				IsIndexEventForContext(context),
+				IsSummaryEvent(),
+				IsValidMigrationOpEventWithConditions(
+					context,
+					opEventMatchers...,
+				),
+			))
+		})
+	}
+}
+
+func runTrackErrorsTests(t *ldtest.T) {
+	hasError := func(label string) m.Matcher { return m.JSONOptProperty(label).Should(m.Equal(true)) }
+	noError := func(label string) m.Matcher { return m.JSONOptProperty(label).Should(m.Equal(false)) }
+	isMissing := func(label string) m.Matcher { return m.JSONOptProperty(label).Should(m.BeNil()) }
+
+	failureHandler := func(w http.ResponseWriter, req *http.Request) { w.WriteHeader(http.StatusConflict) }
+	successfulHandler := func(w http.ResponseWriter, req *http.Request) { w.WriteHeader(http.StatusOK) }
+
+	testParams := []struct {
+		Operation      ldmigration.MigrationOp
+		Stage          ldmigration.MigrationStage
+		ValuesMatchers []m.Matcher
+		OldHandler     http.HandlerFunc
+		NewHandler     http.HandlerFunc
+	}{
+		// Read operations
+		{Operation: ldmigration.Read, Stage: ldmigration.Off, OldHandler: successfulHandler, NewHandler: successfulHandler, ValuesMatchers: []m.Matcher{noError("old"), isMissing("new")}},
+		{Operation: ldmigration.Read, Stage: ldmigration.DualWrite, OldHandler: successfulHandler, NewHandler: successfulHandler, ValuesMatchers: []m.Matcher{noError("old"), isMissing("new")}},
+		{Operation: ldmigration.Read, Stage: ldmigration.Shadow, OldHandler: successfulHandler, NewHandler: successfulHandler, ValuesMatchers: []m.Matcher{noError("old"), noError("new")}},
+		{Operation: ldmigration.Read, Stage: ldmigration.Live, OldHandler: successfulHandler, NewHandler: successfulHandler, ValuesMatchers: []m.Matcher{noError("old"), noError("new")}},
+		{Operation: ldmigration.Read, Stage: ldmigration.RampDown, OldHandler: successfulHandler, NewHandler: successfulHandler, ValuesMatchers: []m.Matcher{isMissing("old"), noError("new")}},
+		{Operation: ldmigration.Read, Stage: ldmigration.Complete, OldHandler: successfulHandler, NewHandler: successfulHandler, ValuesMatchers: []m.Matcher{isMissing("old"), noError("new")}},
+
+		// Write operations
+		{Operation: ldmigration.Write, Stage: ldmigration.Off, OldHandler: successfulHandler, NewHandler: successfulHandler, ValuesMatchers: []m.Matcher{noError("old"), isMissing("new")}},
+		{Operation: ldmigration.Write, Stage: ldmigration.DualWrite, OldHandler: successfulHandler, NewHandler: successfulHandler, ValuesMatchers: []m.Matcher{noError("old"), noError("new")}},
+		{Operation: ldmigration.Write, Stage: ldmigration.Shadow, OldHandler: successfulHandler, NewHandler: successfulHandler, ValuesMatchers: []m.Matcher{noError("old"), noError("new")}},
+		{Operation: ldmigration.Write, Stage: ldmigration.Live, OldHandler: successfulHandler, NewHandler: successfulHandler, ValuesMatchers: []m.Matcher{noError("old"), noError("new")}},
+		{Operation: ldmigration.Write, Stage: ldmigration.RampDown, OldHandler: successfulHandler, NewHandler: successfulHandler, ValuesMatchers: []m.Matcher{noError("old"), noError("new")}},
+		{Operation: ldmigration.Write, Stage: ldmigration.Complete, OldHandler: successfulHandler, NewHandler: successfulHandler, ValuesMatchers: []m.Matcher{isMissing("old"), noError("new")}},
+
+		// Write operations with authoritative failure
+		{Operation: ldmigration.Write, Stage: ldmigration.Off, OldHandler: failureHandler, NewHandler: successfulHandler, ValuesMatchers: []m.Matcher{hasError("old"), isMissing("new")}},
+		{Operation: ldmigration.Write, Stage: ldmigration.DualWrite, OldHandler: failureHandler, NewHandler: successfulHandler, ValuesMatchers: []m.Matcher{hasError("old"), isMissing("new")}},
+		{Operation: ldmigration.Write, Stage: ldmigration.Shadow, OldHandler: failureHandler, NewHandler: successfulHandler, ValuesMatchers: []m.Matcher{hasError("old"), isMissing("new")}},
+		{Operation: ldmigration.Write, Stage: ldmigration.Live, OldHandler: successfulHandler, NewHandler: failureHandler, ValuesMatchers: []m.Matcher{isMissing("old"), hasError("new")}},
+		{Operation: ldmigration.Write, Stage: ldmigration.RampDown, OldHandler: successfulHandler, NewHandler: failureHandler, ValuesMatchers: []m.Matcher{isMissing("old"), hasError("new")}},
+		{Operation: ldmigration.Write, Stage: ldmigration.Complete, OldHandler: successfulHandler, NewHandler: failureHandler, ValuesMatchers: []m.Matcher{isMissing("old"), hasError("new")}},
+
+		// Write operations with non-authoritative failure
+		{Operation: ldmigration.Write, Stage: ldmigration.Off, OldHandler: successfulHandler, NewHandler: failureHandler, ValuesMatchers: []m.Matcher{noError("old"), isMissing("new")}},
+		{Operation: ldmigration.Write, Stage: ldmigration.DualWrite, OldHandler: successfulHandler, NewHandler: failureHandler, ValuesMatchers: []m.Matcher{noError("old"), hasError("new")}},
+		{Operation: ldmigration.Write, Stage: ldmigration.Shadow, OldHandler: successfulHandler, NewHandler: failureHandler, ValuesMatchers: []m.Matcher{noError("old"), hasError("new")}},
+		{Operation: ldmigration.Write, Stage: ldmigration.Live, OldHandler: failureHandler, NewHandler: successfulHandler, ValuesMatchers: []m.Matcher{hasError("old"), noError("new")}},
+		{Operation: ldmigration.Write, Stage: ldmigration.RampDown, OldHandler: failureHandler, NewHandler: successfulHandler, ValuesMatchers: []m.Matcher{hasError("old"), noError("new")}},
+		{Operation: ldmigration.Write, Stage: ldmigration.Complete, OldHandler: failureHandler, NewHandler: successfulHandler, ValuesMatchers: []m.Matcher{isMissing("old"), noError("new")}},
+	}
+
+	for _, testParam := range testParams {
+		t.Run(fmt.Sprintf("%s errors for %s", testParam.Operation, testParam.Stage), func(t *ldtest.T) {
+			client, events := createClient(t, int(testParam.Stage))
+
+			service := mockld.NewMigrationCallbackService(requireContext(t).harness, t.DebugLogger(), testParam.OldHandler, testParam.NewHandler)
+			t.Defer(service.Close)
+
+			context := ldcontext.New("key")
+
+			params := servicedef.MigrationOperationParams{
+				Key:                "migration-key",
+				Context:            context,
+				DefaultStage:       ldmigration.DualWrite,
+				ReadExecutionOrder: ldmigration.Concurrently,
+				OldEndpoint:        service.OldEndpoint().BaseURL(),
+				NewEndpoint:        service.NewEndpoint().BaseURL(),
+				Operation:          testParam.Operation,
+				TrackErrors:        true,
+			}
+
+			_ = client.MigrationOperation(t, params)
+			client.FlushEvents(t)
+
+			opEventMatchers := []m.Matcher{
+				m.JSONOptProperty("samplingRatio").Should(m.BeNil()),
+				m.JSONProperty("operation").Should(m.Equal(testParam.Operation.String())),
+				m.JSONProperty("evaluation").Should(
+					m.AllOf(
+						m.JSONProperty("key").Should(m.Equal("migration-key")),
+						m.JSONProperty("default").Should(m.Equal("dualwrite")),
+						m.JSONProperty("value").Should(m.Equal(testParam.Stage.String())),
+						m.JSONProperty("variation").Should(m.Equal(int(testParam.Stage))),
+						m.JSONProperty("reason").Should(
+							m.JSONProperty("kind").Should(m.Equal("FALLTHROUGH")),
+						),
+					),
+				),
+				m.JSONProperty("measurements").Should(
+					m.ItemsInAnyOrder(
+						m.AllOf(
+							m.JSONProperty("key").Should(m.Equal("errors")),
+							m.JSONProperty("values").Should(
+								m.AllOf(
+									testParam.ValuesMatchers...,
+								),
+							),
+						),
+					),
+				),
+			}
+
+			payload := events.ExpectAnalyticsEvents(t, defaultEventTimeout)
+			m.In(t).Assert(payload, m.ItemsInAnyOrder(
+				IsIndexEventForContext(context),
+				IsSummaryEvent(),
+				IsValidMigrationOpEventWithConditions(
+					context,
+					opEventMatchers...,
+				),
+			))
+		})
+	}
+}
+
+func createClient(t *ldtest.T, variationIndex int) (*SDKClient, *SDKEventSink) {
+	migrationFlag := ldbuilders.NewFlagBuilder("migration-key").On(true).Variations(data.MakeStandardMigrationStages()...).FallthroughVariation(variationIndex).Build()
+	dataBuilder := mockld.NewServerSDKDataBuilder()
+	dataBuilder.Flag(migrationFlag)
+
+	dataSource := NewSDKDataSource(t, dataBuilder.Build())
+	events := NewSDKEventSink(t)
+	client := NewSDKClient(t, dataSource, events)
+
+	return client, events
+}
+
+func stageToVariationIndex(stage ldmigration.MigrationStage) int {
+	switch stage {
+	case ldmigration.Off:
+		return 0
+	case ldmigration.DualWrite:
+		return 1
+	case ldmigration.Shadow:
+		return 2
+	case ldmigration.Live:
+		return 3
+	case ldmigration.RampDown:
+		return 4
+	case ldmigration.Complete:
+		return 5
+	default:
+		return 0
+	}
+}

--- a/sdktests/server_side_migrations.go
+++ b/sdktests/server_side_migrations.go
@@ -316,7 +316,7 @@ func runTrackErrorsTests(t *ldtest.T) {
 				m.JSONProperty("measurements").Should(
 					m.ItemsInAnyOrder(
 						m.AllOf(
-							m.JSONProperty("key").Should(m.Equal("errors")),
+							m.JSONProperty("key").Should(m.Equal("error")),
 							m.JSONProperty("values").Should(
 								m.AllOf(
 									testParam.ValuesMatchers...,

--- a/sdktests/server_side_migrations.go
+++ b/sdktests/server_side_migrations.go
@@ -194,7 +194,7 @@ func runTrackLatencyTests(t *ldtest.T) {
 					m.AllOf(
 						m.JSONProperty("key").Should(m.Equal("migration-key")),
 						m.JSONProperty("default").Should(m.Equal("dualwrite")),
-						m.JSONProperty("value").Should(m.Equal(testParam.Stage)),
+						m.JSONProperty("value").Should(m.Equal(string(testParam.Stage))),
 						m.JSONProperty("variation").Should(m.Equal(stageToVariationIndex(testParam.Stage))),
 						m.JSONProperty("reason").Should(
 							m.JSONProperty("kind").Should(m.Equal("FALLTHROUGH")),
@@ -423,7 +423,7 @@ func runTrackConsistencyTests(t *ldtest.T) {
 					m.AllOf(
 						m.JSONProperty("key").Should(m.Equal("migration-key")),
 						m.JSONProperty("default").Should(m.Equal("dualwrite")),
-						m.JSONProperty("value").Should(m.Equal(testParam.Stage)),
+						m.JSONProperty("value").Should(m.Equal(string(testParam.Stage))),
 						m.JSONProperty("variation").Should(m.Equal(stageToVariationIndex(testParam.Stage))),
 						m.JSONProperty("reason").Should(
 							m.JSONProperty("kind").Should(m.Equal("FALLTHROUGH")),

--- a/sdktests/server_side_migrations.go
+++ b/sdktests/server_side_migrations.go
@@ -189,7 +189,7 @@ func runTrackLatencyTests(t *ldtest.T) {
 
 			opEventMatchers := []m.Matcher{
 				m.JSONOptProperty("samplingRatio").Should(m.BeNil()),
-				m.JSONProperty("operation").Should(m.Equal(testParam.Operation.String())),
+				m.JSONProperty("operation").Should(m.Equal(testParam.Operation)),
 				m.JSONProperty("evaluation").Should(
 					m.AllOf(
 						m.JSONProperty("key").Should(m.Equal("migration-key")),
@@ -301,7 +301,7 @@ func runTrackErrorsTests(t *ldtest.T) {
 
 			opEventMatchers := []m.Matcher{
 				m.JSONOptProperty("samplingRatio").Should(m.BeNil()),
-				m.JSONProperty("operation").Should(m.Equal(testParam.Operation.String())),
+				m.JSONProperty("operation").Should(m.Equal(testParam.Operation)),
 				m.JSONProperty("evaluation").Should(
 					m.AllOf(
 						m.JSONProperty("key").Should(m.Equal("migration-key")),
@@ -418,7 +418,7 @@ func runTrackConsistencyTests(t *ldtest.T) {
 
 			opEventMatchers := []m.Matcher{
 				m.JSONOptProperty("samplingRatio").Should(m.BeNil()),
-				m.JSONProperty("operation").Should(m.Equal(testParam.Operation.String())),
+				m.JSONProperty("operation").Should(m.Equal(testParam.Operation)),
 				m.JSONProperty("evaluation").Should(
 					m.AllOf(
 						m.JSONProperty("key").Should(m.Equal("migration-key")),

--- a/sdktests/server_side_migrations.go
+++ b/sdktests/server_side_migrations.go
@@ -50,7 +50,7 @@ func runMigrationVariationTests(t *ldtest.T) {
 			IsSummaryEvent(),
 		))
 
-		assert.Equal(t, stage, response.Result)
+		assert.Equal(t, string(stage), response.Result)
 	}
 }
 

--- a/sdktests/server_side_migrations.go
+++ b/sdktests/server_side_migrations.go
@@ -32,7 +32,7 @@ func runMigrationVariationTests(t *ldtest.T) {
 	stages := []ldmigration.Stage{ldmigration.Off, ldmigration.DualWrite, ldmigration.Shadow, ldmigration.Live, ldmigration.RampDown, ldmigration.Complete}
 
 	for _, stage := range stages {
-		client, events := createClient(t, int(stage))
+		client, events := createClient(t, stageToVariationIndex(stage))
 		context := ldcontext.New("key")
 
 		params := servicedef.MigrationVariationParams{
@@ -50,7 +50,7 @@ func runMigrationVariationTests(t *ldtest.T) {
 			IsSummaryEvent(),
 		))
 
-		assert.Equal(t, stage.String(), response.Result)
+		assert.Equal(t, stage, response.Result)
 	}
 }
 
@@ -80,7 +80,7 @@ func runUseCorrectOriginsTests(t *ldtest.T) {
 
 	for _, testParam := range testParams {
 		t.Run(fmt.Sprintf("%s %s", testParam.Operation, testParam.Stage), func(t *ldtest.T) {
-			client, _ := createClient(t, int(testParam.Stage))
+			client, _ := createClient(t, stageToVariationIndex(testParam.Stage))
 
 			service := mockld.NewMigrationCallbackService(
 				requireContext(t).harness,
@@ -160,7 +160,7 @@ func runTrackLatencyTests(t *ldtest.T) {
 
 	for _, testParam := range testParams {
 		t.Run(fmt.Sprintf("%s latency for %s", testParam.Operation, testParam.Stage), func(t *ldtest.T) {
-			client, events := createClient(t, int(testParam.Stage))
+			client, events := createClient(t, stageToVariationIndex(testParam.Stage))
 
 			callback := func(w http.ResponseWriter, req *http.Request) {
 				time.Sleep(10 * time.Millisecond)
@@ -194,8 +194,8 @@ func runTrackLatencyTests(t *ldtest.T) {
 					m.AllOf(
 						m.JSONProperty("key").Should(m.Equal("migration-key")),
 						m.JSONProperty("default").Should(m.Equal("dualwrite")),
-						m.JSONProperty("value").Should(m.Equal(testParam.Stage.String())),
-						m.JSONProperty("variation").Should(m.Equal(int(testParam.Stage))),
+						m.JSONProperty("value").Should(m.Equal(testParam.Stage)),
+						m.JSONProperty("variation").Should(m.Equal(stageToVariationIndex(testParam.Stage))),
 						m.JSONProperty("reason").Should(
 							m.JSONProperty("kind").Should(m.Equal("FALLTHROUGH")),
 						),
@@ -278,7 +278,7 @@ func runTrackErrorsTests(t *ldtest.T) {
 
 	for _, testParam := range testParams {
 		t.Run(fmt.Sprintf("%s errors for %s", testParam.Operation, testParam.Stage), func(t *ldtest.T) {
-			client, events := createClient(t, int(testParam.Stage))
+			client, events := createClient(t, stageToVariationIndex(testParam.Stage))
 
 			service := mockld.NewMigrationCallbackService(requireContext(t).harness, t.DebugLogger(), testParam.OldHandler, testParam.NewHandler)
 			t.Defer(service.Close)
@@ -306,8 +306,8 @@ func runTrackErrorsTests(t *ldtest.T) {
 					m.AllOf(
 						m.JSONProperty("key").Should(m.Equal("migration-key")),
 						m.JSONProperty("default").Should(m.Equal("dualwrite")),
-						m.JSONProperty("value").Should(m.Equal(testParam.Stage.String())),
-						m.JSONProperty("variation").Should(m.Equal(int(testParam.Stage))),
+						m.JSONProperty("value").Should(m.Equal(testParam.Stage)),
+						m.JSONProperty("variation").Should(m.Equal(stageToVariationIndex(testParam.Stage))),
 						m.JSONProperty("reason").Should(
 							m.JSONProperty("kind").Should(m.Equal("FALLTHROUGH")),
 						),
@@ -381,7 +381,7 @@ func runTrackConsistencyTests(t *ldtest.T) {
 
 	for _, testParam := range testParams {
 		t.Run(fmt.Sprintf("%s errors for %s", testParam.Operation, testParam.Stage), func(t *ldtest.T) {
-			client, events := createClient(t, int(testParam.Stage))
+			client, events := createClient(t, stageToVariationIndex(testParam.Stage))
 
 			service := mockld.NewMigrationCallbackService(requireContext(t).harness, t.DebugLogger(), testParam.OldHandler, testParam.NewHandler)
 			t.Defer(service.Close)
@@ -423,8 +423,8 @@ func runTrackConsistencyTests(t *ldtest.T) {
 					m.AllOf(
 						m.JSONProperty("key").Should(m.Equal("migration-key")),
 						m.JSONProperty("default").Should(m.Equal("dualwrite")),
-						m.JSONProperty("value").Should(m.Equal(testParam.Stage.String())),
-						m.JSONProperty("variation").Should(m.Equal(int(testParam.Stage))),
+						m.JSONProperty("value").Should(m.Equal(testParam.Stage)),
+						m.JSONProperty("variation").Should(m.Equal(stageToVariationIndex(testParam.Stage))),
 						m.JSONProperty("reason").Should(
 							m.JSONProperty("kind").Should(m.Equal("FALLTHROUGH")),
 						),

--- a/sdktests/testapi_sdk_client.go
+++ b/sdktests/testapi_sdk_client.go
@@ -253,6 +253,40 @@ func (c *SDKClient) EvaluateAllFlags(
 	return resp
 }
 
+// MigrationVariation tells the SDK client to evaluate a feature flag representing a migration. This corresponds to calling the SDK's
+// MigrationVariation method.
+//
+// Any error from the test service causes the test to terminate immediately.
+func (c *SDKClient) MigrationVariation(t *ldtest.T, params servicedef.MigrationVariationParams) servicedef.MigrationVariationResponse {
+	var resp servicedef.MigrationVariationResponse
+	require.NoError(t, c.sdkClientEntity.SendCommandWithParams(
+		servicedef.CommandParams{
+			Command:            servicedef.CommandMigrationVariation,
+			MigrationVariation: o.Some(params),
+		},
+		t.DebugLogger(),
+		&resp,
+	))
+	return resp
+}
+
+// MigrationOperation tells the SDK client to evaluate a feature flag representing a migration. This corresponds to calling the SDK's
+// MigrationOperation method.
+//
+// Any error from the test service causes the test to terminate immediately.
+func (c *SDKClient) MigrationOperation(t *ldtest.T, params servicedef.MigrationOperationParams) servicedef.MigrationOperationResponse {
+	var resp servicedef.MigrationOperationResponse
+	require.NoError(t, c.sdkClientEntity.SendCommandWithParams(
+		servicedef.CommandParams{
+			Command:            servicedef.CommandMigrationOperation,
+			MigrationOperation: o.Some(params),
+		},
+		t.DebugLogger(),
+		&resp,
+	))
+	return resp
+}
+
 // SendIdentifyEvent tells the SDK client to send an identify event.
 //
 // Any error from the test service causes the test to terminate immediately.

--- a/sdktests/testsuite_entry_point.go
+++ b/sdktests/testsuite_entry_point.go
@@ -89,6 +89,7 @@ func doAllServerSideTests(t *ldtest.T) {
 	t.Run("tags", doServerSideTagsTests)
 	t.Run("secure mode hash", doServerSideSecureModeHashTests)
 	t.Run("context type", doSDKContextTypeTests)
+	t.Run("migrations", doServerSideMigrationTests)
 }
 
 func doAllClientSideTests(t *ldtest.T) {

--- a/servicedef/command_params.go
+++ b/servicedef/command_params.go
@@ -128,8 +128,8 @@ type SecureModeHashResponse struct {
 }
 
 type MigrationVariationParams struct {
-	Key          string
-	Context      ldcontext.Context
+	Key          string `json:"key"`
+	Context      ldcontext.Context `json:"context"`
 	DefaultStage ldmigration.Stage `json:"defaultStage"`
 }
 

--- a/servicedef/command_params.go
+++ b/servicedef/command_params.go
@@ -128,9 +128,9 @@ type SecureModeHashResponse struct {
 }
 
 type MigrationVariationParams struct {
-	Key          string                     `json:"key"`
-	Context      ldcontext.Context          `json:"context"`
-	DefaultStage ldmigration.MigrationStage `json:"defaultStage"`
+	Key          string
+	Context      ldcontext.Context
+	DefaultStage ldmigration.Stage `json:"defaultStage"`
 }
 
 type MigrationVariationResponse struct {
@@ -140,9 +140,9 @@ type MigrationVariationResponse struct {
 type MigrationOperationParams struct {
 	Key                string                     `json:"key"`
 	Context            ldcontext.Context          `json:"context"`
-	DefaultStage       ldmigration.MigrationStage `json:"defaultStage"`
+	DefaultStage       ldmigration.Stage          `json:"defaultStage"`
 	ReadExecutionOrder ldmigration.ExecutionOrder `json:"readExecutionOrder"`
-	Operation          ldmigration.MigrationOp    `json:"operation"`
+	Operation          ldmigration.Operation      `json:"operation"`
 	OldEndpoint        string                     `json:"oldEndpoint"`
 	NewEndpoint        string                     `json:"newEndpoint"`
 	TrackLatency       bool                       `json:"trackLatency"`

--- a/servicedef/command_params.go
+++ b/servicedef/command_params.go
@@ -128,7 +128,7 @@ type SecureModeHashResponse struct {
 }
 
 type MigrationVariationParams struct {
-	Key          string `json:"key"`
+	Key          string            `json:"key"`
 	Context      ldcontext.Context `json:"context"`
 	DefaultStage ldmigration.Stage `json:"defaultStage"`
 }

--- a/servicedef/command_params.go
+++ b/servicedef/command_params.go
@@ -6,6 +6,7 @@ import (
 	o "github.com/launchdarkly/sdk-test-harness/v2/framework/opt"
 
 	"github.com/launchdarkly/go-sdk-common/v3/ldcontext"
+	"github.com/launchdarkly/go-sdk-common/v3/ldmigration"
 	"github.com/launchdarkly/go-sdk-common/v3/ldreason"
 	"github.com/launchdarkly/go-sdk-common/v3/ldvalue"
 )
@@ -21,6 +22,8 @@ const (
 	CommandContextBuild             = "contextBuild"
 	CommandContextConvert           = "contextConvert"
 	CommandSecureModeHash           = "secureModeHash"
+	CommandMigrationVariation       = "migrationVariation"
+	CommandMigrationOperation       = "migrationOperation"
 )
 
 type ValueType string
@@ -34,14 +37,16 @@ const (
 )
 
 type CommandParams struct {
-	Command        string                          `json:"command"`
-	Evaluate       o.Maybe[EvaluateFlagParams]     `json:"evaluate,omitempty"`
-	EvaluateAll    o.Maybe[EvaluateAllFlagsParams] `json:"evaluateAll,omitempty"`
-	CustomEvent    o.Maybe[CustomEventParams]      `json:"customEvent,omitempty"`
-	IdentifyEvent  o.Maybe[IdentifyEventParams]    `json:"identifyEvent,omitempty"`
-	ContextBuild   o.Maybe[ContextBuildParams]     `json:"contextBuild,omitempty"`
-	ContextConvert o.Maybe[ContextConvertParams]   `json:"contextConvert,omitempty"`
-	SecureModeHash o.Maybe[SecureModeHashParams]   `json:"secureModeHash,omitempty"`
+	Command            string                            `json:"command"`
+	Evaluate           o.Maybe[EvaluateFlagParams]       `json:"evaluate,omitempty"`
+	EvaluateAll        o.Maybe[EvaluateAllFlagsParams]   `json:"evaluateAll,omitempty"`
+	CustomEvent        o.Maybe[CustomEventParams]        `json:"customEvent,omitempty"`
+	IdentifyEvent      o.Maybe[IdentifyEventParams]      `json:"identifyEvent,omitempty"`
+	ContextBuild       o.Maybe[ContextBuildParams]       `json:"contextBuild,omitempty"`
+	ContextConvert     o.Maybe[ContextConvertParams]     `json:"contextConvert,omitempty"`
+	SecureModeHash     o.Maybe[SecureModeHashParams]     `json:"secureModeHash,omitempty"`
+	MigrationVariation o.Maybe[MigrationVariationParams] `json:"migrationVariation,omitempty"`
+	MigrationOperation o.Maybe[MigrationOperationParams] `json:"migrationOperation,omitempty"`
 }
 
 type EvaluateFlagParams struct {
@@ -119,5 +124,32 @@ type SecureModeHashParams struct {
 }
 
 type SecureModeHashResponse struct {
+	Result string `json:"result"`
+}
+
+type MigrationVariationParams struct {
+	Key          string                     `json:"key"`
+	Context      ldcontext.Context          `json:"context"`
+	DefaultStage ldmigration.MigrationStage `json:"defaultStage"`
+}
+
+type MigrationVariationResponse struct {
+	Result string `json:"result"`
+}
+
+type MigrationOperationParams struct {
+	Key                string                     `json:"key"`
+	Context            ldcontext.Context          `json:"context"`
+	DefaultStage       ldmigration.MigrationStage `json:"defaultStage"`
+	ReadExecutionOrder ldmigration.ExecutionOrder `json:"readExecutionOrder"`
+	Operation          ldmigration.MigrationOp    `json:"operation"`
+	OldEndpoint        string                     `json:"oldEndpoint"`
+	NewEndpoint        string                     `json:"newEndpoint"`
+	TrackLatency       bool                       `json:"trackLatency"`
+	TrackErrors        bool                       `json:"trackErrors"`
+	TrackConsistency   bool                       `json:"trackConsistency"`
+}
+
+type MigrationOperationResponse struct {
 	Result string `json:"result"`
 }

--- a/servicedef/service_params.go
+++ b/servicedef/service_params.go
@@ -24,6 +24,7 @@ const (
 	CapabilityUserType          = "user-type"
 	CapabilityFiltering         = "filtering"
 	CapabilityAutoEnvAttributes = "auto-env-attributes"
+	CapabilityMigrations        = "migrations"
 )
 
 type StatusRep struct {


### PR DESCRIPTION
These initial tests cover the following areas:

1. Ensure migration variation method returns the correct stage.
2. Ensure migrations execute calls from old and new origins for the appropriate stage.
3. Ensure latency and error metrics are present when enabled.