### PR TITLE
fix: don't send 'null' when no prereqs present

### DIFF
--- a/mockld/sdk_data.go
+++ b/mockld/sdk_data.go
@@ -78,7 +78,7 @@ type ClientSDKFlag struct {
 	TrackEvents          bool                                `json:"trackEvents"`
 	TrackReason          bool                                `json:"trackReason"`
 	DebugEventsUntilDate o.Maybe[ldtime.UnixMillisecondTime] `json:"debugEventsUntilDate"`
-	Prerequisites        []string                            `json:"prerequisites"`
+	Prerequisites        []string                            `json:"prerequisites,omitempty"`
 }
 
 // ClientSDKFlagWithKey is used only in stream updates, where the key is within the same object.


### PR DESCRIPTION
Currently we send `"prerequisites": null` in the tests that don't deal with prerequisites. While this should be acceptable to SDKs without causing issues, it's not what LaunchDarkly would send (it should omit the array.)

This adds `omitEmpty` to omit the key altogether if it's empty. 

--------

This _did_ catch an implementation bug I had in the .NET client, so it's clearly valuable to test setting properties to null. But I don't think we consistently do that on purpose in the existing tests (could be wrong, didn't audit). 