### PR TITLE
chore: Elevate payload filter to top level data system property

### DIFF
--- a/docs/service_spec.md
+++ b/docs/service_spec.md
@@ -157,8 +157,7 @@ This means that the SDK has a type corresponding to the old-style user model, an
 This means that the SDK supports the "filter" configuration option for streaming/polling data sources,
 and will send a `?filter=name` query parameter along with streaming/polling requests.
 
-For tests that involve filtering, the test harness will set the `filter` property of the `streaming` or `polling` configuration
-object. The property will either be omitted if no filter is requested, or a non-empty string if requested.
+For tests that involve filtering, the test harness will set the `payloadFilter` property of the `dataSystem` configuration object. The property will either be omitted if no filter is requested, or a non-empty string if requested.
 
 #### Capability `"filtering-strict"`
 
@@ -248,11 +247,9 @@ A `POST` request indicates that the test harness wants to start an instance of t
   * `streaming` (object, optional): Enables streaming mode and provides streaming configuration. If this is omitted _and_ `polling` is also omitted, then the test service can use streaming as a default; but if `streaming` is omitted and `polling` is provided, then streaming should be disabled. Properties are:
     * `baseUri` (string, optional): The base URI for the streaming service. For contract testing, this will be the URI of a simulated streaming endpoint that the test harness provides. If it is null or an empty string, the SDK should default to the value from `serviceEndpoints.streaming` if any, or if that is not set either, connect to the real LaunchDarkly streaming service.
     * `initialRetryDelayMs` (number, optional): The initial stream retry delay in milliseconds. If omitted, use the SDK's default value.
-    * `filter` (string, optional): The key for a filtered environment. If omitted, do not configure the SDK with a filter.
   * `polling` (object, optional): Enables polling mode and provides polling configuration. Properties are:
     * `baseUri` (string, optional): The base URI for the polling service. For contract testing, this will be the URI of a simulated polling endpoint that the test harness provides. If it is null or an empty string, the SDK should default to the value from `serviceEndpoints.polling` if any, or if that is not set either, connect to the real LaunchDarkly polling service.
     * `pollIntervalMs` (number, optional): The polling interval in milliseconds. If omitted, use the SDK's default value. For mobile SDKs that are configured with both streaming and polling enabled, this should be interpreted as the _background_ polling interval.
-    * `filter` (string, optional): The key for a filtered environment. If omitted, do not configure the SDK with a filter.
   * `events` (object, optional): Enables events and provides events configuration, or disables events if it is omitted or null. Properties are:
     * `baseUri` (string, optional): The base URI for the events service. For contract testing, this will be the URI of a simulated event-recorder endpoint that the test harness provides.  If it is null or an empty string, the SDK should default to the value from `serviceEndpoints.events` if any, or if that is not set either, connect to the real LaunchDarkly events service.
     * `capacity` (number, optional): If specified and greater than zero, the event buffer capacity should be set to this value.

--- a/sdktests/common_tests_poll_request.go
+++ b/sdktests/common_tests_poll_request.go
@@ -131,9 +131,9 @@ func (c CommonPollingTests) RequestURLPath(t *ldtest.T, pathMatcher func(flagReq
 
 								_ = NewSDKClient(t, c.baseSDKConfigurationPlus(
 									c.withFlagRequestMethod(method),
+									WithPayloadFilter(filter),
 									WithPollingConfig(servicedef.SDKConfigPollingParams{
 										BaseURI: pollURI,
-										Filter:  filter.Maybe,
 									}),
 								)...)
 

--- a/sdktests/common_tests_stream_request.go
+++ b/sdktests/common_tests_stream_request.go
@@ -78,9 +78,9 @@ func (c CommonStreamingTests) RequestURLPath(t *ldtest.T, pathMatcher func(flagR
 
 								_ = NewSDKClient(t, c.baseSDKConfigurationPlus(
 									append(configurers,
+										WithPayloadFilter(filter),
 										WithStreamingConfig(servicedef.SDKConfigStreamingParams{
 											BaseURI: streamURI,
-											Filter:  filter.Maybe,
 										}),
 										c.withFlagRequestMethod(method),
 									)...)...)

--- a/sdktests/testapi_sdk_client.go
+++ b/sdktests/testapi_sdk_client.go
@@ -74,6 +74,17 @@ func WithEventsConfig(eventsConfig servicedef.SDKConfigEventParams) SDKConfigure
 	})
 }
 
+// WithPayloadFilter is used to with StartSDKClient to apply a non-default payload filter configuration
+func WithPayloadFilter(filter environmentFilter) SDKConfigurer {
+	return helpers.ConfigOptionFunc[servicedef.SDKConfigParams](func(configOut *servicedef.SDKConfigParams) error {
+		dataSystem := configOut.DataSystem.OrElse(servicedef.DataSystem{})
+		dataSystem.PayloadFilter = filter.Maybe
+
+		configOut.DataSystem = o.Some(dataSystem)
+		return nil
+	})
+}
+
 // WithPollingConfig is used with StartSDKClient to specify a non-default polling configuration.
 func WithPollingConfig(pollingConfig servicedef.SDKConfigPollingParams) SDKConfigurer {
 	return helpers.ConfigOptionFunc[servicedef.SDKConfigParams](func(configOut *servicedef.SDKConfigParams) error {

--- a/servicedef/sdk_config.go
+++ b/servicedef/sdk_config.go
@@ -42,6 +42,7 @@ type DataSystem struct {
 	StoreMode     DataStoreMode          `json:"storeMode"`
 	Initializers  []DataInitializer      `json:"initializers"`
 	Synchronizers o.Maybe[Synchronizers] `json:"synchronizers,omitempty"`
+	PayloadFilter o.Maybe[string]        `json:"payloadFilter,omitempty"`
 }
 
 type DataStore struct {
@@ -76,13 +77,11 @@ type SDKConfigServiceEndpointsParams struct {
 type SDKConfigStreamingParams struct {
 	BaseURI             string                              `json:"baseUri,omitempty"`
 	InitialRetryDelayMS o.Maybe[ldtime.UnixMillisecondTime] `json:"initialRetryDelayMs,omitempty"`
-	Filter              o.Maybe[string]                     `json:"filter,omitempty"`
 }
 
 type SDKConfigPollingParams struct {
 	BaseURI        string                              `json:"baseUri,omitempty"`
 	PollIntervalMS o.Maybe[ldtime.UnixMillisecondTime] `json:"pollIntervalMs,omitempty"`
-	Filter         o.Maybe[string]                     `json:"filter,omitempty"`
 }
 
 type SDKConfigEventParams struct {


### PR DESCRIPTION
In FDv1, the payload filter was defined directly on the streaming or
polling configuration. While  redundant then, it becomes even more so
with the FDv2 change.

To ensure we are thinking about the payload filter in the same way the
SDK handles applying it, we are moving the filter up to act as a data
system wide option.
