### PR TITLE
fix: summary events should allow null default value in counter

### DIFF
--- a/sdktests/client_side_events_summary.go
+++ b/sdktests/client_side_events_summary.go
@@ -362,14 +362,14 @@ func doClientSideSummaryBasicPrereqTest(t *ldtest.T) {
 				m.KV("contextKinds", anyContextKindsList()),
 			)),
 			m.KV(prereq2Key, m.AllOf(
-				m.JSONOptProperty("default").Should(m.BeNil()),
+				JSONPropertyNullOrAbsent("default"),
 				m.JSONProperty("counters").Should(m.ItemsInAnyOrder(
 					flagCounter(prereq2Result.Value, prereq2Result.Variation.Value(), prereq2Result.FlagVersion.Value(), 2),
 				)),
 				m.JSONProperty("contextKinds").Should(anyContextKindsList()),
 			)),
 			m.KV(prereq3Key, m.AllOf(
-				m.JSONOptProperty("default").Should(m.BeNil()),
+				JSONPropertyNullOrAbsent("default"),
 				m.JSONProperty("counters").Should(m.ItemsInAnyOrder(
 					flagCounter(prereq3Result.Value, prereq3Result.Variation.Value(), prereq3Result.FlagVersion.Value(), 2),
 				)),

--- a/sdktests/client_side_events_summary.go
+++ b/sdktests/client_side_events_summary.go
@@ -361,17 +361,19 @@ func doClientSideSummaryBasicPrereqTest(t *ldtest.T) {
 				)),
 				m.KV("contextKinds", anyContextKindsList()),
 			)),
-			m.KV(prereq2Key, m.MapOf(
-				m.KV("counters", m.ItemsInAnyOrder(
+			m.KV(prereq2Key, m.AllOf(
+				m.JSONOptProperty("default").Should(m.BeNil()),
+				m.JSONProperty("counters").Should(m.ItemsInAnyOrder(
 					flagCounter(prereq2Result.Value, prereq2Result.Variation.Value(), prereq2Result.FlagVersion.Value(), 2),
 				)),
-				m.KV("contextKinds", anyContextKindsList()),
+				m.JSONProperty("contextKinds").Should(anyContextKindsList()),
 			)),
-			m.KV(prereq3Key, m.MapOf(
-				m.KV("counters", m.ItemsInAnyOrder(
+			m.KV(prereq3Key, m.AllOf(
+				m.JSONOptProperty("default").Should(m.BeNil()),
+				m.JSONProperty("counters").Should(m.ItemsInAnyOrder(
 					flagCounter(prereq3Result.Value, prereq3Result.Variation.Value(), prereq3Result.FlagVersion.Value(), 2),
 				)),
-				m.KV("contextKinds", anyContextKindsList()),
+				m.JSONProperty("contextKinds").Should(anyContextKindsList()),
 			)),
 		)),
 	)


### PR DESCRIPTION
When testing dotnet client, I came across the behavior that a `null` default value will end up in a summary event counter as the key `"default": null`.

This isn't accepted by the test harness, even though our JSON standard mandates that null and an omitted property be treated equivalently.

The SDK could fix this by omitting the property - but the harness should also accept this. 


-----

I'm open to hearing "no, the harness should not accept this."