### PR TITLE
fix: remove bootstrap-sha from release-please-config.json

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -3,7 +3,6 @@
     "." : {
       "release-type" : "go",
       "bump-minor-pre-major" : true,
-      "boostrap-sha" : "b244281d769f355998ec7e7c9da7f15344d8c92d",
       "versioning" : "default",
       "include-component-in-tag" : false,
       "extra-files" : [


### PR DESCRIPTION
Now that a release has been generated, this config item is ignored.