### PR TITLE
fix: Add sampling capabality requirement for event disablement.

### DIFF
--- a/sdktests/common_tests_events_custom.go
+++ b/sdktests/common_tests_events_custom.go
@@ -76,6 +76,7 @@ func (c CommonEventTests) CustomEvents(t *ldtest.T) {
 
 	t.Run("custom events can be disabled through metric values", func(t *ldtest.T) {
 		t.RequireCapability(servicedef.CapabilityAllFlagsWithReasons)
+		t.RequireCapability(servicedef.CapabilityEventSampling)
 
 		context := ldcontext.New("example")
 

--- a/sdktests/server_side_events_index.go
+++ b/sdktests/server_side_events_index.go
@@ -54,6 +54,7 @@ func doServerSideIndexEventTests(t *ldtest.T) {
 	})
 
 	t.Run("can disable", func(t *ldtest.T) {
+		t.RequireCapability(servicedef.CapabilityEventSampling)
 		t.Run("from feature event", func(t *ldtest.T) {
 			dataBuilder := mockld.NewServerSDKDataBuilder()
 			dataBuilder.RawFlag("flag1", json.RawMessage(`{"key": "flag1"}`))

--- a/sdktests/server_side_migrations.go
+++ b/sdktests/server_side_migrations.go
@@ -729,7 +729,10 @@ func tracksConsistencyCorrectlyBasedOnStage(t *ldtest.T) {
 					m.AllOf(
 						m.JSONProperty("key").Should(m.Equal("consistent")),
 						m.JSONProperty("value").Should(m.Equal(consistent)),
-						m.JSONProperty("samplingRatio").Should(m.Equal(1)),
+						m.AnyOf(
+							m.JSONProperty("samplingRatio").Should(m.Equal(1)),
+							m.JSONOptProperty("samplingRatio").Should(m.BeNil()),
+						),
 					),
 				)
 			} else {


### PR DESCRIPTION
Some event disablement tests were running without the sampling capability.

Not sure if this will stay this way, because we likely will split the categories a bit different.
