### PR TITLE
feat: Add `track-hooks` capability

### DIFF
--- a/docs/service_spec.md
+++ b/docs/service_spec.md
@@ -200,6 +200,23 @@ A test hook must:
       * `stage` (string, optional): If executing a stage, for example `beforeEvaluation`, this should be the stage.
   - Return data from the stages as specified via the `data` configuration. For instance the return value from the `beforeEvaluation` hook should be `data['beforeEvaluation']` merged with the input data for the stage.
 
+#### Capability `"track-hooks"`
+
+This means that the SDK has support for hooks and has the ability to register track hooks.
+
+For a test service to support hooks testing it must support a `test-hook`. The configuration will specify registering one or more `test-hooks`.
+
+A test hook must:
+  - Implement the SDK hook interface.
+  - Whenever an evaluation stage is called POST information about that call to the `callbackUrl` of the hook.
+  - The POST should not take place if the hook was configured to return/throw an error for that stage (`errors` object in the configuration).
+    - The payload is an object with the following properties:
+      * `trackSeriesContext` (object, optional): If a track stage was executed, then this should be the associated context.
+        * `key` (string, required): The key for the event being tracked.
+        * `context` (object, required): The context associated with the track operation.
+        * `data` (any): The data associated with the track operation.
+        * `metricValue` (number, optional): The metric value associated with the track operation.
+      * `stage` (string, optional): If executing a stage, for example `afterTrack`, this should be the stage.
 
 #### Capability `"tls:verify-peer"`
 

--- a/sdktests/common_tests_hooks.go
+++ b/sdktests/common_tests_hooks.go
@@ -20,6 +20,11 @@ import (
 )
 
 func doCommonHooksTests(t *ldtest.T) {
+	t.Run("evaluation", doEvaluationSeriesTests)
+	t.Run("track", doTrackSeriesTests)
+}
+
+func doEvaluationSeriesTests(t *ldtest.T) {
 	t.RequireCapability(servicedef.CapabilityEvaluationHooks)
 	t.Run("executes beforeEvaluation stage", executesBeforeEvaluationStage)
 	t.Run("executes afterEvaluation stage", executesAfterEvaluationStage)
@@ -28,6 +33,12 @@ func doCommonHooksTests(t *ldtest.T) {
 	t.Run("data propagates from before to after", beforeEvaluationDataPropagatesToAfter)
 	t.RequireCapability(servicedef.CapabilityMigrations)
 	t.Run("data propagates from before to after for migrations", beforeEvaluationDataPropagatesToAfterMigration)
+}
+
+func doTrackSeriesTests(t *ldtest.T) {
+	t.RequireCapability(servicedef.CapabilityTrackHooks)
+	t.Run("executes afterTrack stage", executesAfterTrackStage)
+	t.Run("a hook error prevents afterTrack stage", errorInHookPreventsAfterTrackStage)
 }
 
 func executesBeforeEvaluationStage(t *ldtest.T) {
@@ -94,6 +105,47 @@ func variationTestParams(detail bool) []VariationParameters {
 			defaultValue: ldvalue.ObjectBuild().Build(),
 			valueType:    servicedef.ValueTypeAny,
 			detail:       detail,
+		},
+	}
+}
+
+type TrackParameters struct {
+	Name string
+	servicedef.CustomEventParams
+}
+
+func trackTestParams(context o.Maybe[ldcontext.Context]) []TrackParameters {
+	return []TrackParameters{{
+		Name: "no metricValue and no data",
+		CustomEventParams: servicedef.CustomEventParams{
+			EventKey: "custom-event-1",
+			Context:  context,
+		},
+	},
+		{
+			Name: "metricValue and no data",
+			CustomEventParams: servicedef.CustomEventParams{
+				EventKey:    "custom-event-2",
+				Context:     context,
+				MetricValue: o.Some(11111.00),
+			},
+		},
+		{
+			Name: "no metricValue and data",
+			CustomEventParams: servicedef.CustomEventParams{
+				EventKey: "custom-event-3",
+				Context:  context,
+				Data:     ldvalue.ObjectBuild().SetBool("boolData", true).SetString("stringData", "value").Build(),
+			},
+		},
+		{
+			Name: "metricValue and data",
+			CustomEventParams: servicedef.CustomEventParams{
+				EventKey:    "custom-event-4",
+				Context:     context,
+				MetricValue: o.Some(11111.00),
+				Data:        ldvalue.ObjectBuild().SetBool("boolData", true).SetString("stringData", "value").Build(),
+			},
 		},
 	}
 }
@@ -359,6 +411,65 @@ func errorInBeforeStageDoesNotAffectAfterStage(t *ldtest.T) {
 		assert.Equal(t, 0, len(call.EvaluationSeriesData.Value()), "HOOKS:1.3.7.1: Since "+
 			"beforeEvaluation should have failed, the data passed to afterEvaluation should be empty")
 	}
+}
+
+func executesAfterTrackStage(t *ldtest.T) {
+	hookName := "executesAfterTrackStage"
+	context := ldcontext.New("user-key")
+	flagContext := o.Some(context)
+	configurers := []SDKConfigurer{}
+
+	if t.Capabilities().Has(servicedef.CapabilityClientSide) {
+		configurers = append(configurers, WithClientSideInitialContext(context))
+		flagContext = o.None[ldcontext.Context]()
+	}
+
+	client, hooks := createClientForHooks(t, []string{hookName}, nil, configurers...)
+	defer hooks.Close()
+
+	testParams := trackTestParams(flagContext)
+
+	for _, testParam := range testParams {
+		t.Run(testParam.Name, func(t *ldtest.T) {
+			client.SendCustomEvent(t, testParam.CustomEventParams)
+
+			hooks.ExpectCall(t, hookName, func(payload servicedef.HookExecutionPayload) bool {
+				if payload.Stage.Value() == servicedef.AfterTrack {
+					hookContext := payload.TrackSeriesContext.Value()
+					assert.Equal(t, testParam.EventKey, hookContext.Key)
+					assert.Equal(t, context, hookContext.Context)
+					assert.Equal(t, testParam.MetricValue, hookContext.MetricValue)
+					assert.Equal(t, testParam.Data, hookContext.Data.Value())
+					return true
+				}
+				return false
+			})
+		})
+	}
+}
+
+func errorInHookPreventsAfterTrackStage(t *ldtest.T) {
+	hookName := "doesNotExecuteAfterTrackStage"
+	context := ldcontext.New("user-key")
+	flagContext := o.Some(context)
+	configurers := []SDKConfigurer{}
+
+	if t.Capabilities().Has(servicedef.CapabilityClientSide) {
+		configurers = append(configurers, WithClientSideInitialContext(context))
+		flagContext = o.None[ldcontext.Context]()
+	}
+
+	client, hooks := createClientForHooksWithErrors(t, []string{hookName}, nil, map[servicedef.HookStage]o.Maybe[string]{
+		servicedef.AfterTrack: o.Some("something went wrong"),
+	}, configurers...)
+	defer hooks.Close()
+
+	client.SendCustomEvent(t, servicedef.CustomEventParams{
+		EventKey: "custom-event",
+		Context:  flagContext,
+	})
+	client.FlushEvents(t)
+	hooks.ExpectNoCall(t, hookName)
 }
 
 func createClientForHooks(t *ldtest.T, instances []string,

--- a/sdktests/testapi_hooks.go
+++ b/sdktests/testapi_hooks.go
@@ -15,6 +15,7 @@ import (
 )
 
 const hookReceiveTimeout = time.Second * 5
+const hookWaitForNoCallTimeout = time.Second * 1
 
 type HookInstance struct {
 	name        string
@@ -83,6 +84,11 @@ func (h *Hooks) ExpectCall(t *ldtest.T, hookName string,
 			break
 		}
 	}
+}
+
+func (h *Hooks) ExpectNoCall(t *ldtest.T, hookName string) {
+	maybeValue := helpers.TryReceive(h.instances[hookName].hookService.CallChannel, hookWaitForNoCallTimeout)
+	assert.False(t, maybeValue.IsDefined(), "Expected 0 hook calls, got 1")
 }
 
 // ExpectAtLeastOneCallForEachHook waits for a single call from N hooks. If there are fewer calls recorded,

--- a/servicedef/command_params.go
+++ b/servicedef/command_params.go
@@ -193,18 +193,29 @@ type HookStage string
 const (
 	BeforeEvaluation HookStage = "beforeEvaluation"
 	AfterEvaluation  HookStage = "afterEvaluation"
+	AfterTrack       HookStage = "afterTrack"
 )
 
 type EvaluationSeriesContext struct {
-	FlagKey      string            `json:"flagKey"`
-	Context      ldcontext.Context `json:"context"`
-	DefaultValue ldvalue.Value     `json:"defaultValue"`
-	Method       string            `json:"method"`
+	FlagKey       string            `json:"flagKey"`
+	Context       ldcontext.Context `json:"context"`
+	DefaultValue  ldvalue.Value     `json:"defaultValue"`
+	Method        string            `json:"method"`
+	EnvironmentID o.Maybe[string]   `json:"environmentId"`
+}
+
+type TrackSeriesContext struct {
+	Context       ldcontext.Context      `json:"context"`
+	Key           string                 `json:"key"`
+	MetricValue   o.Maybe[float64]       `json:"metricValue"`
+	Data          o.Maybe[ldvalue.Value] `json:"data"`
+	EnvironmentID o.Maybe[string]        `json:"environmentId"`
 }
 
 type HookExecutionPayload struct {
 	EvaluationSeriesContext o.Maybe[EvaluationSeriesContext]  `json:"evaluationSeriesContext"`
 	EvaluationSeriesData    o.Maybe[map[string]ldvalue.Value] `json:"evaluationSeriesData"`
 	EvaluationDetail        o.Maybe[EvaluateFlagResponse]     `json:"evaluationDetail"`
+	TrackSeriesContext      o.Maybe[TrackSeriesContext]       `json:"trackSeriesContext"`
 	Stage                   o.Maybe[HookStage]                `json:"stage"`
 }

--- a/servicedef/service_params.go
+++ b/servicedef/service_params.go
@@ -40,6 +40,7 @@ const (
 	CapabilityAnonymousRedaction          = "anonymous-redaction"
 	CapabilityPollingGzip                 = "polling-gzip"
 	CapabilityEvaluationHooks             = "evaluation-hooks"
+	CapabilityTrackHooks                  = "track-hooks"
 	CapabilityClientPrereqEvents          = "client-prereq-events"
 	CapabilityPersistentDataStoreRedis    = "persistent-data-store-redis"
 	CapabilityPersistentDataStoreConsul   = "persistent-data-store-consul"


### PR DESCRIPTION
**Requirements**

- [x] I have added test coverage for new or changed functionality
- [x] I have followed the repository's [pull request submission guidelines](../blob/master/CONTRIBUTING.md#submitting-pull-requests)
- [x] I have validated my changes against all supported platform versions

**Describe the solution you've provided**

Added contract tests for `track-hooks` capability
This changes the old `hooks` test prefix name to `hooks/evaluation` and adds an additional prefix name of `hooks/track`.  A search of all existing code does not show any current exclusions for the `hooks` prefix, so this should not be a breaking change.
