### PR TITLE
fix: js client sdk header tests can match auth headers

### DIFF
--- a/sdktests/common_tests_base.go
+++ b/sdktests/common_tests_base.go
@@ -111,7 +111,7 @@ func (c commonTestsBase) baseSDKConfigurationPlus(configurers ...SDKConfigurer) 
 
 func (c commonTestsBase) authorizationHeaderMatcher(credential string) m.Matcher {
 	if c.sdkKind == mockld.JSClientSDK {
-		return HasNoAuthorizationHeader()
+		return m.AnyOf(HasNoAuthorizationHeader(), HasAuthorizationHeader(credential))
 	}
 	return HasAuthorizationHeader(credential)
 }


### PR DESCRIPTION
**Requirements**

- [ ] I have added test coverage for new or changed functionality
- [ ] I have followed the repository's [pull request submission guidelines](../blob/master/CONTRIBUTING.md#submitting-pull-requests)
- [ ] I have validated my changes against all supported platform versions

**Related issues**

sdk-1864

**Describe the solution you've provided**

This commit will let js client sdk tests allow both empty auth headers (original) and valid auth headers (added by this PR). The reasoning here is that some client sdks might not be limited by browser runtimes and are able to utilize request header auth (eg electron sdk).

**Describe alternatives you've considered**

Alternatively, we can set electron as a mobile sdk (which is probably going to happen anyway)
