### PR TITLE
feat: Support inline context payloads for feature events

### DIFF
--- a/docs/service_spec.md
+++ b/docs/service_spec.md
@@ -72,6 +72,10 @@ This means that the SDK supports caching of the e-tag header between client rest
 
 This means that the SDK supports event sampling; the SDK can limit the number of certain events based on payloads received from upstream services.
 
+#### Capability `"inline-context"`
+
+v4 of the event schema originally required a `contextKeys` property on all feature events. This event format was later broadened to accept either `contextKeys` or `contexts`. It is preferred that SDKs send over the `context` value. Opting into this capability will ensure the appropriate property is set.
+
 #### Capability `"migrations"`
 
 This means that the SDK supports technology migrations, a feature which allows customers to migrate between data sources using well-defined migration stages.

--- a/sdktests/client_side_events_eval.go
+++ b/sdktests/client_side_events_eval.go
@@ -100,7 +100,7 @@ func doClientSideFeatureEventTests(t *ldtest.T) {
 				client.FlushEvents(t)
 
 				matchFeatureEvent := IsValidFeatureEventWithConditions(
-					false, context,
+					t, false, context,
 					m.JSONProperty("key").Should(m.Equal(flag.Key)),
 					m.JSONProperty("version").Should(m.Equal(flag.Version)),
 					m.JSONProperty("value").Should(m.JSONEqual(expectedValue)),

--- a/sdktests/client_side_events_experimentation.go
+++ b/sdktests/client_side_events_experimentation.go
@@ -61,7 +61,7 @@ func doClientSideExperimentationEventTests(t *ldtest.T) {
 			payload := eventSink.ExpectAnalyticsEvents(t, time.Second)
 
 			matchFeatureEvent := IsValidFeatureEventWithConditions(
-				false, context,
+				t, false, context,
 				m.JSONProperty("key").Should(m.Equal(flagKey)),
 				m.JSONProperty("version").Should(m.Equal(flagVersion)),
 				m.JSONProperty("value").Should(m.JSONEqual(expectedValue)),

--- a/sdktests/common_tests_events_contexts.go
+++ b/sdktests/common_tests_events_contexts.go
@@ -214,7 +214,7 @@ func (c CommonEventTests) EventContexts(t *ldtest.T) {
 						payload := events.ExpectAnalyticsEvents(t, defaultEventTimeout)
 						eventMatchers := []m.Matcher{
 							m.AllOf(
-								IsValidFeatureEventWithConditions(true, context,
+								IsValidFeatureEventWithConditions(t, true, context,
 									m.JSONProperty("context").Should(outputMatcher(context))),
 							),
 						}

--- a/sdktests/php_events_eval.go
+++ b/sdktests/php_events_eval.go
@@ -140,7 +140,7 @@ func doPHPFeatureEventTests(t *ldtest.T) {
 								h.IfElse(fs.withDebug, m.JSONEqual(debugDate), m.BeNil()),
 							),
 						}
-						matchFeatureEvent := IsValidFeatureEventWithConditions(true, context, propMatchers...)
+						matchFeatureEvent := IsValidFeatureEventWithConditions(t, true, context, propMatchers...)
 
 						payload := events.ExpectAnalyticsEvents(t, defaultEventTimeout)
 						m.In(t).Assert(payload, m.Items(matchFeatureEvent))
@@ -182,7 +182,7 @@ func doPHPFeatureEventTests(t *ldtest.T) {
 			client.FlushEvents(t)
 
 			propMatchers := []m.Matcher{m.JSONProperty("excludeFromSummaries").Should(m.Equal(true))}
-			matchFeatureEvent := IsValidFeatureEventWithConditions(true, context, propMatchers...)
+			matchFeatureEvent := IsValidFeatureEventWithConditions(t, true, context, propMatchers...)
 
 			payload := events.ExpectAnalyticsEvents(t, defaultEventTimeout)
 			m.In(t).Assert(payload, m.Items(matchFeatureEvent))

--- a/sdktests/server_side_events_eval.go
+++ b/sdktests/server_side_events_eval.go
@@ -124,7 +124,7 @@ func doServerSideFeatureEventTests(t *ldtest.T) {
 					reason = ldreason.NewEvalReasonError(ldreason.EvalErrorMalformedFlag)
 				}
 				matchFeatureEvent := IsValidFeatureEventWithConditions(
-					false, context,
+					t, false, context,
 					m.JSONProperty("key").Should(m.Equal(flag.Key)),
 					m.JSONProperty("version").Should(m.Equal(flag.Version)),
 					m.JSONProperty("value").Should(m.JSONEqual(expectedValue)),
@@ -432,7 +432,7 @@ func doServerSideFeaturePrerequisiteEventTests(t *ldtest.T) {
 
 			eventMatchers := []m.Matcher{
 				IsValidFeatureEventWithConditions(
-					isPHP, context,
+					t, isPHP, context,
 					m.JSONProperty("key").Should(m.Equal(flag1.Key)),
 					m.JSONProperty("version").Should(m.Equal(flag1.Version)),
 					m.JSONProperty("value").Should(m.Equal("value1")),
@@ -441,7 +441,7 @@ func doServerSideFeaturePrerequisiteEventTests(t *ldtest.T) {
 					JSONPropertyNullOrAbsent("prereqOf"),
 				),
 				IsValidFeatureEventWithConditions(
-					isPHP, context,
+					t, isPHP, context,
 					m.JSONProperty("key").Should(m.Equal(flag2.Key)),
 					m.JSONProperty("version").Should(m.Equal(flag2.Version)),
 					m.JSONProperty("value").Should(m.Equal("ok2")),
@@ -451,7 +451,7 @@ func doServerSideFeaturePrerequisiteEventTests(t *ldtest.T) {
 					m.JSONOptProperty("prereqOf").Should(m.Equal("flag1")),
 				),
 				IsValidFeatureEventWithConditions(
-					isPHP, context,
+					t, isPHP, context,
 					m.JSONProperty("key").Should(m.Equal(flag3.Key)),
 					m.JSONProperty("version").Should(m.Equal(flag3.Version)),
 					m.JSONProperty("value").Should(m.Equal("ok3")),

--- a/sdktests/server_side_events_experimentation.go
+++ b/sdktests/server_side_events_experimentation.go
@@ -81,7 +81,7 @@ func doServerSideExperimentationEventTests(t *ldtest.T) {
 
 			eventMatchers := []m.Matcher{
 				IsValidFeatureEventWithConditions(
-					isPHP, context,
+					t, isPHP, context,
 					m.JSONProperty("key").Should(m.Equal(flag.Key)),
 					m.JSONProperty("version").Should(m.Equal(flag.Version)),
 					m.JSONProperty("value").Should(m.JSONEqual(expectedValue)),

--- a/servicedef/service_params.go
+++ b/servicedef/service_params.go
@@ -28,6 +28,7 @@ const (
 	CapabilityMigrations        = "migrations"
 	CapabilityEventSampling     = "event-sampling"
 	CapabilityETagCaching       = "etag-caching"
+	CapabilityInlineContext     = "inline-context"
 )
 
 type StatusRep struct {


### PR DESCRIPTION
Instead of moving to event schema 5, it looks like we are going to broaden what v4 allows.

There are a lot of unrelated changes required to match the spec changes, so I'm going to make a bunch of smaller PRs into a long running feature branch. Let me know if you have any questions.