### PR TITLE
fix: Close the gzip stream ensuring it writes the gzip footer.

### DIFF
--- a/mockld/polling_service.go
+++ b/mockld/polling_service.go
@@ -134,7 +134,7 @@ func (p *PollingService) pollingHandler(getDataFn func(*PollingService, *http.Re
 			if _, err := gzipWriter.Write(data); err != nil {
 				p.debugLogger.Printf("failed to write to polling body gzip writer: %v", err)
 			}
-			if err := gzipWriter.Flush(); err != nil {
+			if err := gzipWriter.Close(); err != nil {
 				p.debugLogger.Printf("failed to flush gzip writer stream: %v", err)
 			}
 


### PR DESCRIPTION
The zlib from node was indicating an unexpected end of the zlib stream. I also piped the responses to a file and `gunzip` agreed they were incomplete. 

It looks like it will write the gzip footer on close: https://pkg.go.dev/compress/gzip#Writer.Close

I am not sure if we also need to make changes related to chunked responses, but node passes the large payload test with this change as well.