### PR TITLE
feat: Update to v5 event schema

### DIFF
--- a/sdktests/common_tests_events_request.go
+++ b/sdktests/common_tests_events_request.go
@@ -12,7 +12,7 @@ import (
 	m "github.com/launchdarkly/go-test-helpers/v2/matchers"
 )
 
-const currentEventSchema = "4"
+const currentEventSchema = "5"
 const phpEventSchema = "2"
 
 func (c CommonEventTests) RequestMethodAndHeaders(t *ldtest.T, credential string, headersMatcher m.Matcher) {

--- a/sdktests/custom_matchers_events.go
+++ b/sdktests/custom_matchers_events.go
@@ -3,7 +3,6 @@ package sdktests
 import (
 	"github.com/launchdarkly/go-sdk-common/v3/ldcontext"
 	m "github.com/launchdarkly/go-test-helpers/v2/matchers"
-	h "github.com/launchdarkly/sdk-test-harness/v3/framework/helpers"
 )
 
 // These are used with the matchers API to make assertions about JSON event data. The value
@@ -84,7 +83,7 @@ func IsValidFeatureEventWithConditions(isPHP bool, context ldcontext.Context, ma
 	if isPHP {
 		propertyKeys = append(propertyKeys, "trackEvents", "debugEventsUntilDate", "context", "excludeFromSummaries")
 	} else {
-		propertyKeys = append(propertyKeys, "contextKeys")
+		propertyKeys = append(propertyKeys, "context")
 	}
 	return m.AllOf(
 		append(
@@ -92,7 +91,7 @@ func IsValidFeatureEventWithConditions(isPHP bool, context ldcontext.Context, ma
 				IsFeatureEvent(),
 				HasAnyCreationDate(),
 				JSONPropertyKeysCanOnlyBe(propertyKeys...),
-				h.IfElse(isPHP, HasContextObjectWithMatchingKeys(context), HasContextKeys(context)),
+				HasContextObjectWithMatchingKeys(context),
 			},
 			matchers...)...)
 }


### PR DESCRIPTION
The event schema is largely unchanged from v4. The only difference is with evaluation events which now inline the context unconditionally.