### PR TITLE
chore: fix secret passing in release workflows

### DIFF
--- a/.github/workflows/manual-release.yml
+++ b/.github/workflows/manual-release.yml
@@ -11,5 +11,6 @@ jobs:
   manual-release:
     uses: ./.github/workflows/release.yml
     with:
-      token: ${{ secrets.GITHUB_TOKEN }}
       tag: ${{ inputs.tag }}
+    secrets:
+      token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/manual-release.yml
+++ b/.github/workflows/manual-release.yml
@@ -12,5 +12,3 @@ jobs:
     uses: ./.github/workflows/release.yml
     with:
       tag: ${{ inputs.tag }}
-    secrets:
-      token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -25,5 +25,3 @@ jobs:
     uses: ./.github/workflows/release.yml
     with:
       tag: ${{ needs.release-please.outputs.tag_name }}
-    secrets:
-      token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -20,11 +20,10 @@ jobs:
           target-branch: v2
 
   release-sdk-test-harness:
-    permissions:
-      contents: write
     needs: release-please
     if: needs.release-please.outputs.release_created == 'true'
     uses: ./.github/workflows/release.yml
     with:
-      token: ${{ secrets.GITHUB_TOKEN }}
       tag: ${{ needs.release-please.outputs.tag_name }}
+    secrets:
+      token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,12 +1,14 @@
 on:
   workflow_call:
     inputs:
-      token:
-        required: true
-        type: string
       tag:
         required: true
+        description: 'The tag to upload release artifacts to.'
         type: string
+    secrets:
+      token:
+        required: true
+        description: 'GitHub token'
 
 jobs:
   release-sdk-test-harness:
@@ -20,5 +22,5 @@ jobs:
         run_linter: 'false'
     - uses: ./.github/actions/publish
       with:
-        token: ${{ github.event.inputs.token }}
+        token: ${{ secrets.token }}
         tag: ${{ github.event.inputs.tag }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,6 +17,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v4
+      with:
+        fetch-depth: 0 # Needed for goreleaser to inspect tags.
     - uses: ./.github/actions/ci
       with:
         run_linter: 'false'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,10 +5,6 @@ on:
         required: true
         description: 'The tag to upload release artifacts to.'
         type: string
-    secrets:
-      token:
-        required: true
-        description: 'GitHub token'
 
 jobs:
   release-sdk-test-harness:
@@ -24,5 +20,5 @@ jobs:
         run_linter: 'false'
     - uses: ./.github/actions/publish
       with:
-        token: ${{ secrets.token }}
+        token: ${{ secrets.GITHUB_TOKEN }}
         tag: ${{ github.event.inputs.tag }}


### PR DESCRIPTION
Didn't realize that reusable workflows need a special syntax for passing secrets like `GITHUB_TOKEN`, different than `inputs`. 

The existing config results in an invalid workflow file (although it works fine in `act`.)

