### PR TITLE
feat: adds long running tests for polling intervals

### DIFF
--- a/sdktests/client_side_poll_all.go
+++ b/sdktests/client_side_poll_all.go
@@ -13,6 +13,9 @@ import (
 
 func doClientSidePollTests(t *ldtest.T) {
 	t.Run("requests", doClientSidePollRequestTest)
+	t.Run("interval", func(t *ldtest.T) {
+		doPollIntervalTests(t, WithCredential("my-sdk-key"))
+	})
 }
 
 func doClientSidePollRequestTest(t *ldtest.T) {

--- a/sdktests/common_tests_poll_base.go
+++ b/sdktests/common_tests_poll_base.go
@@ -7,9 +7,9 @@ import (
 // CommonPollingTests groups together polling-related test methods that are shared between server-side
 // and client-side.
 //
-// Currently we do not have any tests that actually test *repeated* polling. This is because the SDKs
-// enforce minimum polling intervals that would cause the tests to take a very long time. Therefore,
-// the current tests only cover the behavior of the initial poll request.
+// Most tests only cover the behavior of the initial poll request. Long-running tests that verify
+// repeated polling at the configured interval (default 30s, minimum clamp, custom 60s) are in
+// common_tests_poll_interval.go and require -enable-long-running-tests.
 type CommonPollingTests struct {
 	commonTestsBase
 }

--- a/sdktests/common_tests_poll_interval.go
+++ b/sdktests/common_tests_poll_interval.go
@@ -28,7 +28,8 @@ func (c CommonPollingTests) pollIntervals(t *ldtest.T) struct{ Default, Min time
 	panic("pollIntervals: test service has neither server-side nor client-side capability")
 }
 
-// Requires -enable-long-running-tests. Only runs when client-side or server-side-polling capability is present.
+// PollingIntervalTests requires -enable-long-running-tests and only runs when client-side or
+// server-side-polling capability is present.
 func (c CommonPollingTests) PollingIntervalTests(t *ldtest.T) {
 	if t.Capabilities().HasAny(servicedef.CapabilityClientSide, servicedef.CapabilityServerSidePolling) {
 		t.LongRunning()

--- a/sdktests/common_tests_poll_interval.go
+++ b/sdktests/common_tests_poll_interval.go
@@ -7,6 +7,7 @@ import (
 	"github.com/launchdarkly/sdk-test-harness/v2/framework/ldtest"
 	"github.com/launchdarkly/sdk-test-harness/v2/mockld"
 	"github.com/launchdarkly/sdk-test-harness/v2/servicedef"
+	"github.com/stretchr/testify/require"
 )
 
 const pollIntervalEpsilon = 2 * time.Second
@@ -26,6 +27,7 @@ func (c CommonPollingTests) pollIntervals(t *ldtest.T) struct{ Default, Min time
 		return struct{ Default, Min time.Duration }{Default: 5 * time.Minute, Min: 5 * time.Minute}
 	}
 	require.Fail(t, "pollIntervals: test service has neither server-side nor client-side capability")
+	return struct{ Default, Min time.Duration }{} // unreachable; satisfy compiler
 }
 
 // PollingIntervalTests requires -enable-long-running-tests and only runs when client-side or

--- a/sdktests/common_tests_poll_interval.go
+++ b/sdktests/common_tests_poll_interval.go
@@ -1,0 +1,120 @@
+package sdktests
+
+import (
+	"time"
+
+	"github.com/launchdarkly/sdk-test-harness/v2/framework/harness"
+	"github.com/launchdarkly/sdk-test-harness/v2/framework/ldtest"
+	"github.com/launchdarkly/sdk-test-harness/v2/mockld"
+	"github.com/launchdarkly/sdk-test-harness/v2/servicedef"
+)
+
+const pollIntervalEpsilon = 2 * time.Second
+
+// pollIntervals returns the interval parameters for the polling interval tests (Default and Min). Uses server-side/client-side capabilities; uses sdkKind only for the browser (JSClientSDK) special case. Panics if no condition matches. Return type is an anonymous struct so it is not referenced from other files.
+func (c CommonPollingTests) pollIntervals(t *ldtest.T) struct{ Default, Min time.Duration } {
+	if t.Capabilities().Has(servicedef.CapabilityServerSide) {
+		return struct{ Default, Min time.Duration }{Default: 30 * time.Second, Min: 30 * time.Second}
+	}
+	// Browser (JS) SDKs use 5min default, 30s min.
+	if c.sdkKind == mockld.JSClientSDK {
+		return struct{ Default, Min time.Duration }{Default: 5 * time.Minute, Min: 30 * time.Second}
+	}
+	if t.Capabilities().Has(servicedef.CapabilityClientSide) {
+		return struct{ Default, Min time.Duration }{Default: 5 * time.Minute, Min: 5 * time.Minute}
+	}
+	panic("pollIntervals: test service has neither server-side nor client-side capability")
+}
+
+// Requires -enable-long-running-tests. Only runs when client-side or server-side-polling capability is present.
+func (c CommonPollingTests) PollingIntervalTests(t *ldtest.T) {
+	if t.Capabilities().HasAny(servicedef.CapabilityClientSide, servicedef.CapabilityServerSidePolling) {
+		t.LongRunning()
+		t.Run("default polling interval is respected", c.defaultPollingIntervalIsRespected)
+		t.Run("polling interval below minimum is clamped", c.pollingIntervalBelowMinimumIsClamped)
+		t.Run("polling interval above minimum is respected", c.pollingIntervalAboveMinimumIsRespected)
+	}
+}
+
+// doPollIntervalTests runs the polling interval tests (default, clamp, custom). Used by both
+// server-side and client-side poll suites; pass the appropriate SDKConfigurers for the context.
+func doPollIntervalTests(t *ldtest.T, baseSDKConfigurers ...SDKConfigurer) {
+	pollTests := NewCommonPollingTests(t, "pollInterval", baseSDKConfigurers...)
+	pollTests.PollingIntervalTests(t)
+}
+
+func (c CommonPollingTests) defaultPollingIntervalIsRespected(t *ldtest.T) {
+	t.LongRunning()
+
+	dataSystem := NewSDKDataSystem(t, nil, DataSystemOptionPolling())
+	_ = NewSDKClient(t, c.baseSDKConfigurationPlus(dataSystem)...)
+
+	// Do not set PollIntervalMS; SDK uses its default (30s server-side, 5min client-side including browser).
+	intervals := c.pollIntervals(t)
+	c.assertPollingIntervalBetweenRequests(t, dataSystem.Synchronizers[0].Endpoint(), intervals.Default, pollIntervalEpsilon)
+}
+
+func (c CommonPollingTests) pollingIntervalBelowMinimumIsClamped(t *ldtest.T) {
+	t.LongRunning()
+
+	// Request below minimum (min/2); SDK should clamp to minimum (30s server-side and browser, 5min other client-side).
+	params := c.pollIntervals(t)
+	dataSystem := NewSDKDataSystem(t, nil, DataSystemOptionPolling(), DataSystemOptionPollInterval(params.Min/2))
+	_ = NewSDKClient(t, c.baseSDKConfigurationPlus(dataSystem)...)
+
+	c.assertPollingIntervalBetweenRequests(t, dataSystem.Synchronizers[0].Endpoint(), params.Min, pollIntervalEpsilon)
+}
+
+func (c CommonPollingTests) pollingIntervalAboveMinimumIsRespected(t *ldtest.T) {
+	t.LongRunning()
+
+	params := c.pollIntervals(t)
+	// Use default*1.5 as a configured interval above minimum to verify it is respected.
+	customInterval := params.Default * 3 / 2
+	dataSystem := NewSDKDataSystem(t, nil, DataSystemOptionPolling(), DataSystemOptionPollInterval(customInterval))
+	_ = NewSDKClient(t, c.baseSDKConfigurationPlus(dataSystem)...)
+
+	endpoint := dataSystem.Synchronizers[0].Endpoint()
+
+	// First request (initial poll). Use same generous timeout as assertPollingIntervalBetweenRequests for SDK startup.
+	_ = endpoint.RequireConnection(t, time.Second*15)
+	firstReceivedAt := time.Now()
+
+	// Second request must not occur before the configured interval. Wait slightly less and assert no request.
+	noRequestBefore := customInterval - pollIntervalEpsilon
+	endpoint.RequireNoMoreConnections(t, noRequestBefore)
+
+	// Now the second request should arrive within the next few seconds (interval + epsilon). Match helper's +5s buffer.
+	_ = endpoint.RequireConnection(t, pollIntervalEpsilon+5*time.Second)
+	secondReceivedAt := time.Now()
+
+	elapsed := secondReceivedAt.Sub(firstReceivedAt)
+	minAllowed := customInterval - pollIntervalEpsilon
+	if elapsed < minAllowed {
+		t.Errorf("second polling request arrived after %v; expected at least %v (configured interval %v)", elapsed, minAllowed, customInterval)
+	}
+}
+
+// assertPollingIntervalBetweenRequests waits for two polling requests and asserts the time between
+// them is within epsilon of the expected interval.
+func (c CommonPollingTests) assertPollingIntervalBetweenRequests(
+	t *ldtest.T,
+	endpoint *harness.MockEndpoint,
+	expectedInterval time.Duration,
+	epsilon time.Duration,
+) {
+	// Allow generous timeout for first request (SDK startup).
+	_ = endpoint.RequireConnection(t, time.Second*15)
+	firstReceivedAt := time.Now()
+
+	// Second request: expect it after expectedInterval ± epsilon.
+	_ = endpoint.RequireConnection(t, expectedInterval+epsilon+5*time.Second)
+	secondReceivedAt := time.Now()
+
+	elapsed := secondReceivedAt.Sub(firstReceivedAt)
+	minAllowed := expectedInterval - epsilon
+	maxAllowed := expectedInterval + epsilon
+	if elapsed < minAllowed || elapsed > maxAllowed {
+		t.Errorf("second polling request arrived after %v; expected between %v and %v", elapsed, minAllowed, maxAllowed)
+	}
+}

--- a/sdktests/common_tests_poll_interval.go
+++ b/sdktests/common_tests_poll_interval.go
@@ -11,7 +11,7 @@ import (
 
 const pollIntervalEpsilon = 2 * time.Second
 
-// pollIntervals returns the interval parameters for the polling interval tests (Default and Min).
+// pollIntervals returns the default and minimum values used for interval testing.
 // Uses server-side/client-side capabilities; uses sdkKind only for the browser (JSClientSDK) special case.
 // Panics if no condition matches. Return type is an anonymous struct so it is not referenced from other files.
 func (c CommonPollingTests) pollIntervals(t *ldtest.T) struct{ Default, Min time.Duration } {

--- a/sdktests/common_tests_poll_interval.go
+++ b/sdktests/common_tests_poll_interval.go
@@ -3,11 +3,12 @@ package sdktests
 import (
 	"time"
 
+	"github.com/stretchr/testify/require"
+
 	"github.com/launchdarkly/sdk-test-harness/v2/framework/harness"
 	"github.com/launchdarkly/sdk-test-harness/v2/framework/ldtest"
 	"github.com/launchdarkly/sdk-test-harness/v2/mockld"
 	"github.com/launchdarkly/sdk-test-harness/v2/servicedef"
-	"github.com/stretchr/testify/require"
 )
 
 const pollIntervalEpsilon = 2 * time.Second

--- a/sdktests/common_tests_poll_interval.go
+++ b/sdktests/common_tests_poll_interval.go
@@ -11,7 +11,9 @@ import (
 
 const pollIntervalEpsilon = 2 * time.Second
 
-// pollIntervals returns the interval parameters for the polling interval tests (Default and Min). Uses server-side/client-side capabilities; uses sdkKind only for the browser (JSClientSDK) special case. Panics if no condition matches. Return type is an anonymous struct so it is not referenced from other files.
+// pollIntervals returns the interval parameters for the polling interval tests (Default and Min).
+// Uses server-side/client-side capabilities; uses sdkKind only for the browser (JSClientSDK) special case.
+// Panics if no condition matches. Return type is an anonymous struct so it is not referenced from other files.
 func (c CommonPollingTests) pollIntervals(t *ldtest.T) struct{ Default, Min time.Duration } {
 	if t.Capabilities().Has(servicedef.CapabilityServerSide) {
 		return struct{ Default, Min time.Duration }{Default: 30 * time.Second, Min: 30 * time.Second}
@@ -51,7 +53,8 @@ func (c CommonPollingTests) defaultPollingIntervalIsRespected(t *ldtest.T) {
 
 	// Do not set PollIntervalMS; SDK uses its default (30s server-side, 5min client-side including browser).
 	intervals := c.pollIntervals(t)
-	c.assertPollingIntervalBetweenRequests(t, dataSystem.Synchronizers[0].Endpoint(), intervals.Default, pollIntervalEpsilon)
+	c.assertPollingIntervalBetweenRequests(t, dataSystem.Synchronizers[0].Endpoint(),
+		intervals.Default, pollIntervalEpsilon)
 }
 
 func (c CommonPollingTests) pollingIntervalBelowMinimumIsClamped(t *ldtest.T) {
@@ -91,7 +94,8 @@ func (c CommonPollingTests) pollingIntervalAboveMinimumIsRespected(t *ldtest.T) 
 	elapsed := secondReceivedAt.Sub(firstReceivedAt)
 	minAllowed := customInterval - pollIntervalEpsilon
 	if elapsed < minAllowed {
-		t.Errorf("second polling request arrived after %v; expected at least %v (configured interval %v)", elapsed, minAllowed, customInterval)
+		t.Errorf("second polling request arrived after %v; expected at least %v (configured interval %v)",
+			elapsed, minAllowed, customInterval)
 	}
 }
 

--- a/sdktests/common_tests_poll_interval.go
+++ b/sdktests/common_tests_poll_interval.go
@@ -25,7 +25,7 @@ func (c CommonPollingTests) pollIntervals(t *ldtest.T) struct{ Default, Min time
 	if t.Capabilities().Has(servicedef.CapabilityClientSide) {
 		return struct{ Default, Min time.Duration }{Default: 5 * time.Minute, Min: 5 * time.Minute}
 	}
-	panic("pollIntervals: test service has neither server-side nor client-side capability")
+	require.Fail(t, "pollIntervals: test service has neither server-side nor client-side capability")
 }
 
 // PollingIntervalTests requires -enable-long-running-tests and only runs when client-side or

--- a/sdktests/server_side_poll_all.go
+++ b/sdktests/server_side_poll_all.go
@@ -13,6 +13,9 @@ func doServerSidePollTests(t *ldtest.T) {
 
 	t.Run("requests", doServerSidePollRequestTests)
 	t.Run("payload", doServerSidePollPayloadTests)
+	t.Run("interval", func(t *ldtest.T) {
+		doPollIntervalTests(t, WithCredential("my-sdk-key"))
+	})
 }
 
 func doServerSidePollRequestTests(t *ldtest.T) {

--- a/sdktests/testapi_sdk_data_system.go
+++ b/sdktests/testapi_sdk_data_system.go
@@ -3,7 +3,9 @@ package sdktests
 import (
 	"errors"
 	"net/http"
+	"time"
 
+	"github.com/launchdarkly/go-sdk-common/v3/ldtime"
 	"github.com/launchdarkly/sdk-test-harness/v2/framework/harness"
 	"github.com/launchdarkly/sdk-test-harness/v2/framework/helpers"
 	"github.com/launchdarkly/sdk-test-harness/v2/framework/ldtest"
@@ -13,8 +15,9 @@ import (
 )
 
 type sdkDataSystemConfig struct {
-	polling             o.Maybe[bool] // true, false, or "undefined, use the default"
-	pollingInitializers []mockld.FDv2SDKData
+	polling                  o.Maybe[bool] // true, false, or "undefined, use the default"
+	pollingInitializers      []mockld.FDv2SDKData
+	pollingSynchronizerOpts  []DataSynchronizerOption // applied to the default polling sync when created
 }
 
 // SDKDataSystemOption is the interface for options to NewSDKDataSystem.
@@ -40,6 +43,17 @@ func DataSystemOptionPolling() SDKDataSystemOption {
 func DataSystemOptionStreaming() SDKDataSystemOption {
 	return helpers.ConfigOptionFunc[sdkDataSystemConfig](func(c *sdkDataSystemConfig) error {
 		c.polling = o.Some(false)
+		return nil
+	})
+}
+
+// DataSystemOptionPollInterval sets the polling interval (pollIntervalMs) for the default polling
+// synchronizer. Only applies when the data system is in polling mode. Omit to use the SDK's default.
+// The interval is stored on the synchronizer (per-sync); this option applies to the single polling
+// sync created by NewSDKDataSystem/NewSDKDataSystemWithoutEndpoints.
+func DataSystemOptionPollInterval(interval time.Duration) SDKDataSystemOption {
+	return helpers.ConfigOptionFunc[sdkDataSystemConfig](func(c *sdkDataSystemConfig) error {
+		c.pollingSynchronizerOpts = append(c.pollingSynchronizerOpts, SynchronizerOptionPollInterval(interval))
 		return nil
 	})
 }
@@ -121,9 +135,11 @@ func (s *SDKDataSystem) Configure(config *servicedef.SDKConfigParams) error {
 							harness.MockEndpointDescription("polling synchronizer"))
 					s.t.Defer(sync.endpoint.Close)
 				}
-				synchronizers[i].Polling = o.Some(servicedef.SDKConfigPollingParams{
-					BaseURI: sync.endpoint.BaseURL(),
-				})
+				params := servicedef.SDKConfigPollingParams{BaseURI: sync.endpoint.BaseURL()}
+				if sync.pollIntervalMS.IsDefined() {
+					params.PollIntervalMS = o.Some(ldtime.UnixMillisecondTime(sync.pollIntervalMS.Value().Milliseconds()))
+				}
+				synchronizers[i].Polling = o.Some(params)
 			}
 		}
 
@@ -143,12 +159,24 @@ type DataInitializer struct {
 func (d *DataInitializer) Endpoint() *harness.MockEndpoint { return d.endpoint }
 
 type DataSynchronizer struct {
-	streaming *mockld.StreamingService
-	polling   *mockld.PollingService
-	endpoint  *harness.MockEndpoint
+	streaming      *mockld.StreamingService
+	polling        *mockld.PollingService
+	endpoint       *harness.MockEndpoint
+	pollIntervalMS o.Maybe[time.Duration] // if set, sent to SDK as pollIntervalMs for this sync
 }
 
 func (d *DataSynchronizer) Endpoint() *harness.MockEndpoint { return d.endpoint }
+
+// DataSynchronizerOption modifies a DataSynchronizer (e.g. poll interval for a polling sync).
+// Options are applied when a synchronizer is created; multiple polling syncs can each have their own options.
+type DataSynchronizerOption func(*DataSynchronizer)
+
+// SynchronizerOptionPollInterval sets pollIntervalMs for this synchronizer. Only meaningful for polling syncs.
+func SynchronizerOptionPollInterval(interval time.Duration) DataSynchronizerOption {
+	return func(d *DataSynchronizer) {
+		d.pollIntervalMS = o.Some(interval)
+	}
+}
 
 // NewSDKDataSystem creates a new SDKDataSystem with the specified initial data set.
 //
@@ -218,8 +246,7 @@ func NewSDKDataSystemWithoutEndpoints(
 	var config sdkDataSystemConfig
 	_ = helpers.ApplyOptions(&config, options...)
 
-	d := &SDKDataSystem{}
-	d.t = t
+	d := &SDKDataSystem{t: t}
 
 	for _, initializer := range config.pollingInitializers {
 		d.Initializers = append(d.Initializers, DataInitializer{
@@ -230,10 +257,14 @@ func NewSDKDataSystemWithoutEndpoints(
 
 	defaultIsPolling := sdkKind == mockld.JSClientSDK || sdkKind == mockld.PHPSDK
 	if config.polling.Value() || (!config.polling.IsDefined() && defaultIsPolling) {
-		d.AddDataSynchronizer(DataSynchronizer{
+		sync := DataSynchronizer{
 			polling: mockld.NewPollingService(data, sdkKind, t.DebugLogger()).
 				WithGzipCompression(t.Capabilities().Has(servicedef.CapabilityPollingGzip)),
-		})
+		}
+		for _, opt := range config.pollingSynchronizerOpts {
+			opt(&sync)
+		}
+		d.AddDataSynchronizer(sync)
 	} else {
 		d.AddDataSynchronizer(DataSynchronizer{
 			streaming: mockld.NewStreamingService(data, sdkKind, t.DebugLogger()),

--- a/sdktests/testapi_sdk_data_system.go
+++ b/sdktests/testapi_sdk_data_system.go
@@ -15,9 +15,9 @@ import (
 )
 
 type sdkDataSystemConfig struct {
-	polling                  o.Maybe[bool] // true, false, or "undefined, use the default"
-	pollingInitializers      []mockld.FDv2SDKData
-	pollingSynchronizerOpts  []DataSynchronizerOption // applied to the default polling sync when created
+	polling                 o.Maybe[bool] // true, false, or "undefined, use the default"
+	pollingInitializers     []mockld.FDv2SDKData
+	pollingSynchronizerOpts []DataSynchronizerOption // applied to the default polling sync when created
 }
 
 // SDKDataSystemOption is the interface for options to NewSDKDataSystem.


### PR DESCRIPTION
This PR adds 3 tests for testing polling intervals.  They are long running tests and so can only be run while passing the -enable-long-running-tests flag.