### PR TITLE
feat: Allow configuring the query timeout.

### DIFF
--- a/docs/running.md
+++ b/docs/running.md
@@ -19,6 +19,7 @@ Options besides `-url`:
 * `-record-failures` - record failed test IDs to the given file. Recorded tests can be skipped by the next run of 
 the harness via `-skip-from`.
 * `-skip-from` - skips any test IDs recorded in the specified file. May be used in conjunction with `-record-failures`
+* `-status-timeout` - how many seconds to attempt to query to the test service before failing
 
 For `-run`, `-skip`, and tests referenced via `-skip-from`, the rules for pattern matching are as follows:
 
@@ -27,6 +28,7 @@ For `-run`, `-skip`, and tests referenced via `-skip-from`, the rules for patter
 * However, `(` and `)` will always be treated as literal characters, not regular expression operators. This is because some tests may have parens in their names. If you want "or" behavior, instead of `-run (a|b)` just use `-run a -run b` (in other words, there is an implied "or" for multiple values).
 * If `-run` specifies a test that has subtests, then all of its subtests are also run.
 * If `-skip`/`-skip-from` specifies a test that has subtests, then all of its subtests are also skipped.
+* `-status-timeout` is effectively a timeout for the starting of the test service. If the test service and harness are started at the same time, then this allows for time for compilation or startup of the test service.
 
 ## Output
 

--- a/main.go
+++ b/main.go
@@ -17,7 +17,6 @@ import (
 )
 
 const defaultPort = 8111
-const statusQueryTimeout = time.Second * 10
 
 //go:embed VERSION
 var versionString string // comes from the VERSION file which we update for each release
@@ -57,7 +56,7 @@ func run(params commandParams) (*ldtest.Results, error) {
 		params.serviceURL,
 		params.host,
 		params.port,
-		statusQueryTimeout,
+		time.Duration(params.queryTimeoutSeconds)*time.Second,
 		mainDebugLogger,
 		os.Stdout,
 	)

--- a/params.go
+++ b/params.go
@@ -9,16 +9,17 @@ import (
 )
 
 type commandParams struct {
-	serviceURL       string
-	port             int
-	host             string
-	filters          ldtest.RegexFilters
-	stopServiceAtEnd bool
-	debug            bool
-	debugAll         bool
-	jUnitFile        string
-	recordFailures   string
-	skipFile         string
+	serviceURL          string
+	port                int
+	host                string
+	filters             ldtest.RegexFilters
+	stopServiceAtEnd    bool
+	debug               bool
+	debugAll            bool
+	jUnitFile           string
+	recordFailures      string
+	skipFile            string
+	queryTimeoutSeconds int
 }
 
 func (c *commandParams) Read(args []string) bool {
@@ -36,6 +37,8 @@ func (c *commandParams) Read(args []string) bool {
 		"recorded tests can be skipped by the next run of the harness via -skip-from")
 	fs.StringVar(&c.skipFile, "skip-from", "", "skips any test IDs recorded in the specified file.\n"+
 		"may be used in conjunction with -record-failures")
+	fs.IntVar(&c.queryTimeoutSeconds, "status-timeout", 10, "how many seconds to attempt to query to "+
+		"the test service before failing")
 
 	if err := fs.Parse(args[1:]); err != nil {
 		fmt.Fprintln(os.Stderr, err)


### PR DESCRIPTION
In flutter we don't really have a way to pre-build and then run the contract tests. So we try to run them and sometimes it takes more than 10 seconds. This just lets you configure that 10 seconds and still defaults to 10 seconds. 

The limitation on the flutter side is because we need to run headless and we are using the unit test runner to accomplish this. Not ideal, but flutter isn't really a headless thing overall.