### PR TITLE
feat: Add error, heartbeat, and goodbye event tests

### DIFF
--- a/framework/types.go
+++ b/framework/types.go
@@ -58,7 +58,7 @@ type ErrorEvent struct {
 	Reason    string `json:"reason"`
 }
 
-// type heartBeat struct{}
+type Heartbeat struct{}
 
 type Goodbye struct {
 	Reason      string `json:"reason"`

--- a/mockld/streaming_service.go
+++ b/mockld/streaming_service.go
@@ -213,10 +213,18 @@ func (s *StreamingService) PushHeartbeat() {
 	s.PushEvent("heartbeat", framework.Heartbeat{})
 }
 
-func (s *StreamingService) PushError(payloadId, reason string) {
+func (s *StreamingService) PushError(payloadID, reason string) {
 	s.PushEvent("error", framework.ErrorEvent{
-		PayloadID: payloadId,
+		PayloadID: payloadID,
 		Reason:    reason,
+	})
+}
+
+func (s *StreamingService) PushGoodbye(reason string, silent, catastrophe bool) {
+	s.PushEvent("goodbye", framework.Goodbye{
+		Reason:      reason,
+		Silent:      silent,
+		Catastrophe: catastrophe,
 	})
 }
 

--- a/mockld/streaming_service.go
+++ b/mockld/streaming_service.go
@@ -209,6 +209,10 @@ func (s *StreamingService) PushUpdate(namespace, key string, version int, data j
 	s.PushEvent("put-object", eventData)
 }
 
+func (s *StreamingService) PushHeartbeat() {
+	s.PushEvent("heartbeat", framework.Heartbeat{})
+}
+
 func (s *StreamingService) PushPayloadTransferred(state string, version int) {
 	eventData := framework.PayloadTransferred{
 		State:   state,

--- a/mockld/streaming_service.go
+++ b/mockld/streaming_service.go
@@ -213,6 +213,13 @@ func (s *StreamingService) PushHeartbeat() {
 	s.PushEvent("heartbeat", framework.Heartbeat{})
 }
 
+func (s *StreamingService) PushError(payloadId, reason string) {
+	s.PushEvent("error", framework.ErrorEvent{
+		PayloadID: payloadId,
+		Reason:    reason,
+	})
+}
+
 func (s *StreamingService) PushPayloadTransferred(state string, version int) {
 	eventData := framework.PayloadTransferred{
 		State:   state,

--- a/sdktests/common_tests_stream_fdv2.go
+++ b/sdktests/common_tests_stream_fdv2.go
@@ -104,8 +104,8 @@ func (c CommonStreamingTests) UpdatesPreviouslyKnownState(t *ldtest.T) {
 }
 
 func (c CommonStreamingTests) UpdatesAreNotCompleteUntilPayloadTransferredIsSent(t *ldtest.T) {
-	dataBefore := c.makeSDKDataWithFlag("flag-key", 1, initialValue)
-	stream := NewSDKDataSourceWithoutEndpoint(t, dataBefore)
+	data := c.makeSDKDataWithFlag("flag-key", 1, initialValue)
+	stream := NewSDKDataSourceWithoutEndpoint(t, data)
 	streamEndpoint := requireContext(t).harness.NewMockEndpoint(stream.Handler(), t.DebugLogger(),
 		harness.MockEndpointDescription("streaming service"))
 	t.Defer(streamEndpoint.Close)
@@ -118,12 +118,12 @@ func (c CommonStreamingTests) UpdatesAreNotCompleteUntilPayloadTransferredIsSent
 	flagKeyValue := basicEvaluateFlag(t, client, "flag-key", context, defaultValue)
 	m.In(t).Assert(flagKeyValue, m.JSONEqual(initialValue))
 
-	stream.streamingService.PushUpdate("flag", "flag-key", 2, c.makeFlagData("flag-key", 2, updatedValue))
+	stream.streamingService.PushDelete("flag", "flag-key", 2)
 	stream.streamingService.PushUpdate("flag", "new-flag-key", 1, c.makeFlagData("new-flag-key", 1, newInitialValue))
 
 	require.Never(
 		t,
-		checkForUpdatedValue(t, client, "flag-key", context, initialValue, updatedValue, defaultValue),
+		checkForUpdatedValue(t, client, "flag-key", context, initialValue, defaultValue, defaultValue),
 		time.Millisecond*100,
 		time.Millisecond*20,
 		"flag value was updated, but it should not have been",
@@ -139,7 +139,7 @@ func (c CommonStreamingTests) UpdatesAreNotCompleteUntilPayloadTransferredIsSent
 
 	stream.streamingService.PushPayloadTransferred("updated", 2)
 
-	pollUntilFlagValueUpdated(t, client, "flag-key", context, initialValue, updatedValue, defaultValue)
+	pollUntilFlagValueUpdated(t, client, "flag-key", context, initialValue, defaultValue, defaultValue)
 	pollUntilFlagValueUpdated(t, client, "new-flag-key", context, defaultValue, newInitialValue, defaultValue)
 }
 


### PR DESCRIPTION
Expands existing FDv2 streaming tests to include:

- DeleteObject instead of only using PutObjects
- Add test confirming the flag payload version is ignored in lieu of the payload version
- Add test confirming the heartbeat event is ignored
- Add test confirming pending events are discarded when an error occurs
- Add test confirming the SDK disconnects when receiving a goodbye
