### PR TITLE
feat: Add support for gzipped event payloads

### DIFF
--- a/docs/service_spec.md
+++ b/docs/service_spec.md
@@ -72,6 +72,10 @@ This means that the SDK has the ability to construct and compare two contexts fo
 
 This means that the SDK supports caching of the e-tag header between client restarts. Typical SDKs track the polling e-tag header and send it between subsequent requests. SDKs supporting this capability are able to persist that e-tag header for use even between complete client restarts.
 
+#### Capability `"event-gzip"`
+
+This means that the SDK supports gzip compression of event payloads.
+
 #### Capability `"event-sampling"`
 
 This means that the SDK supports event sampling; the SDK can limit the number of certain events based on payloads received from upstream services.

--- a/sdktests/common_tests_events_request.go
+++ b/sdktests/common_tests_events_request.go
@@ -37,6 +37,10 @@ func (c CommonEventTests) RequestMethodAndHeaders(t *ldtest.T, credential string
 					headersMatcher,
 					c.authorizationHeaderMatcher(credential),
 				))
+
+				if t.Capabilities().Has(servicedef.CapabilityEventGzip) {
+					m.In(t).For("request headers").Assert(request.Headers, Header("Content-Encoding").Should(m.StringContains("gzip")))
+				}
 			})
 		}
 	})

--- a/sdktests/testapi_sdk_events.go
+++ b/sdktests/testapi_sdk_events.go
@@ -42,7 +42,10 @@ type SDKEventSink struct {
 // sink will be attached to this test scope, and also to any of its subtests that are active when the
 // output is generated.
 func NewSDKEventSink(t *ldtest.T) *SDKEventSink {
-	eventsService := mockld.NewEventsService(requireContext(t).sdkKind, t.DebugLogger())
+	eventsService := mockld.NewEventsService(
+		requireContext(t).sdkKind,
+		t.DebugLogger(),
+		t.Capabilities().Has(servicedef.CapabilityEventGzip))
 	eventsEndpoint := requireContext(t).harness.NewMockEndpoint(eventsService, t.DebugLogger(),
 		harness.MockEndpointDescription("events service"))
 

--- a/servicedef/service_params.go
+++ b/servicedef/service_params.go
@@ -30,6 +30,7 @@ const (
 	CapabilityAutoEnvAttributes  = "auto-env-attributes"
 	CapabilityMigrations         = "migrations"
 	CapabilityEventSampling      = "event-sampling"
+	CapabilityEventGzip          = "event-gzip"
 	CapabilityETagCaching        = "etag-caching"
 	CapabilityInlineContext      = "inline-context"
 	CapabilityAnonymousRedaction = "anonymous-redaction"


### PR DESCRIPTION
This was already reviewed at https://github.com/launchdarkly/sdk-test-harness/pull/204 

Now that we have some more consensus on the direction of this project, I think it's okay to merge this into main and cut a release.