### PR TITLE
feat: Add test harness support for flag change listeners in Server SDKs

### DIFF
--- a/docs/service_spec.md
+++ b/docs/service_spec.md
@@ -199,6 +199,17 @@ A test hook must:
       * `stage` (string, optional): If executing a stage, for example `beforeEvaluation`, this should be the stage.
   - Return data from the stages as specified via the `data` configuration. For instance the return value from the `beforeEvaluation` hook should be `data['beforeEvaluation']` merged with the input data for the stage.
 
+#### Capability `"flag-change-listeners"`
+
+This means that the SDK has support for flag change listeners and can notify the test harness when flags change.
+
+The SDK must support registering listeners that monitor for flag changes. When a flag changes, the SDK test service should POST notification data to the callback URI provided during listener registration.
+
+The test harness supports testing two types of listeners:
+- **General flag change listeners**: Notified when any flag's configuration changes
+- **Flag value change listeners**: Notified when a specific flag's evaluated value changes for a given context
+
+For details on the commands and callback payloads, see the `registerFlagChangeListener`, `registerFlagValueChangeListener`, and `unregisterListener` commands.
 
 #### Capability `"tls:verify-peer"`
 

--- a/docs/service_spec.md
+++ b/docs/service_spec.md
@@ -201,15 +201,15 @@ A test hook must:
 
 #### Capability `"flag-change-listeners"`
 
-This means that the SDK has support for flag change listeners and can notify the test harness when flags change.
+This means that the SDK has support for general flag change listeners — listeners that are notified when any flag's configuration changes. When a flag changes, the SDK test service should POST notification data to the callback URI provided during listener registration.
 
-The SDK must support registering listeners that monitor for flag changes. When a flag changes, the SDK test service should POST notification data to the callback URI provided during listener registration.
+For details on the commands and callback payloads, see the `registerFlagChangeListener` and `unregisterListener` commands.
 
-The test harness supports testing two types of listeners:
-- **General flag change listeners**: Notified when any flag's configuration changes
-- **Flag value change listeners**: Notified when a specific flag's evaluated value changes for a given context
+#### Capability `"flag-value-change-listeners"`
 
-For details on the commands and callback payloads, see the `registerFlagChangeListener`, `registerFlagValueChangeListener`, and `unregisterListener` commands.
+This means that the SDK has a native API for flag *value* change listeners — listeners that are notified when a specific flag's evaluated value changes for a given context. Not all SDKs provide this API; for example, the Node.js server SDK only supports general flag change listeners.
+
+For details on the commands and callback payloads, see the `registerFlagValueChangeListener` and `unregisterListener` commands.
 
 #### Capability `"tls:verify-peer"`
 

--- a/mockld/listener_callback_service.go
+++ b/mockld/listener_callback_service.go
@@ -1,0 +1,69 @@
+package mockld
+
+import (
+	"encoding/json"
+	"io"
+	"net/http"
+
+	"github.com/launchdarkly/sdk-test-harness/v2/framework"
+	"github.com/launchdarkly/sdk-test-harness/v2/framework/harness"
+	"github.com/launchdarkly/sdk-test-harness/v2/servicedef"
+)
+
+// ListenerCallbackService is a mock HTTP server that receives flag change listener notifications
+// POSTed by an SDK test service. Each registered listener should have its own instance so that
+// notifications can be attributed to the correct listener in test assertions.
+type ListenerCallbackService struct {
+	payloadEndpoint *harness.MockEndpoint
+	CallChannel     chan servicedef.ListenerNotification
+}
+
+// GetURL returns the callback URI to provide when registering a listener. The SDK test service
+// will POST a ListenerNotification JSON body to this URL when the listener fires.
+func (l *ListenerCallbackService) GetURL() string {
+	return l.payloadEndpoint.BaseURL()
+}
+
+// Close shuts down the mock HTTP endpoint and releases its resources.
+func (l *ListenerCallbackService) Close() {
+	l.payloadEndpoint.Close()
+}
+
+// NewListenerCallbackService creates a ListenerCallbackService with a mock HTTP endpoint
+// ready to receive notifications. Call Close() when done.
+func NewListenerCallbackService(
+	testHarness *harness.TestHarness,
+	logger framework.Logger,
+) *ListenerCallbackService {
+	l := &ListenerCallbackService{
+		CallChannel: make(chan servicedef.ListenerNotification),
+	}
+
+	endpointHandler := http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+		bytes, err := io.ReadAll(req.Body)
+		logger.Printf("Received listener notification: %s", string(bytes))
+		if err != nil {
+			logger.Printf("Could not read body from listener callback.")
+			w.WriteHeader(http.StatusBadRequest)
+			return
+		}
+		var notification servicedef.ListenerNotification
+		err = json.Unmarshal(bytes, &notification)
+		if err != nil {
+			logger.Printf("Could not unmarshal listener notification.")
+			w.WriteHeader(http.StatusBadRequest)
+			return
+		}
+
+		go func() {
+			l.CallChannel <- notification
+		}()
+
+		w.WriteHeader(http.StatusOK)
+	})
+
+	l.payloadEndpoint = testHarness.NewMockEndpoint(
+		endpointHandler, logger, harness.MockEndpointDescription("listener notification"))
+
+	return l
+}

--- a/sdktests/common_tests_listeners.go
+++ b/sdktests/common_tests_listeners.go
@@ -32,6 +32,7 @@ func doFlagValueChangeListenerTests(t *ldtest.T) {
 	t.Run("does not notify when value is unchanged", flagValueChangeListenerNoNotificationWhenUnchanged)
 	t.Run("multiple listeners both receive notification", flagValueChangeListenerMultipleBothNotified)
 	t.Run("is context specific", flagValueChangeListenerIsContextSpecific)
+	t.Run("reports correct old and new JSON values", flagValueChangeListenerJSONValues)
 }
 
 // makeFlagForFlagChangeListenerTests builds a server-side feature flag for listener tests. The flag
@@ -257,4 +258,30 @@ func flagValueChangeListenerIsContextSpecific(t *ldtest.T) {
 
 	// context2 (user-2): value unchanged ("value1" → "value1") → no notification expected.
 	callback2.ExpectNoNotification(t, "flag1")
+}
+
+func flagValueChangeListenerJSONValues(t *ldtest.T) {
+	oldValue := ldvalue.ObjectBuild().Set("color", ldvalue.String("red")).Set("count", ldvalue.Int(1)).Build()
+	newValue := ldvalue.ObjectBuild().Set("color", ldvalue.String("blue")).Set("count", ldvalue.Int(2)).Build()
+	defaultValue := ldvalue.ObjectBuild().Build()
+
+	flag := makeFlagForFlagChangeListenerTests("flag1", 1, oldValue)
+	data := mockld.NewServerSDKDataBuilder().Flag(flag).Build()
+	dataSystem := NewSDKDataSystem(t, data)
+	client := NewSDKClient(t, dataSystem)
+
+	callback := NewListenerCallback(requireContext(t).harness, t.DebugLogger())
+	defer callback.Close()
+
+	client.RegisterFlagValueChangeListener(t, servicedef.RegisterFlagValueChangeListenerParams{
+		ListenerID:   "listener-1",
+		FlagKey:      "flag1",
+		Context:      ldcontext.New("user-key"),
+		DefaultValue: defaultValue,
+		CallbackURI:  callback.GetURL(),
+	})
+
+	pushFlagUpdateForFlagChangeListenerTests(dataSystem, "flag1", 2, newValue)
+
+	callback.ExpectValueChangeNotification(t, "flag1", oldValue, newValue)
 }

--- a/sdktests/common_tests_listeners.go
+++ b/sdktests/common_tests_listeners.go
@@ -1,0 +1,287 @@
+package sdktests
+
+import (
+	"github.com/launchdarkly/go-test-helpers/v2/jsonhelpers"
+
+	"github.com/launchdarkly/go-sdk-common/v3/ldattr"
+	"github.com/launchdarkly/go-sdk-common/v3/ldcontext"
+	"github.com/launchdarkly/go-sdk-common/v3/ldvalue"
+	"github.com/launchdarkly/go-server-sdk-evaluation/v3/ldbuilders"
+	"github.com/launchdarkly/go-server-sdk-evaluation/v3/ldmodel"
+
+	"github.com/launchdarkly/sdk-test-harness/v2/framework/ldtest"
+	"github.com/launchdarkly/sdk-test-harness/v2/mockld"
+	"github.com/launchdarkly/sdk-test-harness/v2/servicedef"
+)
+
+func doCommonListenerTests(t *ldtest.T) {
+	t.RequireCapability(servicedef.CapabilityFlagChangeListeners)
+	t.Run("flag change listener", doFlagChangeListenerTests)
+	t.Run("flag value change listener", doFlagValueChangeListenerTests)
+}
+
+func doFlagChangeListenerTests(t *ldtest.T) {
+	t.Run("receives notification when flag changes", flagChangeListenerReceivesNotification)
+	t.Run("fires on config change even when value unchanged", flagChangeListenerFiresOnConfigChange)
+	t.Run("filters by flag key", flagChangeListenerFiltersByFlagKey)
+	t.Run("with empty flag key receives all flag changes", flagChangeListenerEmptyKeyReceivesAllFlags)
+}
+
+func doFlagValueChangeListenerTests(t *ldtest.T) {
+	t.Run("receives notification when value changes", flagValueChangeListenerReceivesNotification)
+	t.Run("does not notify when value is unchanged", flagValueChangeListenerNoNotificationWhenUnchanged)
+	t.Run("multiple listeners both receive notification", multipleValueListenersBothNotified)
+	t.Run("is context specific", valueListenerIsContextSpecific)
+}
+
+// makeListenerFlag builds a server-side feature flag for listener tests. The flag evaluates to
+// value as its off-variation, so any context will receive that value.
+func makeListenerFlag(key string, version int, value ldvalue.Value) ldmodel.FeatureFlag {
+	return ldbuilders.NewFlagBuilder(key).Version(version).
+		On(false).OffVariation(0).Variations(value, ldvalue.String("other")).Build()
+}
+
+// createClientForListeners sets up a client with two flags (flag1 and flag2) pre-loaded via
+// streaming, both initially evaluating to "value1". Use dataSystem.Synchronizers[0].streaming
+// to push flag updates and trigger listener notifications.
+func createClientForListeners(t *ldtest.T) (*SDKClient, *SDKDataSystem) {
+	flag1 := makeListenerFlag("flag1", 1, ldvalue.String("value1"))
+	flag2 := makeListenerFlag("flag2", 1, ldvalue.String("value1"))
+	data := mockld.NewServerSDKDataBuilder().Flag(flag1, flag2).Build()
+
+	dataSystem := NewSDKDataSystem(t, data)
+	client := NewSDKClient(t, dataSystem)
+
+	return client, dataSystem
+}
+
+// pushFlagUpdate pushes a flag update through the streaming service and signals that the payload
+// is complete. version must increase with each call; it is used as both the flag version and the
+// payload-transferred sequence number.
+func pushFlagUpdate(dataSystem *SDKDataSystem, key string, version int, value ldvalue.Value) {
+	flag := makeListenerFlag(key, version, value)
+
+	streaming := dataSystem.Synchronizers[0].streaming
+	streaming.PushUpdate("flag", key, version, jsonhelpers.ToJSON(flag))
+	streaming.PushPayloadTransferred("updated", version)
+}
+
+// --- Flag change listener tests ---
+
+func flagChangeListenerReceivesNotification(t *ldtest.T) {
+	client, dataSystem := createClientForListeners(t)
+
+	callback := NewListenerCallback(requireContext(t).harness, t.DebugLogger())
+	defer callback.Close()
+
+	client.RegisterFlagChangeListener(t, servicedef.RegisterFlagChangeListenerParams{
+		ListenerID:  "listener-1",
+		FlagKey:     "flag1",
+		CallbackURI: callback.GetURL(),
+	})
+
+	pushFlagUpdate(dataSystem, "flag1", 2, ldvalue.String("new-value"))
+
+	callback.ExpectFlagChangeNotification(t, "flag1")
+}
+
+func flagChangeListenerFiresOnConfigChange(t *ldtest.T) {
+	client, dataSystem := createClientForListeners(t)
+
+	callback := NewListenerCallback(requireContext(t).harness, t.DebugLogger())
+	defer callback.Close()
+
+	client.RegisterFlagChangeListener(t, servicedef.RegisterFlagChangeListenerParams{
+		ListenerID:  "listener-1",
+		FlagKey:     "flag1",
+		CallbackURI: callback.GetURL(),
+	})
+
+	// Push an update that changes the flag's version but not its evaluated value.
+	// The general flag change listener must fire regardless of value changes, because
+	// it tracks configuration changes (e.g. targeting rule edits), not just value changes.
+	pushFlagUpdate(dataSystem, "flag1", 2, ldvalue.String("value1"))
+
+	callback.ExpectFlagChangeNotification(t, "flag1")
+}
+
+func flagChangeListenerEmptyKeyReceivesAllFlags(t *ldtest.T) {
+	client, dataSystem := createClientForListeners(t)
+
+	callback := NewListenerCallback(requireContext(t).harness, t.DebugLogger())
+	defer callback.Close()
+
+	// An empty FlagKey means the listener should receive changes for any flag.
+	client.RegisterFlagChangeListener(t, servicedef.RegisterFlagChangeListenerParams{
+		ListenerID:  "listener-1",
+		FlagKey:     "",
+		CallbackURI: callback.GetURL(),
+	})
+
+	// Update flag1 — listener should fire.
+	pushFlagUpdate(dataSystem, "flag1", 2, ldvalue.String("new-value"))
+	callback.ExpectFlagChangeNotification(t, "flag1")
+
+	// Update flag2 — listener should fire again.
+	// Use version 3 so the payload-transferred sequence number also increments.
+	pushFlagUpdate(dataSystem, "flag2", 3, ldvalue.String("new-value"))
+	callback.ExpectFlagChangeNotification(t, "flag2")
+}
+
+func flagChangeListenerFiltersByFlagKey(t *ldtest.T) {
+	client, dataSystem := createClientForListeners(t)
+
+	callback := NewListenerCallback(requireContext(t).harness, t.DebugLogger())
+	defer callback.Close()
+
+	// Register listener only for flag1.
+	client.RegisterFlagChangeListener(t, servicedef.RegisterFlagChangeListenerParams{
+		ListenerID:  "listener-1",
+		FlagKey:     "flag1",
+		CallbackURI: callback.GetURL(),
+	})
+
+	// Update flag2 — should NOT trigger the listener.
+	pushFlagUpdate(dataSystem, "flag2", 2, ldvalue.String("new-value"))
+	callback.ExpectNoNotification(t, "flag1")
+
+	// Update flag1 — SHOULD trigger the listener.
+	pushFlagUpdate(dataSystem, "flag1", 2, ldvalue.String("another-value"))
+	callback.ExpectFlagChangeNotification(t, "flag1")
+}
+
+// --- Flag value change listener tests ---
+
+func flagValueChangeListenerReceivesNotification(t *ldtest.T) {
+	client, dataSystem := createClientForListeners(t)
+
+	context := ldcontext.New("user-key")
+	oldValue := ldvalue.String("value1")
+	newValue := ldvalue.String("new-value")
+	defaultValue := ldvalue.String("default")
+
+	callback := NewListenerCallback(requireContext(t).harness, t.DebugLogger())
+	defer callback.Close()
+
+	client.RegisterFlagValueChangeListener(t, servicedef.RegisterFlagValueChangeListenerParams{
+		ListenerID:   "listener-1",
+		FlagKey:      "flag1",
+		Context:      context,
+		DefaultValue: defaultValue,
+		CallbackURI:  callback.GetURL(),
+	})
+
+	pushFlagUpdate(dataSystem, "flag1", 2, newValue)
+
+	callback.ExpectValueChangeNotification(t, "flag1", oldValue, newValue)
+}
+
+func flagValueChangeListenerNoNotificationWhenUnchanged(t *ldtest.T) {
+	client, dataSystem := createClientForListeners(t)
+
+	context := ldcontext.New("user-key")
+
+	callback := NewListenerCallback(requireContext(t).harness, t.DebugLogger())
+	defer callback.Close()
+
+	client.RegisterFlagValueChangeListener(t, servicedef.RegisterFlagValueChangeListenerParams{
+		ListenerID:   "listener-1",
+		FlagKey:      "flag1",
+		Context:      context,
+		DefaultValue: ldvalue.String("default"),
+		CallbackURI:  callback.GetURL(),
+	})
+
+	// Update flag1 with a new version but the same evaluated value — should NOT trigger notification.
+	pushFlagUpdate(dataSystem, "flag1", 2, ldvalue.String("value1"))
+	callback.ExpectNoNotification(t, "flag1")
+}
+
+func multipleValueListenersBothNotified(t *ldtest.T) {
+	client, dataSystem := createClientForListeners(t)
+
+	context := ldcontext.New("user-key")
+	oldValue := ldvalue.String("value1")
+	newValue := ldvalue.String("new-value")
+	defaultValue := ldvalue.String("default")
+
+	callback1 := NewListenerCallback(requireContext(t).harness, t.DebugLogger())
+	defer callback1.Close()
+	callback2 := NewListenerCallback(requireContext(t).harness, t.DebugLogger())
+	defer callback2.Close()
+
+	// Register two independent listeners for the same flag and context.
+	client.RegisterFlagValueChangeListener(t, servicedef.RegisterFlagValueChangeListenerParams{
+		ListenerID:   "listener-1",
+		FlagKey:      "flag1",
+		Context:      context,
+		DefaultValue: defaultValue,
+		CallbackURI:  callback1.GetURL(),
+	})
+	client.RegisterFlagValueChangeListener(t, servicedef.RegisterFlagValueChangeListenerParams{
+		ListenerID:   "listener-2",
+		FlagKey:      "flag1",
+		Context:      context,
+		DefaultValue: defaultValue,
+		CallbackURI:  callback2.GetURL(),
+	})
+
+	pushFlagUpdate(dataSystem, "flag1", 2, newValue)
+
+	// Both listeners must receive the notification independently.
+	callback1.ExpectValueChangeNotification(t, "flag1", oldValue, newValue)
+	callback2.ExpectValueChangeNotification(t, "flag1", oldValue, newValue)
+}
+
+func valueListenerIsContextSpecific(t *ldtest.T) {
+	context1 := ldcontext.New("user-1")
+	context2 := ldcontext.New("user-2")
+	defaultValue := ldvalue.String("default")
+
+	// Initially both contexts see "value1" (flag is off, returns the same off-variation for all).
+	flag1 := makeListenerFlag("flag1", 1, ldvalue.String("value1"))
+	data := mockld.NewServerSDKDataBuilder().Flag(flag1).Build()
+	dataSystem := NewSDKDataSystem(t, data)
+	client := NewSDKClient(t, dataSystem)
+
+	callback1 := NewListenerCallback(requireContext(t).harness, t.DebugLogger())
+	defer callback1.Close()
+	callback2 := NewListenerCallback(requireContext(t).harness, t.DebugLogger())
+	defer callback2.Close()
+
+	client.RegisterFlagValueChangeListener(t, servicedef.RegisterFlagValueChangeListenerParams{
+		ListenerID:   "listener-1",
+		FlagKey:      "flag1",
+		Context:      context1,
+		DefaultValue: defaultValue,
+		CallbackURI:  callback1.GetURL(),
+	})
+	client.RegisterFlagValueChangeListener(t, servicedef.RegisterFlagValueChangeListenerParams{
+		ListenerID:   "listener-2",
+		FlagKey:      "flag1",
+		Context:      context2,
+		DefaultValue: defaultValue,
+		CallbackURI:  callback2.GetURL(),
+	})
+
+	// Push an updated flag that returns "updated-value" for user-1 via a targeting rule,
+	// and "value1" (unchanged) for everyone else via the fallthrough.
+	updatedFlag := ldbuilders.NewFlagBuilder("flag1").Version(2).
+		On(true).
+		FallthroughVariation(0).
+		Variations(ldvalue.String("value1"), ldvalue.String("updated-value")).
+		AddRule(ldbuilders.NewRuleBuilder().ID("target-rule").Variation(1).Clauses(
+			ldbuilders.Clause(ldattr.KeyAttr, ldmodel.OperatorIn, ldvalue.String("user-1")),
+		)).
+		Build()
+
+	streaming := dataSystem.Synchronizers[0].streaming
+	streaming.PushUpdate("flag", "flag1", 2, jsonhelpers.ToJSON(updatedFlag))
+	streaming.PushPayloadTransferred("updated", 2)
+
+	// context1 (user-1): value changed from "value1" to "updated-value" → notification expected.
+	callback1.ExpectValueChangeNotification(t, "flag1", ldvalue.String("value1"), ldvalue.String("updated-value"))
+
+	// context2 (user-2): value unchanged ("value1" → "value1") → no notification expected.
+	callback2.ExpectNoNotification(t, "flag1")
+}

--- a/sdktests/common_tests_listeners.go
+++ b/sdktests/common_tests_listeners.go
@@ -15,38 +15,38 @@ import (
 )
 
 func doCommonListenerTests(t *ldtest.T) {
-	t.RequireCapability(servicedef.CapabilityFlagChangeListeners)
 	t.Run("flag change listener", doFlagChangeListenerTests)
 	t.Run("flag value change listener", doFlagValueChangeListenerTests)
 }
 
 func doFlagChangeListenerTests(t *ldtest.T) {
+	t.RequireCapability(servicedef.CapabilityFlagChangeListeners)
 	t.Run("receives notification when flag changes", flagChangeListenerReceivesNotification)
 	t.Run("fires on config change even when value unchanged", flagChangeListenerFiresOnConfigChange)
-	t.Run("filters by flag key", flagChangeListenerFiltersByFlagKey)
-	t.Run("with empty flag key receives all flag changes", flagChangeListenerEmptyKeyReceivesAllFlags)
+	t.Run("receives notifications for different flags", flagChangeListenerReceivesDifferentFlags)
 }
 
 func doFlagValueChangeListenerTests(t *ldtest.T) {
+	t.RequireCapability(servicedef.CapabilityFlagValueChangeListeners)
 	t.Run("receives notification when value changes", flagValueChangeListenerReceivesNotification)
 	t.Run("does not notify when value is unchanged", flagValueChangeListenerNoNotificationWhenUnchanged)
-	t.Run("multiple listeners both receive notification", multipleValueListenersBothNotified)
-	t.Run("is context specific", valueListenerIsContextSpecific)
+	t.Run("multiple listeners both receive notification", flagValueChangeListenerMultipleBothNotified)
+	t.Run("is context specific", flagValueChangeListenerIsContextSpecific)
 }
 
-// makeListenerFlag builds a server-side feature flag for listener tests. The flag evaluates to
-// value as its off-variation, so any context will receive that value.
-func makeListenerFlag(key string, version int, value ldvalue.Value) ldmodel.FeatureFlag {
+// makeFlagForFlagChangeListenerTests builds a server-side feature flag for listener tests. The flag
+// evaluates to value as its off-variation, so any context will receive that value.
+func makeFlagForFlagChangeListenerTests(key string, version int, value ldvalue.Value) ldmodel.FeatureFlag {
 	return ldbuilders.NewFlagBuilder(key).Version(version).
 		On(false).OffVariation(0).Variations(value, ldvalue.String("other")).Build()
 }
 
-// createClientForListeners sets up a client with two flags (flag1 and flag2) pre-loaded via
-// streaming, both initially evaluating to "value1". Use dataSystem.Synchronizers[0].streaming
+// createClientForFlagChangeListenerTests sets up a client with two flags (flag1 and flag2) pre-loaded
+// via streaming, both initially evaluating to "value1". Use dataSystem.Synchronizers[0].streaming
 // to push flag updates and trigger listener notifications.
-func createClientForListeners(t *ldtest.T) (*SDKClient, *SDKDataSystem) {
-	flag1 := makeListenerFlag("flag1", 1, ldvalue.String("value1"))
-	flag2 := makeListenerFlag("flag2", 1, ldvalue.String("value1"))
+func createClientForFlagChangeListenerTests(t *ldtest.T) (*SDKClient, *SDKDataSystem) {
+	flag1 := makeFlagForFlagChangeListenerTests("flag1", 1, ldvalue.String("value1"))
+	flag2 := makeFlagForFlagChangeListenerTests("flag2", 1, ldvalue.String("value1"))
 	data := mockld.NewServerSDKDataBuilder().Flag(flag1, flag2).Build()
 
 	dataSystem := NewSDKDataSystem(t, data)
@@ -55,11 +55,11 @@ func createClientForListeners(t *ldtest.T) (*SDKClient, *SDKDataSystem) {
 	return client, dataSystem
 }
 
-// pushFlagUpdate pushes a flag update through the streaming service and signals that the payload
-// is complete. version must increase with each call; it is used as both the flag version and the
-// payload-transferred sequence number.
-func pushFlagUpdate(dataSystem *SDKDataSystem, key string, version int, value ldvalue.Value) {
-	flag := makeListenerFlag(key, version, value)
+// pushFlagUpdateForFlagChangeListenerTests pushes a flag update through the streaming service and
+// signals that the payload is complete. version must increase with each call; it is used as both the
+// flag version and the payload-transferred sequence number.
+func pushFlagUpdateForFlagChangeListenerTests(dataSystem *SDKDataSystem, key string, version int, value ldvalue.Value) {
+	flag := makeFlagForFlagChangeListenerTests(key, version, value)
 
 	streaming := dataSystem.Synchronizers[0].streaming
 	streaming.PushUpdate("flag", key, version, jsonhelpers.ToJSON(flag))
@@ -69,91 +69,64 @@ func pushFlagUpdate(dataSystem *SDKDataSystem, key string, version int, value ld
 // --- Flag change listener tests ---
 
 func flagChangeListenerReceivesNotification(t *ldtest.T) {
-	client, dataSystem := createClientForListeners(t)
+	client, dataSystem := createClientForFlagChangeListenerTests(t)
 
 	callback := NewListenerCallback(requireContext(t).harness, t.DebugLogger())
 	defer callback.Close()
 
 	client.RegisterFlagChangeListener(t, servicedef.RegisterFlagChangeListenerParams{
 		ListenerID:  "listener-1",
-		FlagKey:     "flag1",
 		CallbackURI: callback.GetURL(),
 	})
 
-	pushFlagUpdate(dataSystem, "flag1", 2, ldvalue.String("new-value"))
+	pushFlagUpdateForFlagChangeListenerTests(dataSystem, "flag1", 2, ldvalue.String("new-value"))
 
 	callback.ExpectFlagChangeNotification(t, "flag1")
 }
 
 func flagChangeListenerFiresOnConfigChange(t *ldtest.T) {
-	client, dataSystem := createClientForListeners(t)
+	client, dataSystem := createClientForFlagChangeListenerTests(t)
 
 	callback := NewListenerCallback(requireContext(t).harness, t.DebugLogger())
 	defer callback.Close()
 
 	client.RegisterFlagChangeListener(t, servicedef.RegisterFlagChangeListenerParams{
 		ListenerID:  "listener-1",
-		FlagKey:     "flag1",
 		CallbackURI: callback.GetURL(),
 	})
 
 	// Push an update that changes the flag's version but not its evaluated value.
 	// The general flag change listener must fire regardless of value changes, because
 	// it tracks configuration changes (e.g. targeting rule edits), not just value changes.
-	pushFlagUpdate(dataSystem, "flag1", 2, ldvalue.String("value1"))
+	pushFlagUpdateForFlagChangeListenerTests(dataSystem, "flag1", 2, ldvalue.String("value1"))
 
 	callback.ExpectFlagChangeNotification(t, "flag1")
 }
 
-func flagChangeListenerEmptyKeyReceivesAllFlags(t *ldtest.T) {
-	client, dataSystem := createClientForListeners(t)
+func flagChangeListenerReceivesDifferentFlags(t *ldtest.T) {
+	client, dataSystem := createClientForFlagChangeListenerTests(t)
 
 	callback := NewListenerCallback(requireContext(t).harness, t.DebugLogger())
 	defer callback.Close()
 
-	// An empty FlagKey means the listener should receive changes for any flag.
 	client.RegisterFlagChangeListener(t, servicedef.RegisterFlagChangeListenerParams{
 		ListenerID:  "listener-1",
-		FlagKey:     "",
 		CallbackURI: callback.GetURL(),
 	})
 
 	// Update flag1 — listener should fire.
-	pushFlagUpdate(dataSystem, "flag1", 2, ldvalue.String("new-value"))
+	pushFlagUpdateForFlagChangeListenerTests(dataSystem, "flag1", 2, ldvalue.String("new-value"))
 	callback.ExpectFlagChangeNotification(t, "flag1")
 
-	// Update flag2 — listener should fire again.
-	// Use version 3 so the payload-transferred sequence number also increments.
-	pushFlagUpdate(dataSystem, "flag2", 3, ldvalue.String("new-value"))
+	// Update flag2 — listener should fire again for the different flag.
+	pushFlagUpdateForFlagChangeListenerTests(dataSystem, "flag2", 3, ldvalue.String("new-value"))
 	callback.ExpectFlagChangeNotification(t, "flag2")
-}
-
-func flagChangeListenerFiltersByFlagKey(t *ldtest.T) {
-	client, dataSystem := createClientForListeners(t)
-
-	callback := NewListenerCallback(requireContext(t).harness, t.DebugLogger())
-	defer callback.Close()
-
-	// Register listener only for flag1.
-	client.RegisterFlagChangeListener(t, servicedef.RegisterFlagChangeListenerParams{
-		ListenerID:  "listener-1",
-		FlagKey:     "flag1",
-		CallbackURI: callback.GetURL(),
-	})
-
-	// Update flag2 — should NOT trigger the listener.
-	pushFlagUpdate(dataSystem, "flag2", 2, ldvalue.String("new-value"))
-	callback.ExpectNoNotification(t, "flag1")
-
-	// Update flag1 — SHOULD trigger the listener.
-	pushFlagUpdate(dataSystem, "flag1", 2, ldvalue.String("another-value"))
-	callback.ExpectFlagChangeNotification(t, "flag1")
 }
 
 // --- Flag value change listener tests ---
 
 func flagValueChangeListenerReceivesNotification(t *ldtest.T) {
-	client, dataSystem := createClientForListeners(t)
+	client, dataSystem := createClientForFlagChangeListenerTests(t)
 
 	context := ldcontext.New("user-key")
 	oldValue := ldvalue.String("value1")
@@ -171,13 +144,13 @@ func flagValueChangeListenerReceivesNotification(t *ldtest.T) {
 		CallbackURI:  callback.GetURL(),
 	})
 
-	pushFlagUpdate(dataSystem, "flag1", 2, newValue)
+	pushFlagUpdateForFlagChangeListenerTests(dataSystem, "flag1", 2, newValue)
 
 	callback.ExpectValueChangeNotification(t, "flag1", oldValue, newValue)
 }
 
 func flagValueChangeListenerNoNotificationWhenUnchanged(t *ldtest.T) {
-	client, dataSystem := createClientForListeners(t)
+	client, dataSystem := createClientForFlagChangeListenerTests(t)
 
 	context := ldcontext.New("user-key")
 
@@ -193,12 +166,12 @@ func flagValueChangeListenerNoNotificationWhenUnchanged(t *ldtest.T) {
 	})
 
 	// Update flag1 with a new version but the same evaluated value — should NOT trigger notification.
-	pushFlagUpdate(dataSystem, "flag1", 2, ldvalue.String("value1"))
+	pushFlagUpdateForFlagChangeListenerTests(dataSystem, "flag1", 2, ldvalue.String("value1"))
 	callback.ExpectNoNotification(t, "flag1")
 }
 
-func multipleValueListenersBothNotified(t *ldtest.T) {
-	client, dataSystem := createClientForListeners(t)
+func flagValueChangeListenerMultipleBothNotified(t *ldtest.T) {
+	client, dataSystem := createClientForFlagChangeListenerTests(t)
 
 	context := ldcontext.New("user-key")
 	oldValue := ldvalue.String("value1")
@@ -226,20 +199,20 @@ func multipleValueListenersBothNotified(t *ldtest.T) {
 		CallbackURI:  callback2.GetURL(),
 	})
 
-	pushFlagUpdate(dataSystem, "flag1", 2, newValue)
+	pushFlagUpdateForFlagChangeListenerTests(dataSystem, "flag1", 2, newValue)
 
 	// Both listeners must receive the notification independently.
 	callback1.ExpectValueChangeNotification(t, "flag1", oldValue, newValue)
 	callback2.ExpectValueChangeNotification(t, "flag1", oldValue, newValue)
 }
 
-func valueListenerIsContextSpecific(t *ldtest.T) {
+func flagValueChangeListenerIsContextSpecific(t *ldtest.T) {
 	context1 := ldcontext.New("user-1")
 	context2 := ldcontext.New("user-2")
 	defaultValue := ldvalue.String("default")
 
 	// Initially both contexts see "value1" (flag is off, returns the same off-variation for all).
-	flag1 := makeListenerFlag("flag1", 1, ldvalue.String("value1"))
+	flag1 := makeFlagForFlagChangeListenerTests("flag1", 1, ldvalue.String("value1"))
 	data := mockld.NewServerSDKDataBuilder().Flag(flag1).Build()
 	dataSystem := NewSDKDataSystem(t, data)
 	client := NewSDKClient(t, dataSystem)

--- a/sdktests/testapi_listeners.go
+++ b/sdktests/testapi_listeners.go
@@ -1,0 +1,108 @@
+package sdktests
+
+import (
+	"time"
+
+	"github.com/launchdarkly/go-sdk-common/v3/ldvalue"
+	"github.com/launchdarkly/sdk-test-harness/v2/framework"
+	"github.com/launchdarkly/sdk-test-harness/v2/framework/harness"
+	"github.com/launchdarkly/sdk-test-harness/v2/framework/helpers"
+	"github.com/launchdarkly/sdk-test-harness/v2/framework/ldtest"
+	o "github.com/launchdarkly/sdk-test-harness/v2/framework/opt"
+	"github.com/launchdarkly/sdk-test-harness/v2/mockld"
+	"github.com/launchdarkly/sdk-test-harness/v2/servicedef"
+
+	"github.com/stretchr/testify/assert"
+)
+
+const listenerReceiveTimeout = time.Second * 5
+const listenerNoNotificationTimeout = time.Millisecond * 500
+
+// ListenerCallback is used in flag change listener tests to receive and assert on listener
+// notifications from the SDK test service. Each instance manages a dedicated mock HTTP
+// endpoint that the SDK test service POSTs to when the registered listener fires.
+//
+// The general usage pattern is:
+//
+//	callback := NewListenerCallback(requireContext(t).harness, t.DebugLogger())
+//	defer callback.Close()
+//	client.RegisterFlagChangeListener(t, listenerID, flagKey, callback.GetURL())
+//	// ... trigger a flag change via the streaming service ...
+//	callback.ExpectFlagChangeNotification(t, flagKey)
+type ListenerCallback struct {
+	service *mockld.ListenerCallbackService
+}
+
+// NewListenerCallback creates a ListenerCallback with a dedicated mock HTTP endpoint ready to
+// receive notifications. Call Close() when done to release the endpoint.
+func NewListenerCallback(
+	testHarness *harness.TestHarness,
+	logger framework.Logger,
+) *ListenerCallback {
+	return &ListenerCallback{
+		service: mockld.NewListenerCallbackService(testHarness, logger),
+	}
+}
+
+// GetURL returns the callback URI to pass as the callbackUri field in a
+// registerFlagChangeListener or registerFlagValueChangeListener command.
+func (lc *ListenerCallback) GetURL() string {
+	return lc.service.GetURL()
+}
+
+// Close shuts down the mock HTTP endpoint.
+func (lc *ListenerCallback) Close() {
+	lc.service.Close()
+}
+
+// ExpectFlagChangeNotification waits up to listenerReceiveTimeout for a general flag change
+// notification for the given flag key. It fails the test if no notification arrives within the
+// timeout, or if the notification's flag key does not match. Returns the notification for
+// further inspection.
+func (lc *ListenerCallback) ExpectFlagChangeNotification(
+	t *ldtest.T,
+	flagKey string,
+) servicedef.ListenerNotification {
+	notification := helpers.RequireValueWithMessage(
+		t, lc.service.CallChannel, listenerReceiveTimeout,
+		"timed out waiting for flag change notification for flag %q", flagKey,
+	)
+
+	assert.Equal(t, flagKey, notification.FlagKey,
+		"flag change notification had unexpected flag key")
+
+	return notification
+}
+
+// ExpectValueChangeNotification waits up to listenerReceiveTimeout for a value change
+// notification for the given flag key, and asserts that the old and new values match.
+// It fails the test if no notification arrives within the timeout, or if any assertion fails.
+// Returns the notification for further inspection.
+func (lc *ListenerCallback) ExpectValueChangeNotification(
+	t *ldtest.T,
+	flagKey string,
+	oldValue ldvalue.Value,
+	newValue ldvalue.Value,
+) servicedef.ListenerNotification {
+	notification := helpers.RequireValueWithMessage(
+		t, lc.service.CallChannel, listenerReceiveTimeout,
+		"timed out waiting for value change notification for flag %q", flagKey,
+	)
+
+	assert.Equal(t, flagKey, notification.FlagKey,
+		"value change notification had unexpected flag key")
+	assert.Equal(t, o.Some(oldValue), notification.OldValue,
+		"value change notification had unexpected old value for flag %q", flagKey)
+	assert.Equal(t, o.Some(newValue), notification.NewValue,
+		"value change notification had unexpected new value for flag %q", flagKey)
+
+	return notification
+}
+
+// ExpectNoNotification asserts that no notification arrives within listenerNoNotificationTimeout.
+// Use this to verify that a listener did NOT fire (e.g., because the flag value did not change).
+// The flagKey parameter is used only in the failure message if a notification unexpectedly arrives.
+func (lc *ListenerCallback) ExpectNoNotification(t *ldtest.T, flagKey string) {
+	helpers.RequireNoMoreValuesWithMessage(t, lc.service.CallChannel, listenerNoNotificationTimeout,
+		"received unexpected listener notification for flag %q", flagKey)
+}

--- a/sdktests/testapi_sdk_client.go
+++ b/sdktests/testapi_sdk_client.go
@@ -415,9 +415,9 @@ func (c *SDKClient) ContextComparison(t *ldtest.T, params servicedef.ContextComp
 	return resp
 }
 
-// RegisterFlagChangeListener tells the SDK test service to register a general flag change listener
-// for the given flag key. The listener will POST a ListenerNotification to callbackURI whenever
-// the flag's configuration changes. Pass an empty flagKey to listen for changes to any flag.
+// RegisterFlagChangeListener tells the SDK test service to register a general flag change listener.
+// The listener will POST a ListenerNotification to callbackURI whenever any flag's configuration
+// changes.
 //
 // Any error from the test service causes the test to terminate immediately.
 func (c *SDKClient) RegisterFlagChangeListener(

--- a/sdktests/testapi_sdk_client.go
+++ b/sdktests/testapi_sdk_client.go
@@ -415,6 +415,59 @@ func (c *SDKClient) ContextComparison(t *ldtest.T, params servicedef.ContextComp
 	return resp
 }
 
+// RegisterFlagChangeListener tells the SDK test service to register a general flag change listener
+// for the given flag key. The listener will POST a ListenerNotification to callbackURI whenever
+// the flag's configuration changes. Pass an empty flagKey to listen for changes to any flag.
+//
+// Any error from the test service causes the test to terminate immediately.
+func (c *SDKClient) RegisterFlagChangeListener(
+	t *ldtest.T,
+	params servicedef.RegisterFlagChangeListenerParams,
+) {
+	require.NoError(t, c.sdkClientEntity.SendCommandWithParams(
+		servicedef.CommandParams{
+			Command:                    servicedef.CommandRegisterFlagChangeListener,
+			RegisterFlagChangeListener: o.Some(params),
+		},
+		t.DebugLogger(),
+		nil,
+	))
+}
+
+// RegisterFlagValueChangeListener tells the SDK test service to register a value change listener
+// for the given flag key and context. The listener will POST a ListenerNotification to callbackURI
+// whenever the evaluated value of the flag changes for that context.
+//
+// Any error from the test service causes the test to terminate immediately.
+func (c *SDKClient) RegisterFlagValueChangeListener(
+	t *ldtest.T,
+	params servicedef.RegisterFlagValueChangeListenerParams,
+) {
+	require.NoError(t, c.sdkClientEntity.SendCommandWithParams(
+		servicedef.CommandParams{
+			Command:                         servicedef.CommandRegisterFlagValueChangeListener,
+			RegisterFlagValueChangeListener: o.Some(params),
+		},
+		t.DebugLogger(),
+		nil,
+	))
+}
+
+// UnregisterListener tells the SDK test service to unregister a previously registered listener
+// by its ID.
+//
+// Any error from the test service causes the test to terminate immediately.
+func (c *SDKClient) UnregisterListener(t *ldtest.T, params servicedef.UnregisterListenerParams) {
+	require.NoError(t, c.sdkClientEntity.SendCommandWithParams(
+		servicedef.CommandParams{
+			Command:            servicedef.CommandUnregisterListener,
+			UnregisterListener: o.Some(params),
+		},
+		t.DebugLogger(),
+		nil,
+	))
+}
+
 // GetSecureModeHash tells the SDK client to calculate a secure mode hash for a context. The test
 // harness will only call this method if the test service has the "secure-mode-hash" capability.
 func (c *SDKClient) GetSecureModeHash(t *ldtest.T, context ldcontext.Context) string {

--- a/sdktests/testsuite_entry_point.go
+++ b/sdktests/testsuite_entry_point.go
@@ -96,6 +96,7 @@ func doAllServerSideTests(t *ldtest.T) {
 	t.Run("context type", doSDKContextTypeTests)
 	t.Run("migrations", doServerSideMigrationTests)
 	t.Run("hooks", doCommonHooksTests)
+	t.Run("flag change listeners", doCommonListenerTests)
 	t.Run("wrapper", doServerSideWrapperTests)
 	t.Run("persistent data store", doServerSidePersistentTests)
 }

--- a/servicedef/command_params.go
+++ b/servicedef/command_params.go
@@ -219,7 +219,6 @@ type HookExecutionPayload struct {
 // The listener will be notified whenever any flag's configuration changes.
 type RegisterFlagChangeListenerParams struct {
 	ListenerID  string `json:"listenerId"`
-	FlagKey     string `json:"flagKey"`
 	CallbackURI string `json:"callbackUri"`
 }
 

--- a/servicedef/command_params.go
+++ b/servicedef/command_params.go
@@ -12,19 +12,22 @@ import (
 )
 
 const (
-	CommandEvaluateFlag             = "evaluate"
-	CommandEvaluateAllFlags         = "evaluateAll"
-	CommandIdentifyEvent            = "identifyEvent"
-	CommandCustomEvent              = "customEvent"
-	CommandAliasEvent               = "aliasEvent"
-	CommandFlushEvents              = "flushEvents"
-	CommandGetBigSegmentStoreStatus = "getBigSegmentStoreStatus"
-	CommandContextBuild             = "contextBuild"
-	CommandContextConvert           = "contextConvert"
-	CommandContextComparison        = "contextComparison"
-	CommandSecureModeHash           = "secureModeHash"
-	CommandMigrationVariation       = "migrationVariation"
-	CommandMigrationOperation       = "migrationOperation"
+	CommandEvaluateFlag                    = "evaluate"
+	CommandEvaluateAllFlags                = "evaluateAll"
+	CommandIdentifyEvent                   = "identifyEvent"
+	CommandCustomEvent                     = "customEvent"
+	CommandAliasEvent                      = "aliasEvent"
+	CommandFlushEvents                     = "flushEvents"
+	CommandGetBigSegmentStoreStatus        = "getBigSegmentStoreStatus"
+	CommandContextBuild                    = "contextBuild"
+	CommandContextConvert                  = "contextConvert"
+	CommandContextComparison               = "contextComparison"
+	CommandSecureModeHash                  = "secureModeHash"
+	CommandMigrationVariation              = "migrationVariation"
+	CommandMigrationOperation              = "migrationOperation"
+	CommandRegisterFlagChangeListener      = "registerFlagChangeListener"
+	CommandRegisterFlagValueChangeListener = "registerFlagValueChangeListener"
+	CommandUnregisterListener              = "unregisterListener"
 )
 
 type ValueType string
@@ -38,17 +41,20 @@ const (
 )
 
 type CommandParams struct {
-	Command            string                               `json:"command"`
-	Evaluate           o.Maybe[EvaluateFlagParams]          `json:"evaluate,omitempty"`
-	EvaluateAll        o.Maybe[EvaluateAllFlagsParams]      `json:"evaluateAll,omitempty"`
-	CustomEvent        o.Maybe[CustomEventParams]           `json:"customEvent,omitempty"`
-	IdentifyEvent      o.Maybe[IdentifyEventParams]         `json:"identifyEvent,omitempty"`
-	ContextBuild       o.Maybe[ContextBuildParams]          `json:"contextBuild,omitempty"`
-	ContextConvert     o.Maybe[ContextConvertParams]        `json:"contextConvert,omitempty"`
-	ContextComparison  o.Maybe[ContextComparisonPairParams] `json:"contextComparison,omitempty"`
-	SecureModeHash     o.Maybe[SecureModeHashParams]        `json:"secureModeHash,omitempty"`
-	MigrationVariation o.Maybe[MigrationVariationParams]    `json:"migrationVariation,omitempty"`
-	MigrationOperation o.Maybe[MigrationOperationParams]    `json:"migrationOperation,omitempty"`
+	Command                         string                                         `json:"command"`
+	Evaluate                        o.Maybe[EvaluateFlagParams]                    `json:"evaluate,omitempty"`
+	EvaluateAll                     o.Maybe[EvaluateAllFlagsParams]                `json:"evaluateAll,omitempty"`
+	CustomEvent                     o.Maybe[CustomEventParams]                     `json:"customEvent,omitempty"`
+	IdentifyEvent                   o.Maybe[IdentifyEventParams]                   `json:"identifyEvent,omitempty"`
+	ContextBuild                    o.Maybe[ContextBuildParams]                    `json:"contextBuild,omitempty"`
+	ContextConvert                  o.Maybe[ContextConvertParams]                  `json:"contextConvert,omitempty"`
+	ContextComparison               o.Maybe[ContextComparisonPairParams]           `json:"contextComparison,omitempty"`
+	SecureModeHash                  o.Maybe[SecureModeHashParams]                  `json:"secureModeHash,omitempty"`
+	MigrationVariation              o.Maybe[MigrationVariationParams]              `json:"migrationVariation,omitempty"`
+	MigrationOperation              o.Maybe[MigrationOperationParams]              `json:"migrationOperation,omitempty"`
+	RegisterFlagChangeListener      o.Maybe[RegisterFlagChangeListenerParams]      `json:"registerFlagChangeListener,omitempty"`      //nolint:lll
+	RegisterFlagValueChangeListener o.Maybe[RegisterFlagValueChangeListenerParams] `json:"registerFlagValueChangeListener,omitempty"` //nolint:lll
+	UnregisterListener              o.Maybe[UnregisterListenerParams]              `json:"unregisterListener,omitempty"`
 }
 
 type EvaluateFlagParams struct {
@@ -207,4 +213,27 @@ type HookExecutionPayload struct {
 	EvaluationSeriesData    o.Maybe[map[string]ldvalue.Value] `json:"evaluationSeriesData"`
 	EvaluationDetail        o.Maybe[EvaluateFlagResponse]     `json:"evaluationDetail"`
 	Stage                   o.Maybe[HookStage]                `json:"stage"`
+}
+
+// RegisterFlagChangeListenerParams defines parameters for registering a general flag change listener.
+// The listener will be notified whenever any flag's configuration changes.
+type RegisterFlagChangeListenerParams struct {
+	ListenerID  string `json:"listenerId"`
+	FlagKey     string `json:"flagKey"`
+	CallbackURI string `json:"callbackUri"`
+}
+
+// RegisterFlagValueChangeListenerParams defines parameters for registering a flag value change listener.
+// The listener will be notified when the evaluated value of the specified flag changes for the given context.
+type RegisterFlagValueChangeListenerParams struct {
+	ListenerID   string            `json:"listenerId"`
+	FlagKey      string            `json:"flagKey"`
+	Context      ldcontext.Context `json:"context"`
+	DefaultValue ldvalue.Value     `json:"defaultValue"`
+	CallbackURI  string            `json:"callbackUri"`
+}
+
+// UnregisterListenerParams defines parameters for unregistering a previously registered listener.
+type UnregisterListenerParams struct {
+	ListenerID string `json:"listenerId"`
 }

--- a/servicedef/command_params.go
+++ b/servicedef/command_params.go
@@ -237,3 +237,14 @@ type RegisterFlagValueChangeListenerParams struct {
 type UnregisterListenerParams struct {
 	ListenerID string `json:"listenerId"`
 }
+
+// ListenerNotification is the JSON payload POSTed by the SDK test service to a callback URI
+// when a flag change listener fires. OldValue and NewValue are only present for value change
+// notifications (registerFlagValueChangeListener), not for general flag change notifications
+// (registerFlagChangeListener).
+type ListenerNotification struct {
+	ListenerID string                 `json:"listenerId"`
+	FlagKey    string                 `json:"flagKey"`
+	OldValue   o.Maybe[ldvalue.Value] `json:"oldValue,omitempty"`
+	NewValue   o.Maybe[ldvalue.Value] `json:"newValue,omitempty"`
+}

--- a/servicedef/service_params.go
+++ b/servicedef/service_params.go
@@ -40,6 +40,7 @@ const (
 	CapabilityAnonymousRedaction          = "anonymous-redaction"
 	CapabilityPollingGzip                 = "polling-gzip"
 	CapabilityEvaluationHooks             = "evaluation-hooks"
+	CapabilityFlagChangeListeners         = "flag-change-listeners"
 	CapabilityClientPrereqEvents          = "client-prereq-events"
 	CapabilityPersistentDataStoreRedis    = "persistent-data-store-redis"
 	CapabilityPersistentDataStoreConsul   = "persistent-data-store-consul"

--- a/servicedef/service_params.go
+++ b/servicedef/service_params.go
@@ -41,6 +41,7 @@ const (
 	CapabilityPollingGzip                 = "polling-gzip"
 	CapabilityEvaluationHooks             = "evaluation-hooks"
 	CapabilityFlagChangeListeners         = "flag-change-listeners"
+	CapabilityFlagValueChangeListeners    = "flag-value-change-listeners"
 	CapabilityClientPrereqEvents          = "client-prereq-events"
 	CapabilityPersistentDataStoreRedis    = "persistent-data-store-redis"
 	CapabilityPersistentDataStoreConsul   = "persistent-data-store-consul"


### PR DESCRIPTION
This pull request is part of a larger set of PRs that implement Flag Change Listener tests for server SDKs. Here's the list of pull requests that I currently have open:
* **[sdk-test-harness] feat: Add test harness support for flag change listeners in Server SDKs <-- This PR**
* [[go-server-sdk] feat(contract-tests): Implement flag change listener tests in the Go server SDK](https://github.com/launchdarkly/go-server-sdk/pull/349)
* [[js-core] feat(contract-tests): Implement flag change listener tests in the Node server SDK](https://github.com/launchdarkly/js-core/pull/1120)

---

## Summary

### Flag Change Listener Contract Tests

This PR adds contract tests for the SDK **flag change listener** feature — the ability for applications to subscribe to notifications when flag configurations or evaluated values change. Listener registration uses dynamic commands (rather than SDK creation params) because listeners are typically added and removed during a client's lifetime, and this approach enables future tests for unregistration and runtime listener management.

### Design

The test harness already has a well-established pattern for verifying async, event-driven SDK behavior: the **HTTP callback** pattern (used by hooks, migrations, etc.). Flag change listeners follow the same approach.

```
                          ┌─────────────────────────┐
                          │     SDK Test Harness     │
                          │                          │
                          │  1. Create mock stream   │
                          │  2. Start SDK client     │
                          │  3. Register listener ──────────┐
                          │  4. Push flag update     │      │
                          │  5. Assert notification  │      │
                          │         ▲                │      │
                          └─────────│────────────────┘      │
                                    │                       │
                             POST   │                       │  Command
                             notification                   │  (JSON)
                                    │                       │
                          ┌─────────│────────────────┐      │
                          │   Callback Endpoint      │      ▼
                          │   (mock HTTP server)     │ ┌──────────────┐
                          │                          │ │  SDK Test    │
                          │   Receives JSON:         │ │  Service     │
                          │   {                      │ │              │
                          │     "listenerId": "...", │ │  Wraps SDK   │
                          │     "flagKey": "...",    │ │  listener    │
                          │     "oldValue": ...,     │ │  API, POSTs  │
                          │     "newValue": ...      │ │  back on     │
                          │   }                      │ │  change      │
                          └──────────────────────────┘ └──────────────┘
```

**Flow:**
1. The test harness initializes the SDK client with flags loaded via a mock streaming endpoint
2. The harness sends a **register** command to the test service, providing a callback URL
3. The test service calls the SDK's native listener API (e.g., `FlagTracker.AddFlagChangeListener` in Go)
4. The harness pushes a flag update through the mock streaming service
5. The SDK detects the change and fires the listener
6. The test service POSTs a `ListenerNotification` to the callback URL
7. The harness asserts on the notification contents (flag key, old/new values)

### Two Listener Types

| Listener Type | Command | Fires when... | Notification includes |
|---|---|---|---|
| **Flag Change** | `registerFlagChangeListener` | Flag configuration changes (any update) | `flagKey` only |
| **Flag Value Change** | `registerFlagValueChangeListener` | Evaluated value changes for a specific context | `flagKey`, `oldValue`, `newValue` |

The distinction matters: a flag change listener fires on *any* configuration update (e.g., targeting rule edits), even if the evaluated value stays the same. A flag value change listener only fires when the value the application would see actually differs.

### Capabilities

Tests are split across two capabilities so SDKs only run tests for APIs they actually provide:

| Capability | Required for | SDKs |
|---|---|---|
| `flag-change-listeners` | Config change listeners | All server-side SDKs |
| `flag-value-change-listeners` | Value change listeners (old/new) | Go, Java, .NET, Python, Ruby |

The Node.js server SDK, for example, only supports config change events (`update` / `update:KEY`) and does not have a native value change listener API, so it advertises only `flag-change-listeners`.

### Test Coverage

| Test | What it verifies |
|---|---|
| **Flag Change Listener** (`flag-change-listeners`) | |
| Receives notification when flag changes | Basic listener fires on update |
| Fires on config change even when value unchanged | Fires regardless of value delta (e.g., targeting rule edit) |
| Receives notifications for different flags | Listener fires for multiple distinct flag updates |
| **Flag Value Change Listener** (`flag-value-change-listeners`) | |
| Receives notification when value changes | Reports correct old and new values |
| Does not notify when value is unchanged | Suppresses no-op updates (same value, new version) |
| Multiple listeners both receive notification | Two listeners on the same flag both fire independently |
| Is context specific | Value change is evaluated per-context (user-1 changes, user-2 doesn't) |

### What SDK Repositories Need to Implement

Each SDK's **test service** must:

1. **Add capabilities** to the `GET /` status response:
   - `"flag-change-listeners"` — all SDKs with a config change listener API
   - `"flag-value-change-listeners"` — only SDKs with a native value change listener API (Go, Java, .NET, Python, Ruby)
2. **Handle new commands** on the client command endpoint:
   - `registerFlagChangeListener` — subscribe to the SDK's flag change API, POST a `ListenerNotification` to the callback URL when the listener fires
   - `registerFlagValueChangeListener` *(if advertising the capability)* — subscribe to the SDK's flag *value* change API, capturing old/new values and POSTing them to the callback URL
   - `unregisterListener` — remove a previously registered listener by its ID
3. **Maintain a listener map** keyed by `listenerId` so that `unregisterListener` can clean up correctly

No changes to the SDK itself are required — only the test service wrapper.

---

**Requirements**

- [ ] I have added test coverage for new or changed functionality
- [ ] I have followed the repository's [pull request submission guidelines](../blob/master/CONTRIBUTING.md#submitting-pull-requests)
- [ ] I have validated my changes against all supported platform versions

**Related issues**

Provide links to any issues in this repository or elsewhere relating to this pull request.

**Describe the solution you've provided**

Provide a clear and concise description of what you expect to happen.

**Describe alternatives you've considered**

Provide a clear and concise description of any alternative solutions or features you've considered.

**Additional context**

Add any other context about the pull request here.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: mostly adds new contract tests and service-spec/command definitions, and the new listener tests are gated behind opt-in capabilities so existing SDK test services should not be affected unless they advertise them.
> 
> **Overview**
> Adds **contract-test coverage for flag change listeners** in server-side SDK suites, including both general *config change* listeners and optional *value change (old/new)* listeners.
> 
> Introduces new test-service surface area to support those tests: new capabilities (`flag-change-listeners`, `flag-value-change-listeners`), new commands (`registerFlagChangeListener`, `registerFlagValueChangeListener`, `unregisterListener`) and payload types (`ListenerNotification`), plus a mock HTTP callback endpoint (`ListenerCallbackService`) and `SDKClient` helpers to register/unregister listeners. Updates `docs/service_spec.md` to document the new capabilities.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 88b7c7d511844407d1c0f54fb88fa1a349fa12b2. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->