### PR TITLE
feat: Add hooks contract tests.

### DIFF
--- a/docs/service_spec.md
+++ b/docs/service_spec.md
@@ -141,6 +141,9 @@ A test hook must:
         * `method` (string, required): The name of the evaluation emthod that was called.
       * `evaluationHookData` (object, optional): The EvaluationHookData passed to the stage during execution.
       * `evaluationDetail` (object, optional): The details of the evaluation if executing an `afterEvaluation` stage.
+        * `value` (any): The JSON value of the result.
+        * `variationIndex` (int or null): The variation index of the result.
+        * `reason` (object): The evaluation reason of the result.
       * `stage` (string, optional): If executing a stage, for example `beforeEvaluation`, this should be the stage.
   - Return data from the stages as specified via the `data` configuration. For instance the return value from the `beforeEvaluation` hook should be `data['beforeEvaluation']` merged with the input data for the stage.
 

--- a/docs/service_spec.md
+++ b/docs/service_spec.md
@@ -134,12 +134,12 @@ A test hook must:
   - Implement the SDK hook interface.
   - Whenever an evaluation stage is called post information about that call to the `callbackUrl` of the hook.
     - The payload is an object with the following properties:
-      * `evaluationHookContext` (object, optional): If an evaluation stage was executed, then this should be the associated context.
+      * `evaluationSeriesContext` (object, optional): If an evaluation stage was executed, then this should be the associated context.
         * `flagKey` (string, required): The key of the flag being evaluated.
         * `context` (object, required): The evaluation context associated with the evaluation.
         * `defaultValue` (any): The default value for the evaluation.
         * `method` (string, required): The name of the evaluation emthod that was called.
-      * `evaluationHookData` (object, optional): The EvaluationHookData passed to the stage during execution.
+      * `evaluationSeriesData` (object, optional): The EvaluationSeriesData passed to the stage during execution.
       * `evaluationDetail` (object, optional): The details of the evaluation if executing an `afterEvaluation` stage.
       * `stage` (string, optional): If executing a stage, for example `beforeEvaluation`, this should be the stage.
   - Return data from the stages as specified via the `data` configuration. For instance the return value from the `beforeEvaluation` hook should be `data['beforeEvaluation']` merged with the input data for the stage.

--- a/docs/service_spec.md
+++ b/docs/service_spec.md
@@ -124,6 +124,26 @@ and will send a `?filter=name` query parameter along with streaming/polling requ
 For tests that involve filtering, the test harness will set the `filter` property of the `streaming` or `polling` configuration
 object. The property will either be omitted if no filter is requested, or a non-empty string if requested.
 
+### Capability `"evaluation-hooks"`
+
+This means that the SDK has support for hooks and has the ability to register evaluation hooks.
+
+For a test service to support hooks testing it must support a `test-hook`. The configuration will specify registering one or more `test-hooks`.
+
+A test hook must:
+  - Implement the SDK hook interface.
+  - Whenever an evaluation stage is called post information about that call to the `callbackUrl` of the hook.
+    - The payload is an object with the following properties:
+      * `evaluationHookContext` (object, optional): If an evaluation stage was executed, then this should be the associated context.
+        * `flagKey` (string, required): The key of the flag being evaluated.
+        * `context` (object, required): The evaluation context associated with the evaluation.
+        * `defaultValue` (any): The default value for the evaluation.
+        * `method` (string, required): The name of the evaluation emthod that was called.
+      * `evaluationHookData` (object, optional): The EvaluationHookData passed to the stage during execution.
+      * `evaluationDetail` (object, optional): The details of the evaluation if executing an `afterEvaluation` stage.
+      * `stage` (string, optional): If executing a stage, for example `beforeEvaluation`, this should be the stage.
+  - Return data from the stages as specified via the `data` configuration. For instance the return value from the `beforeEvaluation` hook should be `data['beforeEvaluation']` merged with the input data for the stage.
+
 ### Stop test service: `DELETE /`
 
 The test harness sends this request at the end of a test run if you have specified `--stop-service-at-end` on the [command line](./running.md). The test service should simply quit. This is a convenience so CI scripts can simply start the test service in the background and assume it will be stopped for them.
@@ -164,6 +184,13 @@ A `POST` request indicates that the test harness wants to start an instance of t
     * `initialContext` (object, optional): The context properties to initialize the SDK with (unless `initialUser` is specified instead). The test service for a client-side SDK can assume that the test harness will _always_ set this: if the test logic does not explicitly provide a value, the test harness will add a default one.
     * `initialUser` (object, optional): Can be specified instead of `initialContext` to use an old-style user JSON representation.
     * `evaluationReasons`, `useReport` (boolean, optional): These correspond to the SDK configuration properties of the same names.
+  * `hooks` (object, optional): If specified this has the configuration for hooks.
+    * `hooks` (array, required): Contains configuration of one or more hooks, each item is an object with the following parameters.
+      * `name` (string, required): A name to associate with the hook.
+      * `callbackUri` (string, required): A callback URL that the hook should post data to.
+      * `data` (object, optional): Contains data which should return from different execution stages.
+        * `beforeEvaluation` (object, optional): A map of `string` to `ldvalue` items. This should be returned from the `beforeEvaluation` stage of the test hook.
+        * `afterEvaluation` (object, optional): A map of `string` to `ldvalue` items. This should be returned from the `afterEvaluation` stage of the test hook.
 
 The response to a valid request is any HTTP `2xx` status, with a `Location` header whose value is the URL of the test service resource representing this SDK client instance (that is, the one that would be used for "Close client" or "Send command" as described below).
 

--- a/docs/service_spec.md
+++ b/docs/service_spec.md
@@ -124,7 +124,7 @@ and will send a `?filter=name` query parameter along with streaming/polling requ
 For tests that involve filtering, the test harness will set the `filter` property of the `streaming` or `polling` configuration
 object. The property will either be omitted if no filter is requested, or a non-empty string if requested.
 
-### Capability `"evaluation-hooks"`
+#### Capability `"evaluation-hooks"`
 
 This means that the SDK has support for hooks and has the ability to register evaluation hooks.
 

--- a/mockld/hook_callback_service.go
+++ b/mockld/hook_callback_service.go
@@ -44,7 +44,7 @@ func NewHookCallbackService(
 		var response servicedef.HookExecutionPayload
 		err = json.Unmarshal(bytes, &response)
 		if err != nil {
-			logger.Printf("Could not unmarshall hook payload.")
+			logger.Printf("Could not unmarshal hook payload.")
 			w.WriteHeader(http.StatusBadRequest)
 			return
 		}

--- a/mockld/hook_callback_service.go
+++ b/mockld/hook_callback_service.go
@@ -1,0 +1,53 @@
+package mockld
+
+import (
+	"encoding/json"
+	"github.com/launchdarkly/sdk-test-harness/v2/framework"
+	"github.com/launchdarkly/sdk-test-harness/v2/framework/harness"
+	"github.com/launchdarkly/sdk-test-harness/v2/servicedef"
+	"io"
+	"net/http"
+)
+
+type HookCallbackService struct {
+	payloadEndpoint *harness.MockEndpoint
+	CallChannel     chan servicedef.HookExecutionPayload
+	stopChannel     chan struct{}
+}
+
+func (h *HookCallbackService) GetURL() string {
+	return h.payloadEndpoint.BaseURL()
+}
+
+func (h *HookCallbackService) Close() {
+	h.payloadEndpoint.Close()
+}
+
+func NewHookCallbackService(
+	testHarness *harness.TestHarness,
+	logger framework.Logger,
+) *HookCallbackService {
+	h := &HookCallbackService{
+		CallChannel: make(chan servicedef.HookExecutionPayload),
+		stopChannel: make(chan struct{}),
+	}
+
+	endpointHandler := http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+		bytes, err := io.ReadAll(req.Body)
+		logger.Printf("Received from hook: %s", string(bytes))
+		if err != nil {
+			return
+		}
+		var response servicedef.HookExecutionPayload
+		err = json.Unmarshal(bytes, &response)
+		if err == nil {
+			h.CallChannel <- response
+		}
+
+		w.WriteHeader(http.StatusOK)
+	})
+
+	h.payloadEndpoint = testHarness.NewMockEndpoint(endpointHandler, logger, harness.MockEndpointDescription("hook payload"))
+
+	return h
+}

--- a/mockld/hook_callback_service.go
+++ b/mockld/hook_callback_service.go
@@ -2,11 +2,12 @@ package mockld
 
 import (
 	"encoding/json"
+	"io"
+	"net/http"
+
 	"github.com/launchdarkly/sdk-test-harness/v2/framework"
 	"github.com/launchdarkly/sdk-test-harness/v2/framework/harness"
 	"github.com/launchdarkly/sdk-test-harness/v2/servicedef"
-	"io"
-	"net/http"
 )
 
 type HookCallbackService struct {
@@ -47,7 +48,8 @@ func NewHookCallbackService(
 		w.WriteHeader(http.StatusOK)
 	})
 
-	h.payloadEndpoint = testHarness.NewMockEndpoint(endpointHandler, logger, harness.MockEndpointDescription("hook payload"))
+	h.payloadEndpoint = testHarness.NewMockEndpoint(
+		endpointHandler, logger, harness.MockEndpointDescription("hook payload"))
 
 	return h
 }

--- a/mockld/hook_callback_service.go
+++ b/mockld/hook_callback_service.go
@@ -37,13 +37,19 @@ func NewHookCallbackService(
 		bytes, err := io.ReadAll(req.Body)
 		logger.Printf("Received from hook: %s", string(bytes))
 		if err != nil {
+			logger.Printf("Could not read body from hook.")
+			w.WriteHeader(http.StatusBadRequest)
 			return
 		}
 		var response servicedef.HookExecutionPayload
 		err = json.Unmarshal(bytes, &response)
-		if err == nil {
-			h.CallChannel <- response
+		if err != nil {
+			logger.Printf("Could not unmarshall hook payload.")
+			w.WriteHeader(http.StatusBadRequest)
+			return
 		}
+
+		h.CallChannel <- response
 
 		w.WriteHeader(http.StatusOK)
 	})

--- a/mockld/hook_callback_service.go
+++ b/mockld/hook_callback_service.go
@@ -49,7 +49,9 @@ func NewHookCallbackService(
 			return
 		}
 
-		h.CallChannel <- response
+		go func() {
+			h.CallChannel <- response
+		}()
 
 		w.WriteHeader(http.StatusOK)
 	})

--- a/sdktests/server_side_hooks.go
+++ b/sdktests/server_side_hooks.go
@@ -4,13 +4,17 @@ import (
 	"github.com/launchdarkly/go-sdk-common/v3/ldcontext"
 	"github.com/launchdarkly/go-sdk-common/v3/ldmigration"
 	"github.com/launchdarkly/go-sdk-common/v3/ldvalue"
+
 	"github.com/launchdarkly/go-server-sdk-evaluation/v3/ldbuilders"
+
 	"github.com/launchdarkly/sdk-test-harness/v2/data"
 	"github.com/launchdarkly/sdk-test-harness/v2/framework/ldtest"
 	o "github.com/launchdarkly/sdk-test-harness/v2/framework/opt"
 	"github.com/launchdarkly/sdk-test-harness/v2/mockld"
 	"github.com/launchdarkly/sdk-test-harness/v2/servicedef"
+
 	"github.com/stretchr/testify/assert"
+
 	"time"
 )
 
@@ -267,7 +271,8 @@ func beforeEvaluationDataPropagatesToAfterMigration(t *ldtest.T) {
 	})
 }
 
-func createClientForHooks(t *ldtest.T, instances []string, hookData map[servicedef.HookStage]map[string]ldvalue.Value) (*SDKClient, *Hooks) {
+func createClientForHooks(t *ldtest.T, instances []string,
+	hookData map[servicedef.HookStage]map[string]ldvalue.Value) (*SDKClient, *Hooks) {
 	boolFlag := ldbuilders.NewFlagBuilder("bool-flag").
 		Variations(ldvalue.Bool(false), ldvalue.Bool(true)).
 		FallthroughVariation(1).On(true).Build()

--- a/sdktests/server_side_hooks.go
+++ b/sdktests/server_side_hooks.go
@@ -1,0 +1,302 @@
+package sdktests
+
+import (
+	"github.com/launchdarkly/go-sdk-common/v3/ldcontext"
+	"github.com/launchdarkly/go-sdk-common/v3/ldmigration"
+	"github.com/launchdarkly/go-sdk-common/v3/ldvalue"
+	"github.com/launchdarkly/go-server-sdk-evaluation/v3/ldbuilders"
+	"github.com/launchdarkly/sdk-test-harness/v2/data"
+	"github.com/launchdarkly/sdk-test-harness/v2/framework/ldtest"
+	o "github.com/launchdarkly/sdk-test-harness/v2/framework/opt"
+	"github.com/launchdarkly/sdk-test-harness/v2/mockld"
+	"github.com/launchdarkly/sdk-test-harness/v2/servicedef"
+	"github.com/stretchr/testify/assert"
+	"time"
+)
+
+func doServerSideHooksTests(t *ldtest.T) {
+	t.RequireCapability(servicedef.CapabilityEvaluationHooks)
+	t.Run("executes beforeEvaluation stage", executesBeforeEvaluationStage)
+	t.Run("executes afterEvaluation stage", executesAfterEvaluationStage)
+	t.Run("data propagates from before to after", beforeEvaluationDataPropagatesToAfter)
+	t.Run("data propagates from before to after for migrations", beforeEvaluationDataPropagatesToAfterMigration)
+}
+
+func executesBeforeEvaluationStage(t *ldtest.T) {
+	t.Run("without detail", func(t *ldtest.T) { executesBeforeEvaluationStageDetail(t, false) })
+	t.Run("with detail", func(t *ldtest.T) { executesBeforeEvaluationStageDetail(t, true) })
+	t.Run("for migrations", executesBeforeEvaluationStageMigration)
+}
+
+func executesAfterEvaluationStage(t *ldtest.T) {
+	t.Run("without detail", func(t *ldtest.T) { executesAfterEvaluationStageDetail(t, false) })
+	t.Run("with detail", func(t *ldtest.T) { executesAfterEvaluationStageDetail(t, true) })
+	t.Run("for migrations", executesAfterEvaluationStageMigration)
+}
+
+func beforeEvaluationDataPropagatesToAfter(t *ldtest.T) {
+	t.Run("without detail", func(t *ldtest.T) { beforeEvaluationDataPropagatesToAfterDetail(t, false) })
+	t.Run("with detail", func(t *ldtest.T) { beforeEvaluationDataPropagatesToAfterDetail(t, true) })
+}
+
+type VariationParameters struct {
+	name         string
+	flagKey      string
+	defaultValue ldvalue.Value
+	valueType    servicedef.ValueType
+	detail       bool
+}
+
+func variationTestParams(detail bool) []VariationParameters {
+	return []VariationParameters{{
+		name:         "for boolean variation",
+		flagKey:      "bool-flag",
+		defaultValue: ldvalue.Bool(false),
+		valueType:    servicedef.ValueTypeBool,
+		detail:       detail,
+	},
+		{
+			name:         "for string variation",
+			flagKey:      "string-flag",
+			defaultValue: ldvalue.String("default"),
+			valueType:    servicedef.ValueTypeString,
+			detail:       detail,
+		},
+		{
+			name:         "for double variation",
+			flagKey:      "number-flag",
+			defaultValue: ldvalue.Float64(3.14),
+			valueType:    servicedef.ValueTypeDouble,
+			detail:       detail,
+		},
+		{
+			name:         "for int variation",
+			flagKey:      "number-flag",
+			defaultValue: ldvalue.Int(0xDEADBEEF),
+			valueType:    servicedef.ValueTypeInt,
+			detail:       detail,
+		},
+		{
+			name:         "for json variation",
+			flagKey:      "json-flag",
+			defaultValue: ldvalue.ObjectBuild().Build(),
+			valueType:    servicedef.ValueTypeInt,
+			detail:       detail,
+		},
+	}
+}
+
+func executesBeforeEvaluationStageDetail(t *ldtest.T, detail bool) {
+	testParams := variationTestParams(detail)
+
+	hookName := "executesBeforeEvaluationStage"
+	client, hooks := createClientForHooks(t, []string{hookName}, nil)
+	defer hooks.Close()
+
+	for _, testParam := range testParams {
+		t.Run(testParam.name, func(t *ldtest.T) {
+			client.EvaluateFlag(t, servicedef.EvaluateFlagParams{
+				FlagKey:      testParam.flagKey,
+				Context:      o.Some(ldcontext.New("user-key")),
+				ValueType:    testParam.valueType,
+				DefaultValue: testParam.defaultValue,
+			})
+
+			hooks.ExpectCall(t, hookName, 1*time.Second, func(payload servicedef.HookExecutionPayload) bool {
+				if payload.Stage.Value() == servicedef.BeforeEvaluation {
+					hookContext := payload.EvaluationHookContext.Value()
+					assert.Equal(t, testParam.flagKey, hookContext.FlagKey)
+					assert.Equal(t, ldcontext.New("user-key"), hookContext.Context)
+					assert.Equal(t, testParam.defaultValue, hookContext.DefaultValue)
+					return true
+				}
+				return false
+			})
+		})
+	}
+}
+
+func executesBeforeEvaluationStageMigration(t *ldtest.T) {
+	hookName := "executesBeforeEvaluationStageMigration"
+	client, hooks := createClientForHooks(t, []string{hookName}, nil)
+	defer hooks.Close()
+
+	flagKey := "migration-flag"
+	params := servicedef.MigrationVariationParams{
+		Key:          flagKey,
+		Context:      ldcontext.New("user-key"),
+		DefaultStage: ldmigration.Off,
+	}
+	client.MigrationVariation(t, params)
+
+	hooks.ExpectCall(t, hookName, 1*time.Second, func(payload servicedef.HookExecutionPayload) bool {
+		if payload.Stage.Value() == servicedef.BeforeEvaluation {
+			hookContext := payload.EvaluationHookContext.Value()
+			assert.Equal(t, flagKey, hookContext.FlagKey)
+			assert.Equal(t, ldcontext.New("user-key"), hookContext.Context)
+			assert.Equal(t, ldvalue.String(string(ldmigration.Off)), hookContext.DefaultValue)
+			return true
+		}
+		return false
+	})
+}
+
+func executesAfterEvaluationStageDetail(t *ldtest.T, detail bool) {
+	testParams := variationTestParams(detail)
+
+	hookName := "executesAfterEvaluationStage"
+	client, hooks := createClientForHooks(t, []string{hookName}, nil)
+	defer hooks.Close()
+
+	for _, testParam := range testParams {
+		t.Run(testParam.name, func(t *ldtest.T) {
+			result := client.EvaluateFlag(t, servicedef.EvaluateFlagParams{
+				FlagKey:      testParam.flagKey,
+				Context:      o.Some(ldcontext.New("user-key")),
+				ValueType:    testParam.valueType,
+				DefaultValue: testParam.defaultValue,
+				Detail:       detail,
+			})
+
+			hooks.ExpectCall(t, hookName, 1*time.Second, func(payload servicedef.HookExecutionPayload) bool {
+				if payload.Stage.Value() == servicedef.AfterEvaluation {
+					hookContext := payload.EvaluationHookContext.Value()
+					assert.Equal(t, testParam.flagKey, hookContext.FlagKey)
+					assert.Equal(t, ldcontext.New("user-key"), hookContext.Context)
+					assert.Equal(t, testParam.defaultValue, hookContext.DefaultValue)
+					evaluationDetail := payload.EvaluationDetail.Value()
+					assert.Equal(t, result.Value, evaluationDetail.Value)
+					if detail {
+						assert.Equal(t, result.VariationIndex, evaluationDetail.VariationIndex)
+						assert.Equal(t, result.Reason, evaluationDetail.Reason)
+					}
+					return true
+				}
+				return false
+			})
+		})
+	}
+}
+
+func executesAfterEvaluationStageMigration(t *ldtest.T) {
+	hookName := "executesBeforeEvaluationStageMigration"
+	client, hooks := createClientForHooks(t, []string{hookName}, nil)
+	defer hooks.Close()
+
+	flagKey := "migration-flag"
+	params := servicedef.MigrationVariationParams{
+		Key:          flagKey,
+		Context:      ldcontext.New("user-key"),
+		DefaultStage: ldmigration.Off,
+	}
+	result := client.MigrationVariation(t, params)
+
+	hooks.ExpectCall(t, hookName, 1*time.Second, func(payload servicedef.HookExecutionPayload) bool {
+		if payload.Stage.Value() == servicedef.AfterEvaluation {
+			hookContext := payload.EvaluationHookContext.Value()
+			assert.Equal(t, flagKey, hookContext.FlagKey)
+			assert.Equal(t, ldcontext.New("user-key"), hookContext.Context)
+			assert.Equal(t, ldvalue.String(string(ldmigration.Off)), hookContext.DefaultValue)
+			evaluationDetail := payload.EvaluationDetail.Value()
+			assert.Equal(t, ldvalue.String(result.Result), evaluationDetail.Value)
+			return true
+		}
+		return false
+	})
+}
+
+func beforeEvaluationDataPropagatesToAfterDetail(t *ldtest.T, detail bool) {
+	testParams := variationTestParams(detail)
+
+	hookName := "beforeEvaluationDataPropagatesToAfterDetail"
+	hookData := make(map[servicedef.HookStage]map[string]ldvalue.Value)
+	hookData[servicedef.BeforeEvaluation] = make(map[string]ldvalue.Value)
+	hookData[servicedef.BeforeEvaluation]["someData"] = ldvalue.String("the hookData")
+
+	client, hooks := createClientForHooks(t, []string{hookName}, hookData)
+	defer hooks.Close()
+
+	for _, testParam := range testParams {
+		t.Run(testParam.name, func(t *ldtest.T) {
+			client.EvaluateFlag(t, servicedef.EvaluateFlagParams{
+				FlagKey:      testParam.flagKey,
+				Context:      o.Some(ldcontext.New("user-key")),
+				ValueType:    testParam.valueType,
+				DefaultValue: testParam.defaultValue,
+				Detail:       detail,
+			})
+
+			hooks.ExpectCall(t, hookName, 1*time.Second, func(payload servicedef.HookExecutionPayload) bool {
+				if payload.Stage.Value() == servicedef.AfterEvaluation {
+					hookData := payload.EvaluationHookData.Value()
+					assert.Equal(t, ldvalue.String("the hookData"), hookData["someData"])
+					assert.Len(t, hookData, 1)
+					return true
+				}
+				return false
+			})
+		})
+	}
+}
+
+func beforeEvaluationDataPropagatesToAfterMigration(t *ldtest.T) {
+	hookName := "beforeEvaluationDataPropagatesToAfterDetail"
+	hookData := make(map[servicedef.HookStage]map[string]ldvalue.Value)
+	hookData[servicedef.BeforeEvaluation] = make(map[string]ldvalue.Value)
+	hookData[servicedef.BeforeEvaluation]["someData"] = ldvalue.String("the hookData")
+
+	client, hooks := createClientForHooks(t, []string{hookName}, hookData)
+	defer hooks.Close()
+
+	flagKey := "migration-flag"
+	params := servicedef.MigrationVariationParams{
+		Key:          flagKey,
+		Context:      ldcontext.New("user-key"),
+		DefaultStage: ldmigration.Off,
+	}
+	client.MigrationVariation(t, params)
+
+	hooks.ExpectCall(t, hookName, 1*time.Second, func(payload servicedef.HookExecutionPayload) bool {
+		if payload.Stage.Value() == servicedef.AfterEvaluation {
+			hookData := payload.EvaluationHookData.Value()
+			assert.Equal(t, ldvalue.String("the hookData"), hookData["someData"])
+			assert.Len(t, hookData, 1)
+			return true
+		}
+		return false
+	})
+}
+
+func createClientForHooks(t *ldtest.T, instances []string, hookData map[servicedef.HookStage]map[string]ldvalue.Value) (*SDKClient, *Hooks) {
+	boolFlag := ldbuilders.NewFlagBuilder("bool-flag").
+		Variations(ldvalue.Bool(false), ldvalue.Bool(true)).
+		FallthroughVariation(1).On(true).Build()
+
+	numberFlag := ldbuilders.NewFlagBuilder("number-flag").
+		Variations(ldvalue.Int(0), ldvalue.Int(42)).
+		OffVariation(1).On(false).Build()
+
+	stringFlag := ldbuilders.NewFlagBuilder("string-flag").
+		Variations(ldvalue.String("string-off"), ldvalue.String("string-on")).
+		FallthroughVariation(1).On(true).Build()
+
+	jsonFlag := ldbuilders.NewFlagBuilder("json-flag").
+		Variations(ldvalue.ObjectBuild().Set("value", ldvalue.Bool(false)).Build(),
+			ldvalue.ObjectBuild().Set("value", ldvalue.Bool(true)).Build()).
+		FallthroughVariation(1).On(true).Build()
+	migrationFlag := ldbuilders.NewFlagBuilder("migration-flag").
+		On(true).
+		Variations(data.MakeStandardMigrationStages()...).
+		FallthroughVariation(1).
+		Build()
+
+	dataBuilder := mockld.NewServerSDKDataBuilder()
+	dataBuilder.Flag(boolFlag, numberFlag, stringFlag, jsonFlag, migrationFlag)
+
+	hooks := NewHooks(requireContext(t).harness, t.DebugLogger(), instances, hookData)
+
+	dataSource := NewSDKDataSource(t, dataBuilder.Build())
+	events := NewSDKEventSink(t)
+	client := NewSDKClient(t, dataSource, hooks, events)
+	return client, hooks
+}

--- a/sdktests/server_side_hooks.go
+++ b/sdktests/server_side_hooks.go
@@ -106,7 +106,7 @@ func executesBeforeEvaluationStageDetail(t *ldtest.T, detail bool) {
 
 			hooks.ExpectCall(t, hookName, func(payload servicedef.HookExecutionPayload) bool {
 				if payload.Stage.Value() == servicedef.BeforeEvaluation {
-					hookContext := payload.EvaluationHookContext.Value()
+					hookContext := payload.EvaluationSeriesContext.Value()
 					assert.Equal(t, testParam.flagKey, hookContext.FlagKey)
 					assert.Equal(t, ldcontext.New("user-key"), hookContext.Context)
 					assert.Equal(t, testParam.defaultValue, hookContext.DefaultValue)
@@ -133,7 +133,7 @@ func executesBeforeEvaluationStageMigration(t *ldtest.T) {
 
 	hooks.ExpectCall(t, hookName, func(payload servicedef.HookExecutionPayload) bool {
 		if payload.Stage.Value() == servicedef.BeforeEvaluation {
-			hookContext := payload.EvaluationHookContext.Value()
+			hookContext := payload.EvaluationSeriesContext.Value()
 			assert.Equal(t, flagKey, hookContext.FlagKey)
 			assert.Equal(t, ldcontext.New("user-key"), hookContext.Context)
 			assert.Equal(t, ldvalue.String(string(ldmigration.Off)), hookContext.DefaultValue)
@@ -162,7 +162,7 @@ func executesAfterEvaluationStageDetail(t *ldtest.T, detail bool) {
 
 			hooks.ExpectCall(t, hookName, func(payload servicedef.HookExecutionPayload) bool {
 				if payload.Stage.Value() == servicedef.AfterEvaluation {
-					hookContext := payload.EvaluationHookContext.Value()
+					hookContext := payload.EvaluationSeriesContext.Value()
 					assert.Equal(t, testParam.flagKey, hookContext.FlagKey)
 					assert.Equal(t, ldcontext.New("user-key"), hookContext.Context)
 					assert.Equal(t, testParam.defaultValue, hookContext.DefaultValue)
@@ -195,7 +195,7 @@ func executesAfterEvaluationStageMigration(t *ldtest.T) {
 
 	hooks.ExpectCall(t, hookName, func(payload servicedef.HookExecutionPayload) bool {
 		if payload.Stage.Value() == servicedef.AfterEvaluation {
-			hookContext := payload.EvaluationHookContext.Value()
+			hookContext := payload.EvaluationSeriesContext.Value()
 			assert.Equal(t, flagKey, hookContext.FlagKey)
 			assert.Equal(t, ldcontext.New("user-key"), hookContext.Context)
 			assert.Equal(t, ldvalue.String(string(ldmigration.Off)), hookContext.DefaultValue)
@@ -230,7 +230,7 @@ func beforeEvaluationDataPropagatesToAfterDetail(t *ldtest.T, detail bool) {
 
 			hooks.ExpectCall(t, hookName, func(payload servicedef.HookExecutionPayload) bool {
 				if payload.Stage.Value() == servicedef.AfterEvaluation {
-					hookData := payload.EvaluationHookData.Value()
+					hookData := payload.EvaluationSeriesData.Value()
 					assert.Equal(t, ldvalue.String("the hookData"), hookData["someData"])
 					assert.Len(t, hookData, 1)
 					return true
@@ -260,7 +260,7 @@ func beforeEvaluationDataPropagatesToAfterMigration(t *ldtest.T) {
 
 	hooks.ExpectCall(t, hookName, func(payload servicedef.HookExecutionPayload) bool {
 		if payload.Stage.Value() == servicedef.AfterEvaluation {
-			hookData := payload.EvaluationHookData.Value()
+			hookData := payload.EvaluationSeriesData.Value()
 			assert.Equal(t, ldvalue.String("the hookData"), hookData["someData"])
 			assert.Len(t, hookData, 1)
 			return true

--- a/sdktests/server_side_hooks.go
+++ b/sdktests/server_side_hooks.go
@@ -74,7 +74,7 @@ func variationTestParams(detail bool) []VariationParameters {
 		{
 			name:         "for int variation",
 			flagKey:      "number-flag",
-			defaultValue: ldvalue.Int(0xDEADBEEF),
+			defaultValue: ldvalue.Int(314159265),
 			valueType:    servicedef.ValueTypeInt,
 			detail:       detail,
 		},

--- a/sdktests/testapi_hooks.go
+++ b/sdktests/testapi_hooks.go
@@ -1,6 +1,8 @@
 package sdktests
 
 import (
+	"time"
+
 	"github.com/launchdarkly/go-sdk-common/v3/ldvalue"
 	"github.com/launchdarkly/sdk-test-harness/v2/framework"
 	"github.com/launchdarkly/sdk-test-harness/v2/framework/harness"
@@ -9,7 +11,6 @@ import (
 	o "github.com/launchdarkly/sdk-test-harness/v2/framework/opt"
 	"github.com/launchdarkly/sdk-test-harness/v2/mockld"
 	"github.com/launchdarkly/sdk-test-harness/v2/servicedef"
-	"time"
 )
 
 type HookInstance struct {
@@ -61,7 +62,8 @@ func (h *Hooks) Close() {
 	}
 }
 
-func (h *Hooks) ExpectCall(t *ldtest.T, hookName string, receiveTimeout time.Duration, matcher func(payload servicedef.HookExecutionPayload) bool) {
+func (h *Hooks) ExpectCall(t *ldtest.T, hookName string, receiveTimeout time.Duration,
+	matcher func(payload servicedef.HookExecutionPayload) bool) {
 	for {
 		maybeValue := helpers.TryReceive(h.instances[hookName].hookService.CallChannel, receiveTimeout)
 		if !maybeValue.IsDefined() {

--- a/sdktests/testapi_hooks.go
+++ b/sdktests/testapi_hooks.go
@@ -1,0 +1,77 @@
+package sdktests
+
+import (
+	"github.com/launchdarkly/go-sdk-common/v3/ldvalue"
+	"github.com/launchdarkly/sdk-test-harness/v2/framework"
+	"github.com/launchdarkly/sdk-test-harness/v2/framework/harness"
+	"github.com/launchdarkly/sdk-test-harness/v2/framework/helpers"
+	"github.com/launchdarkly/sdk-test-harness/v2/framework/ldtest"
+	o "github.com/launchdarkly/sdk-test-harness/v2/framework/opt"
+	"github.com/launchdarkly/sdk-test-harness/v2/mockld"
+	"github.com/launchdarkly/sdk-test-harness/v2/servicedef"
+	"time"
+)
+
+type HookInstance struct {
+	name        string
+	hookService *mockld.HookCallbackService
+	data        map[servicedef.HookStage]map[string]ldvalue.Value
+}
+
+type Hooks struct {
+	instances map[string]HookInstance
+}
+
+func NewHooks(
+	testHarness *harness.TestHarness,
+	logger framework.Logger,
+	instances []string,
+	data map[servicedef.HookStage]map[string]ldvalue.Value,
+) *Hooks {
+	hooks := &Hooks{
+		instances: make(map[string]HookInstance),
+	}
+	for _, instance := range instances {
+		hooks.instances[instance] = HookInstance{
+			name:        instance,
+			hookService: mockld.NewHookCallbackService(testHarness, logger),
+			data:        data,
+		}
+	}
+
+	return hooks
+}
+
+func (h *Hooks) Configure(config *servicedef.SDKConfigParams) error {
+	hookConfig := config.Hooks.Value()
+	for _, instance := range h.instances {
+		hookConfig.Hooks = append(hookConfig.Hooks, servicedef.SDKConfigHookInstance{
+			Name:        instance.name,
+			CallbackURI: instance.hookService.GetURL(),
+			Data:        instance.data,
+		})
+	}
+	config.Hooks = o.Some(hookConfig)
+	return nil
+}
+
+func (h *Hooks) Close() {
+	for _, instance := range h.instances {
+		instance.hookService.Close()
+	}
+}
+
+func (h *Hooks) ExpectCall(t *ldtest.T, hookName string, receiveTimeout time.Duration, matcher func(payload servicedef.HookExecutionPayload) bool) {
+	for {
+		maybeValue := helpers.TryReceive(h.instances[hookName].hookService.CallChannel, receiveTimeout)
+		if !maybeValue.IsDefined() {
+			t.Errorf("Timed out trying to receive hook execution data")
+			t.FailNow()
+			break
+		}
+		payload := maybeValue.Value()
+		if matcher(payload) {
+			break
+		}
+	}
+}

--- a/sdktests/testsuite_entry_point.go
+++ b/sdktests/testsuite_entry_point.go
@@ -90,6 +90,7 @@ func doAllServerSideTests(t *ldtest.T) {
 	t.Run("secure mode hash", doServerSideSecureModeHashTests)
 	t.Run("context type", doSDKContextTypeTests)
 	t.Run("migrations", doServerSideMigrationTests)
+	t.Run("hooks", doServerSideHooksTests)
 }
 
 func doAllClientSideTests(t *ldtest.T) {

--- a/servicedef/command_params.go
+++ b/servicedef/command_params.go
@@ -187,3 +187,24 @@ type MigrationOperationParams struct {
 type MigrationOperationResponse struct {
 	Result string `json:"result"`
 }
+
+type HookStage string
+
+const (
+	BeforeEvaluation HookStage = "beforeEvaluation"
+	AfterEvaluation  HookStage = "afterEvaluation"
+)
+
+type EvaluationHookContext struct {
+	FlagKey      string            `json:"flagKey"`
+	Context      ldcontext.Context `json:"context"`
+	DefaultValue ldvalue.Value     `json:"defaultValue"`
+	Method       string            `json:"method"`
+}
+
+type HookExecutionPayload struct {
+	EvaluationHookContext o.Maybe[EvaluationHookContext]    `json:"evaluationHookContext"`
+	EvaluationHookData    o.Maybe[map[string]ldvalue.Value] `json:"evaluationHookData"`
+	EvaluationDetail      o.Maybe[EvaluateFlagResponse]     `json:"evaluationDetail"`
+	Stage                 o.Maybe[HookStage]                `json:"stage"`
+}

--- a/servicedef/command_params.go
+++ b/servicedef/command_params.go
@@ -195,7 +195,7 @@ const (
 	AfterEvaluation  HookStage = "afterEvaluation"
 )
 
-type EvaluationHookContext struct {
+type EvaluationSeriesContext struct {
 	FlagKey      string            `json:"flagKey"`
 	Context      ldcontext.Context `json:"context"`
 	DefaultValue ldvalue.Value     `json:"defaultValue"`
@@ -203,8 +203,8 @@ type EvaluationHookContext struct {
 }
 
 type HookExecutionPayload struct {
-	EvaluationHookContext o.Maybe[EvaluationHookContext]    `json:"evaluationHookContext"`
-	EvaluationHookData    o.Maybe[map[string]ldvalue.Value] `json:"evaluationHookData"`
-	EvaluationDetail      o.Maybe[EvaluateFlagResponse]     `json:"evaluationDetail"`
-	Stage                 o.Maybe[HookStage]                `json:"stage"`
+	EvaluationSeriesContext o.Maybe[EvaluationSeriesContext]  `json:"evaluationSeriesContext"`
+	EvaluationSeriesData    o.Maybe[map[string]ldvalue.Value] `json:"evaluationSeriesData"`
+	EvaluationDetail        o.Maybe[EvaluateFlagResponse]     `json:"evaluationDetail"`
+	Stage                   o.Maybe[HookStage]                `json:"stage"`
 }

--- a/servicedef/sdk_config.go
+++ b/servicedef/sdk_config.go
@@ -2,6 +2,7 @@ package servicedef
 
 import (
 	"encoding/json"
+
 	"github.com/launchdarkly/go-sdk-common/v3/ldvalue"
 
 	o "github.com/launchdarkly/sdk-test-harness/v2/framework/opt"

--- a/servicedef/sdk_config.go
+++ b/servicedef/sdk_config.go
@@ -78,10 +78,12 @@ type SDKConfigClientSideParams struct {
 	IncludeEnvironmentAttributes o.Maybe[bool]              `json:"includeEnvironmentAttributes,omitempty"`
 }
 
+type SDKConfigEvaluationHookData map[string]ldvalue.Value
+
 type SDKConfigHookInstance struct {
-	Name        string                                 `json:"name"`
-	CallbackURI string                                 `json:"callbackUri"`
-	Data        map[HookStage]map[string]ldvalue.Value `json:"data,omitempty"`
+	Name        string                                    `json:"name"`
+	CallbackURI string                                    `json:"callbackUri"`
+	Data        map[HookStage]SDKConfigEvaluationHookData `json:"data,omitempty"`
 }
 
 type SDKConfigHooksParams struct {

--- a/servicedef/sdk_config.go
+++ b/servicedef/sdk_config.go
@@ -2,6 +2,7 @@ package servicedef
 
 import (
 	"encoding/json"
+	"github.com/launchdarkly/go-sdk-common/v3/ldvalue"
 
 	o "github.com/launchdarkly/sdk-test-harness/v2/framework/opt"
 
@@ -21,6 +22,7 @@ type SDKConfigParams struct {
 	BigSegments         o.Maybe[SDKConfigBigSegmentsParams]         `json:"bigSegments,omitempty"`
 	Tags                o.Maybe[SDKConfigTagsParams]                `json:"tags,omitempty"`
 	ClientSide          o.Maybe[SDKConfigClientSideParams]          `json:"clientSide,omitempty"`
+	Hooks               o.Maybe[SDKConfigHooksParams]               `json:"hooks,omitempty"`
 }
 
 type SDKConfigServiceEndpointsParams struct {
@@ -73,4 +75,14 @@ type SDKConfigClientSideParams struct {
 	EvaluationReasons            o.Maybe[bool]              `json:"evaluationReasons,omitempty"`
 	UseReport                    o.Maybe[bool]              `json:"useReport,omitempty"`
 	IncludeEnvironmentAttributes o.Maybe[bool]              `json:"includeEnvironmentAttributes,omitempty"`
+}
+
+type SDKConfigHookInstance struct {
+	Name        string                                 `json:"name"`
+	CallbackURI string                                 `json:"callbackUri"`
+	Data        map[HookStage]map[string]ldvalue.Value `json:"data,omitempty"`
+}
+
+type SDKConfigHooksParams struct {
+	Hooks []SDKConfigHookInstance `json:"hooks"`
 }

--- a/servicedef/service_params.go
+++ b/servicedef/service_params.go
@@ -32,6 +32,7 @@ const (
 	CapabilityInlineContext      = "inline-context"
 	CapabilityAnonymousRedaction = "anonymous-redaction"
 	CapabilityPollingGzip        = "polling-gzip"
+	CapabilityEvaluationHooks    = "evaluation-hooks"
 )
 
 type StatusRep struct {


### PR DESCRIPTION
This PR adds support for basic contract testing of hooks.

It does not include support for dynamic registration of hooks.
It does not yet test hook execution order.
It does not test hooks throwing errors.