### PR TITLE
feat: Add test count summary to display total and skipped tests (#307)

### DIFF
--- a/framework/ldtest/test_logger.go
+++ b/framework/ldtest/test_logger.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"os"
 	"strings"
+	"sync"
 
 	"github.com/launchdarkly/sdk-test-harness/v2/framework"
 	"github.com/launchdarkly/sdk-test-harness/v2/framework/helpers"
@@ -42,6 +43,51 @@ type ConsoleTestLogger struct {
 
 type MultiTestLogger struct {
 	Loggers []TestLogger
+}
+
+type CountingTestLogger struct {
+	wrapped      TestLogger
+	totalTests   int
+	skippedTests int
+	mu           sync.Mutex
+}
+
+func NewCountingTestLogger(wrapped TestLogger) *CountingTestLogger {
+	return &CountingTestLogger{
+		wrapped: wrapped,
+	}
+}
+
+func (c *CountingTestLogger) TestStarted(id TestID) {
+	c.mu.Lock()
+	c.totalTests++
+	c.mu.Unlock()
+	c.wrapped.TestStarted(id)
+}
+
+func (c *CountingTestLogger) TestError(id TestID, err error) {
+	c.wrapped.TestError(id, err)
+}
+
+func (c *CountingTestLogger) TestFinished(id TestID, result TestResult, debugOutput framework.CapturedOutput) {
+	c.wrapped.TestFinished(id, result, debugOutput)
+}
+
+func (c *CountingTestLogger) TestSkipped(id TestID, reason string) {
+	c.mu.Lock()
+	c.skippedTests++
+	c.mu.Unlock()
+	c.wrapped.TestSkipped(id, reason)
+}
+
+func (c *CountingTestLogger) EndLog(results Results) error {
+	return c.wrapped.EndLog(results)
+}
+
+func (c *CountingTestLogger) GetCounts() (total, skipped int) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return c.totalTests, c.skippedTests
 }
 
 func (c ConsoleTestLogger) TestStarted(id TestID) {

--- a/main.go
+++ b/main.go
@@ -79,10 +79,17 @@ func run(params commandParams) (*ldtest.Results, error) {
 		}}
 	}
 
-	results := sdktests.RunSDKTestSuite(harness, params.filters, testLogger)
+	countingLogger := ldtest.NewCountingTestLogger(testLogger)
+	testLogger = countingLogger
+
+	results := sdktests.RunSDKTestSuite(harness, params.filters, countingLogger)
 
 	fmt.Println()
 	logErr := testLogger.EndLog(results)
+
+	total, skipped := countingLogger.GetCounts()
+	fmt.Printf("Test Summary: %d total, %d skipped, %d ran\n", total, skipped, total-skipped)
+	fmt.Println()
 
 	if params.stopServiceAtEnd {
 		fmt.Println("Stopping test service")


### PR DESCRIPTION
## Summary

Adds a test count summary that displays at the end of each test run showing the total number of tests attempted, how many were skipped, and how many actually ran.

## Changes

- **New `CountingTestLogger` wrapper** (`framework/ldtest/test_logger.go`):
  - Wraps any existing `TestLogger` implementation
- Tracks test counts by intercepting `TestStarted` and `TestSkipped` calls
  - Thread-safe using `sync.Mutex` for concurrent test execution
  - Provides `GetCounts()` method to retrieve counts

- **Updated test execution** (`main.go`):
  - Wraps the configured test logger with `CountingTestLogger`
- Prints summary after test completion: `Test Summary: X total, Y skipped, Z ran`
  - Summary appears regardless of pass/fail status

## Example Output

```
All tests passed
Test Summary: 150 total, 12 skipped, 138 ran
```

## Important Review Points

1. **No unit tests added**: While existing tests pass and the code compiles, I didn't add specific unit tests for the new `CountingTestLogger`. Consider whether these should be added.

2. **Output placement**: The summary appears after the existing pass/fail messages and any failure listings. Verify this placement meets expectations.

3. **Count interpretation**: 
   - "Total" = all tests that were attempted (called `TestStarted`)
- "Skipped" = tests filtered out or explicitly skipped (called `TestSkipped`)
   - "Ran" = Total - Skipped

4. **Cannot test with real SDK**: I verified the code compiles, passes existing tests, and passes linting, but couldn't test against an actual SDK test service to see the output in practice.

---

**Requirements**

- [ ] I have added test coverage for new or changed functionality *(No unit tests added for CountingTestLogger)*
- [x] I have followed the repository's [pull request submission guidelines](../blob/master/CONTRIBUTING.md#submitting-pull-requests)
- [x] I have validated my changes against all supported platform versions *(Code compiles, existing tests pass, linting passes)*

**Related issues**

Requested by rlamb@launchdarkly.com in Slack thread: https://launchdarkly.slack.com/archives/C03DEV5CMFD/p1761927792275089

**Describe the solution you've provided**

Implemented a transparent wrapper (`CountingTestLogger`) that tracks test counts by intercepting `TestStarted` and `TestSkipped` calls. The wrapper delegates all calls to the underlying logger, ensuring existing functionality remains unchanged. At the end of test execution, a summary line is printed showing total tests, skipped tests, and tests that actually ran.

**Describe alternatives you've considered**

1. **Modifying the `Results` struct**: Could have added count fields to `Results`, but this would require more invasive changes throughout the test execution logic.

2. **Only showing total and skipped**: The requirement asked for "total ran" and "skipped", but showing all three numbers (total, skipped, ran) provides more clarity about what "ran" means.

3. **Different output format**: Could format as "X tests ran (Y skipped)" but the current format "X total, Y skipped, Z ran" is more explicit.

**Additional context**

Link to Devin run:
https://app.devin.ai/sessions/61b07c9217f54e62848d32fc3b5136b1

Requested by: rlamb@launchdarkly.com

---------

**Requirements**

- [ ] I have added test coverage for new or changed functionality
- [ ] I have followed the repository's [pull request submission guidelines](../blob/master/CONTRIBUTING.md#submitting-pull-requests)
- [ ] I have validated my changes against all supported platform versions

**Related issues**

Provide links to any issues in this repository or elsewhere relating to this pull request.

**Describe the solution you've provided**

Provide a clear and concise description of what you expect to happen.

**Describe alternatives you've considered**

Provide a clear and concise description of any alternative solutions or features you've considered.

**Additional context**

Add any other context about the pull request here.
