### PR TITLE
fix: Use correct payload type for server/client in common tests.

### DIFF
--- a/sdktests/common_tests_events_custom.go
+++ b/sdktests/common_tests_events_custom.go
@@ -8,7 +8,6 @@ import (
 	h "github.com/launchdarkly/sdk-test-harness/v2/framework/helpers"
 	"github.com/launchdarkly/sdk-test-harness/v2/framework/ldtest"
 	o "github.com/launchdarkly/sdk-test-harness/v2/framework/opt"
-	"github.com/launchdarkly/sdk-test-harness/v2/mockld"
 	"github.com/launchdarkly/sdk-test-harness/v2/servicedef"
 
 	"github.com/launchdarkly/go-sdk-common/v3/ldvalue"
@@ -38,7 +37,7 @@ func (c CommonEventTests) CustomEvents(t *ldtest.T) {
 			t.Run(contexts.Description(), func(t *ldtest.T) {
 				context := contexts.NextUniqueContext()
 
-				dataSource := NewSDKDataSource(t, mockld.EmptyServerSDKData())
+				dataSource := NewSDKDataSource(t, nil)
 				events := NewSDKEventSink(t)
 				client := NewSDKClient(t, c.baseSDKConfigurationPlus(dataSource, events)...)
 

--- a/sdktests/sdk_context_type.go
+++ b/sdktests/sdk_context_type.go
@@ -6,7 +6,6 @@ import (
 
 	"github.com/launchdarkly/sdk-test-harness/v2/data"
 	"github.com/launchdarkly/sdk-test-harness/v2/framework/ldtest"
-	"github.com/launchdarkly/sdk-test-harness/v2/mockld"
 	"github.com/launchdarkly/sdk-test-harness/v2/servicedef"
 
 	"github.com/launchdarkly/go-sdk-common/v3/ldvalue"
@@ -34,7 +33,7 @@ func doSDKContextTypeTests(t *ldtest.T) {
 // at a client instance.
 
 func doSDKContextBuildTests(t *ldtest.T) {
-	dataSource := NewSDKDataSource(t, mockld.EmptyServerSDKData())
+	dataSource := NewSDKDataSource(t, nil)
 	client := NewSDKClient(t, dataSource)
 
 	optStr := func(s string) *string { return &s }
@@ -114,7 +113,7 @@ func doSDKContextBuildTests(t *ldtest.T) {
 }
 
 func doSDKContextConvertTests(t *ldtest.T) {
-	dataSource := NewSDKDataSource(t, mockld.EmptyServerSDKData())
+	dataSource := NewSDKDataSource(t, nil)
 	client := NewSDKClient(t, dataSource)
 
 	basicInputPlusProps := func(extraProps string) string {
@@ -320,7 +319,7 @@ func doSDKContextConvertTests(t *ldtest.T) {
 }
 
 func doSDKContextComparisonTests(t *ldtest.T) {
-	dataSource := NewSDKDataSource(t, mockld.EmptyServerSDKData())
+	dataSource := NewSDKDataSource(t, nil)
 	client := NewSDKClient(t, dataSource)
 	address := ldvalue.ObjectBuild().SetString("street", "123 Easy St").SetString("city", "Anytown").Build()
 	privateAttributes := []servicedef.PrivateAttribute{


### PR DESCRIPTION
Some tests common to client/server use a server payload instead of a client payload. 