### PR TITLE
fix: relaxing context type test, now contains application/json

### DIFF
--- a/sdktests/client_side_events_all.go
+++ b/sdktests/client_side_events_all.go
@@ -31,7 +31,7 @@ func doClientSideEventRequestTests(t *ldtest.T) {
 	eventTests.RequestMethodAndHeaders(t, envIDOrMobileKey, m.AllOf(
 		Header("X-LaunchDarkly-Event-Schema").Should(m.Equal(currentEventSchema)),
 		Header("X-LaunchDarkly-Payload-Id").Should(m.Not(m.Equal(""))),
-		Header("Content-Type").Should(m.Equal("application/json")),
+		Header("Content-Type").Should(m.StringContains("application/json")),
 	))
 
 	requestPathMatcher := h.IfElse(


### PR DESCRIPTION
Java SDK was failing on this test, just relaxing the test a smidge.