### PR TITLE
feat: refactor auto env attribute tests to be more robust

### DIFF
--- a/sdktests/client_side_auto_env_attributes.go
+++ b/sdktests/client_side_auto_env_attributes.go
@@ -151,7 +151,8 @@ func doClientSideAutoEnvAttributesEventsCollisionsTests(t *ldtest.T) {
 				// with one that contains application info. That's not correct, since auto env contexts should
 				// NOT overwrite user-provided contexts.
 
-				contextWithAutoEnvAndSuffix := contextWithTransformedKeys(contextWithAutoEnv1, func(key string) string { return key + "-no-overwrite" })
+				contextWithAutoEnvAndSuffix := contextWithTransformedKeys(contextWithAutoEnv1,
+					func(key string) string { return key + "-no-overwrite" })
 				client.SendIdentifyEvent(t, contextWithAutoEnvAndSuffix)
 				client.FlushEvents(t)
 

--- a/sdktests/client_side_auto_env_attributes.go
+++ b/sdktests/client_side_auto_env_attributes.go
@@ -139,7 +139,7 @@ func doClientSideAutoEnvAttributesEventsCollisionsTests(t *ldtest.T) {
 				contextWithAutoEnv1 := ldcontext.Context{}
 				err := json.Unmarshal([]byte(jsonWithAutoEnv1), &contextWithAutoEnv1)
 				if err != nil {
-					t.Errorf("Expected to unmarshal context.", err)
+					t.Errorf("Expected to unmarshal context. %v", err)
 				}
 
 				// Now we potentially have a multi-kind context that consists of the original 'user', plus whatever
@@ -163,7 +163,7 @@ func doClientSideAutoEnvAttributesEventsCollisionsTests(t *ldtest.T) {
 				contextWithAutoEnv2 := ldcontext.Context{}
 				err = json.Unmarshal([]byte(jsonWithAutoEnv2), &contextWithAutoEnv2)
 				if err != nil {
-					t.Errorf("Expected to unmarshal context.", err)
+					t.Errorf("Expected to unmarshal context. %v", err)
 				}
 
 				m.In(t).Assert(contextWithAutoEnvAndSuffix, m.Equal(contextWithAutoEnv2))


### PR DESCRIPTION
**Requirements**

- [x] I have added test coverage for new or changed functionality
- [x] I have followed the repository's [pull request submission guidelines](../blob/master/CONTRIBUTING.md#submitting-pull-requests)
- [x] I have validated my changes against all supported platform versions

**Describe the solution you've provided**

Loosening auto env attributes tests to not require ld_device.  No specific set of context kinds is required by the auto env attributes feature, and ld_device is not supported on all Dotnet SDK platforms.

Also made `doClientSideAutoEnvAttributesEventsCollisionsTests` smarter to still test collision handling without strictly checking for ld_application or ld_device.  This was done to ensure we continue getting testing coverage of collision handling.
