### PR TITLE
feat: Add tests for omit anonymous contexts.

### DIFF
--- a/docs/service_spec.md
+++ b/docs/service_spec.md
@@ -180,6 +180,12 @@ If specified, the SDK will send a `tls` object containing a `customCAFile` prope
 a file path containing one or more PEM-encoded x509 certificates. The SDK should configure its TLS stack to use
 this file when verifying the peer's certificate chain. 
 
+### Capability `"omit-anonymous-contexts"`
+
+This means the SDK supports filtering anonymous contexts out of index and identify events.
+
+When this capability is set a subset of tests will set the "omitAnonymousContexts" of the events configuration to true.
+
 ### Stop test service: `DELETE /`
 
 The test harness sends this request at the end of a test run if you have specified `--stop-service-at-end` on the [command line](./running.md). The test service should simply quit. This is a convenience so CI scripts can simply start the test service in the background and assume it will be stopped for them.

--- a/framework/harness/mock_endpoints.go
+++ b/framework/harness/mock_endpoints.go
@@ -6,6 +6,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"io"
 	"io/ioutil"
 	"net"
 	"net/http"
@@ -177,7 +178,7 @@ func (m *mockEndpointsManager) serveHTTP(w http.ResponseWriter, r *http.Request)
 
 	var body []byte
 	if r.Body != nil {
-		data, err := ioutil.ReadAll(r.Body)
+		data, err := io.ReadAll(r.Body)
 		_ = r.Body.Close()
 		if err != nil {
 			m.logger.Printf("Unexpected error trying to read request body: %s", err)

--- a/framework/harness/mock_endpoints.go
+++ b/framework/harness/mock_endpoints.go
@@ -7,7 +7,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net"
 	"net/http"
 	"net/url"
@@ -197,7 +196,7 @@ func (m *mockEndpointsManager) serveHTTP(w http.ResponseWriter, r *http.Request)
 	url.Path = path
 	transformedReq.URL = &url
 	if body != nil {
-		transformedReq.Body = ioutil.NopCloser(bytes.NewBuffer(body))
+		transformedReq.Body = io.NopCloser(bytes.NewBuffer(body))
 	}
 
 	incoming := &IncomingRequestInfo{

--- a/framework/harness/test_service.go
+++ b/framework/harness/test_service.go
@@ -6,7 +6,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net/http"
 	"strings"
 	"sync"
@@ -123,7 +122,7 @@ func doRequest(method, url string, body []byte) ([]byte, http.Header, error) {
 	}
 	var respBody []byte
 	if resp.Body != nil {
-		respBody, err = ioutil.ReadAll(resp.Body)
+		respBody, err = io.ReadAll(resp.Body)
 		if err != nil {
 			return nil, nil, err
 		}

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/launchdarkly/sdk-test-harness/v2
 
-go 1.18
+go 1.19
 
 require (
 	github.com/fatih/color v1.13.0

--- a/mockld/callback_helpers.go
+++ b/mockld/callback_helpers.go
@@ -3,7 +3,7 @@ package mockld
 import (
 	"bytes"
 	"encoding/json"
-	"io/ioutil"
+	"io"
 	"net/http"
 
 	"github.com/launchdarkly/sdk-test-harness/v2/framework"
@@ -34,7 +34,7 @@ func (c *callbackService) addPath(path string, handler func(*json.Decoder) (inte
 		var requestDecoder *json.Decoder
 		var body []byte
 		if r.Body != nil {
-			body, _ = ioutil.ReadAll(r.Body)
+			body, _ = io.ReadAll(r.Body)
 			_ = r.Body.Close()
 			requestDecoder = json.NewDecoder(bytes.NewBuffer(body))
 		}

--- a/mockld/events_service.go
+++ b/mockld/events_service.go
@@ -3,7 +3,7 @@ package mockld
 import (
 	"compress/gzip"
 	"encoding/json"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"strings"
 	"sync"
@@ -120,7 +120,7 @@ func (s *EventsService) postEvents(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusMethodNotAllowed)
 		return
 	}
-	data, err := ioutil.ReadAll(r.Body)
+	data, err := io.ReadAll(r.Body)
 	if err != nil {
 		w.WriteHeader(http.StatusInternalServerError)
 		s.logger.Printf("Unable to read request body")

--- a/mockld/polling_service_test.go
+++ b/mockld/polling_service_test.go
@@ -3,7 +3,7 @@ package mockld
 import (
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -104,7 +104,7 @@ func doPollingServiceTests(
 
 		require.Equal(t, 200, resp.StatusCode, "got error status for %s %s", req.Method, req.URL)
 
-		data, err := ioutil.ReadAll(resp.Body)
+		data, err := io.ReadAll(resp.Body)
 		require.NoError(t, err)
 		m.In(t).Assert(data, m.JSONStrEqual(string(initialData.Serialize())))
 	})

--- a/mockld/roku.go
+++ b/mockld/roku.go
@@ -3,7 +3,7 @@ package mockld
 import (
 	"encoding/base64"
 	"encoding/json"
-	"io/ioutil"
+	"io"
 	"net/http"
 )
 
@@ -50,7 +50,7 @@ func (srv *RokuServer) ServeHandshake(baseWriter http.ResponseWriter, req *http.
 	// Save mobile key for use when client connects to stream
 	srv.mobileKey = &authorization
 
-	body, err := ioutil.ReadAll(req.Body)
+	body, err := io.ReadAll(req.Body)
 	if err != nil {
 		baseWriter.WriteHeader(http.StatusBadRequest)
 		return

--- a/sdktests/server_side_events_index.go
+++ b/sdktests/server_side_events_index.go
@@ -169,9 +169,13 @@ func doServerSideIndexEventTests(t *ldtest.T) {
 				return NewSDKClient(t, dataSource, WithEventsConfig(eventsConfig)), events
 			}
 
-			t.Run(fmt.Sprintf("does not emit any events for single context which is anonymous for %s event", scenario.name), func(t *ldtest.T) {
+			t.Run(fmt.Sprintf("does not emit any events for single context which is anonymous for %s event",
+				scenario.name), func(t *ldtest.T) {
 				client, events := setup()
-				anonSingleContext := ldcontext.NewBuilder("anon-context1").Kind("user").Anonymous(true).Build()
+				anonSingleContext := ldcontext.NewBuilder("anon-context1").
+					Kind("user").
+					Anonymous(true).
+					Build()
 				scenario.action(t, client, anonSingleContext)
 				client.FlushEvents(t)
 				payload := events.ExpectAnalyticsEvents(t, defaultEventTimeout)
@@ -179,10 +183,18 @@ func doServerSideIndexEventTests(t *ldtest.T) {
 				m.In(t).Assert(payload, m.Items(scenario.matcher))
 			})
 
-			t.Run(fmt.Sprintf("does not emit any events for a multi-context where all contexts are anonymous for %s event", scenario.name), func(t *ldtest.T) {
+			t.Run(fmt.Sprintf(
+				"does not emit any events for a multi-context where all contexts are anonymous for %s event",
+				scenario.name), func(t *ldtest.T) {
 				client, events := setup()
-				anonSingleContextA := ldcontext.NewBuilder("anon-context1").Kind("user").Anonymous(true).Build()
-				anonSingleContextB := ldcontext.NewBuilder("other-context1").Kind("other").Anonymous(true).Build()
+				anonSingleContextA := ldcontext.NewBuilder("anon-context1").
+					Kind("user").
+					Anonymous(true).
+					Build()
+				anonSingleContextB := ldcontext.NewBuilder("other-context1").
+					Kind("other").
+					Anonymous(true).
+					Build()
 				anonMultiContext := ldcontext.NewMulti(anonSingleContextA, anonSingleContextB)
 				scenario.action(t, client, anonMultiContext)
 				client.FlushEvents(t)
@@ -191,9 +203,13 @@ func doServerSideIndexEventTests(t *ldtest.T) {
 				m.In(t).Assert(payload, m.Items(scenario.matcher))
 			})
 
-			t.Run(fmt.Sprintf("omits the anonymous contexts from a multi-context for %s event", scenario.name), func(t *ldtest.T) {
+			t.Run(fmt.Sprintf("omits the anonymous contexts from a multi-context for %s event",
+				scenario.name), func(t *ldtest.T) {
 				client, events := setup()
-				anonSingleContext := ldcontext.NewBuilder("anon-context2").Kind("user").Anonymous(true).Build()
+				anonSingleContext := ldcontext.NewBuilder("anon-context2").
+					Kind("user").
+					Anonymous(true).
+					Build()
 				nonAnonSingleContext := ldcontext.NewBuilder("other-context2").Kind("other").Build()
 				multiContext := ldcontext.NewMulti(anonSingleContext, nonAnonSingleContext)
 				scenario.action(t, client, multiContext)

--- a/servicedef/sdk_config.go
+++ b/servicedef/sdk_config.go
@@ -56,6 +56,7 @@ type SDKConfigEventParams struct {
 	AllAttributesPrivate    bool                                `json:"allAttributesPrivate,omitempty"`
 	GlobalPrivateAttributes []string                            `json:"globalPrivateAttributes,omitempty"`
 	FlushIntervalMS         o.Maybe[ldtime.UnixMillisecondTime] `json:"flushIntervalMs,omitempty"`
+	OmitAnonymousContexts   bool                                `json:"omitAnonymousContexts,omitempty"`
 }
 
 type SDKConfigPersistentDataStoreParams struct {

--- a/servicedef/service_params.go
+++ b/servicedef/service_params.go
@@ -52,6 +52,8 @@ const (
 	// to use a custom CA certificate. The path to this CA cert is provided to the SDK. The SDK should then configure this
 	// path as the only CA cert in its trust store (rather than adding it to an existing trust store.)
 	CapabilityTLSCustomCA = "tls:custom-ca"
+
+	CapabilityOmitAnonymousContexts = "omit-anonymous-contexts"
 )
 
 type StatusRep struct {


### PR DESCRIPTION
The tests are largely duplicated between identify and index events, but I think this makes it easier to reason about the tests.