### PR TITLE
fix: Only use h.RequireNever, not require.Never.

### DIFF
--- a/sdktests/common_tests_stream_updates.go
+++ b/sdktests/common_tests_stream_updates.go
@@ -86,7 +86,7 @@ func (c CommonStreamingTests) Updates(t *ldtest.T) {
 					h.RequireNever(
 						t,
 						checkForUpdatedValue(t, client, flagKey, context, valueBefore, expectedValueIfUpdated, defaultValue),
-						time.Millisecond*200,
+						time.Millisecond*100,
 						time.Millisecond*20,
 						"flag value was updated, but it should not have been",
 					)

--- a/sdktests/common_tests_stream_updates.go
+++ b/sdktests/common_tests_stream_updates.go
@@ -18,7 +18,6 @@ import (
 	"github.com/launchdarkly/go-sdk-common/v3/ldvalue"
 
 	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 )
 
 func (c CommonStreamingTests) Updates(t *ldtest.T) {
@@ -84,10 +83,10 @@ func (c CommonStreamingTests) Updates(t *ldtest.T) {
 				if shouldApply {
 					pollUntilFlagValueUpdated(t, client, flagKey, context, valueBefore, expectedValueIfUpdated, defaultValue)
 				} else {
-					require.Never(
+					h.RequireNever(
 						t,
 						checkForUpdatedValue(t, client, flagKey, context, valueBefore, expectedValueIfUpdated, defaultValue),
-						time.Millisecond*100,
+						time.Millisecond*200,
 						time.Millisecond*20,
 						"flag value was updated, but it should not have been",
 					)
@@ -141,7 +140,7 @@ func (c CommonStreamingTests) Updates(t *ldtest.T) {
 					if shouldApply {
 						pollUntilFlagValueUpdated(t, client, flagKey, context, valueBefore, valueAfter, defaultValue)
 					} else {
-						require.Never(
+						h.RequireNever(
 							t,
 							checkForUpdatedValue(t, client, flagKey, context, valueBefore, expectedValueIfUpdated, defaultValue),
 							time.Millisecond*100,
@@ -208,7 +207,7 @@ func (c CommonStreamingTests) Updates(t *ldtest.T) {
 					// A delete for an unknown segment should be persisted by the SDK so it knows this version was
 					// deleted. A subsequent update for the same segment with an equal or lower version should be ignored.
 					stream.StreamingService().PushUpdate("segments", segmentKey, jsonhelpers.ToJSON(segment))
-					require.Never(
+					h.RequireNever(
 						t,
 						checkForUpdatedValue(t, client, flagKey, context, valueBefore, valueAfter, defaultValue),
 						time.Millisecond*100,

--- a/sdktests/server_side_persistence_base.go
+++ b/sdktests/server_side_persistence_base.go
@@ -175,7 +175,7 @@ func (s *ServerSidePersistentTests) Run(t *ldtest.T) {
 
 		client := NewSDKClient(t, persistence)
 
-		require.Never(
+		h.RequireNever(
 			t,
 			checkForUpdatedValue(t, client, "flag-key", ldcontext.New("user-key"),
 				ldvalue.String("default"), ldvalue.String("fallthrough"), ldvalue.String("default")),


### PR DESCRIPTION
The `require.Never` method uses goroutines internally which results in race conditions with assertions that are using http requests. In order to prevent this we have `h.RequireNever` which is a replacement that does condition checks synchronously.

The tests that used `require.Never` would periodically fail. When running these tests locally the rate of failure had become quite high. It is unclear what changed to make the failures more pronounced, but the tests are stabilized with this change.