### PR TITLE
ci: don't specify release type on release-please action

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -15,7 +15,6 @@ jobs:
       - uses: google-github-actions/release-please-action@v4
         id: release
         with:
-          release-type: simple
           token: ${{ secrets.GITHUB_TOKEN }}
           target-branch: v2
 

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -3,7 +3,7 @@
     "." : {
       "release-type" : "go",
       "bump-minor-pre-major" : true,
-      "boostrap-sha" : "12774d23187e79d802083368132ea95b64a45cca",
+      "boostrap-sha" : "b244281d769f355998ec7e7c9da7f15344d8c92d",
       "versioning" : "default",
       "include-component-in-tag" : false,
       "extra-files" : [


### PR DESCRIPTION
The [release PR ](https://github.com/launchdarkly/sdk-test-harness/pull/192) didn't update [`main.go`](https://github.com/launchdarkly/sdk-test-harness/blob/v2/main.go#L20) as expected - I'm not seeing `fetching main.go from branch v2` or similar in the logs.

It's possible this is because the release-type is `simple`, when I meant it to be `go`. 

This may or may not solve the problem, but in any case it's a necessary change. 