### PR TITLE
feat: Add test harness support for flag change listeners in Client SDKs

### DIFF
--- a/.cursor/change-listener-tests-research.md
+++ b/.cursor/change-listener-tests-research.md
@@ -12,6 +12,12 @@
   - [Cross-SDK Comparison](#cross-sdk-comparison)
   - [Universal Design Patterns](#universal-design-patterns)
   - [Implications for Test Harness](#implications-for-test-harness)
+- [Client-Side SDK Analysis](#client-side-sdk-analysis)
+  - [Client-Side Listener APIs](#client-side-listener-apis)
+  - [Key Differences: Client-Side vs Server-Side](#key-differences-client-side-vs-server-side)
+  - [Can the Callback Architecture Work for Client-Side?](#can-the-callback-architecture-work-for-client-side)
+  - [Streaming Data Format for Client-Side](#streaming-data-format-for-client-side)
+  - [Plan: Sharing Tests Between Server and Client Side](#plan-sharing-tests-between-server-and-client-side)
 - [Proposed Test Harness Design](#proposed-test-harness-design)
 - [Implementation Plan](#implementation-plan)
 - [Open Questions](#open-questions)
@@ -606,6 +612,178 @@ The test harness design must accommodate:
 
 ---
 
+## Client-Side SDK Analysis
+
+This section covers client-side SDK listener APIs and the plan for extending the test harness to cover them. SDKs surveyed: `js-core` (browser/React Native), `.NET` client SDK (`dotnet-core/pkgs/sdk/client`), and Android (`android-client-sdk`).
+
+### Client-Side Listener APIs
+
+#### JavaScript / React Native (`js-core`)
+
+**Key files**: `packages/shared/sdk-client/src/LDClientImpl.ts`, `packages/shared/sdk-client/src/LDEmitter.ts`
+
+API: event emitter pattern
+
+```typescript
+// All flags: fires with (context, flagKeys[]) whenever any flag's value changes
+client.on('change', (context, flagKeys) => { ... });
+
+// Specific flag: fires with (context) when that flag's value changes
+client.on('change:flag-key', (context) => { ... });
+```
+
+**Characteristics:**
+- Backed by `LDEmitter`, which is typed: event names are `'change'` or the template literal `` `change:${string}` ``
+- The `_flagManager.on(...)` callback (in `LDClientImpl`) emits both events whenever flags change, including after `Identify` when new flag values arrive
+- No explicit "unregister" method—listeners are removed with `client.off(eventName, listener)`
+- No `FlagValueChangeEvent` with old/new values; the listener must call `variation()` to get the current value
+
+#### .NET Client SDK (`dotnet-core`, `pkgs/sdk/client`)
+
+**Key file**: `pkgs/sdk/client/src/Interfaces/IFlagTracker.cs`
+
+API: C# event
+
+```csharp
+client.FlagTracker.FlagValueChanged += (sender, eventArgs) =>
+{
+    Console.WriteLine($"Flag '{eventArgs.Key}' changed from {eventArgs.OldValue} to {eventArgs.NewValue}");
+};
+```
+
+**Characteristics:**
+- A single `FlagValueChanged` event fires for **all** flags (no per-flag subscription at the SDK level)
+- `FlagValueChangeEvent` includes `Key`, `OldValue`, `NewValue`, and `Deleted`
+- Fires when `Identify` is called and any flag value changes for the new context
+- Does **not** fire on initial flag load—only on subsequent changes
+- Explicitly documented: does not fire when offline + Identify + stored data loaded (only fires for fresh data from LD)
+
+#### Android SDK (`android-client-sdk`)
+
+**Key files**:
+- `FeatureFlagChangeListener.java` — per-flag callback (`onFeatureFlagChange(String flagKey)`)
+- `LDAllFlagsListener.java` — all-flags callback (`onChange(List<String> flagKeys)`)
+- `LDClientInterface.java` — `registerFeatureFlagListener(key, listener)` / `unregisterFeatureFlagListener(key, listener)`
+
+Two distinct APIs:
+
+```java
+// Specific flag — listener receives only the key; must call variation() for new value
+client.registerFeatureFlagListener("flag-key", flagKey -> { ... });
+
+// All flags — listener receives the list of changed keys
+client.registerListener(allFlagsListener); // LDAllFlagsListener
+```
+
+**Characteristics:**
+- Per-flag listener: receives the flag key only (no old/new value in callback)
+- All-flags listener: receives `List<String>` of changed flag keys
+- Explicit register/unregister lifecycle (unlike JS `on`/`off`)
+- Fires when the flag value changes for the current evaluation context
+
+---
+
+### Key Differences: Client-Side vs Server-Side
+
+| Aspect | Server-Side | Client-Side |
+|---|---|---|
+| **Context** | Specified per listener call | Implicit: the client's current context |
+| **Data format (streaming)** | Full `FeatureFlag` model JSON | Evaluated results only (`ClientSDKFlagWithKey`) |
+| **Config vs value change** | Two listener types: general (config) + value | Value change only (client evaluates for one context) |
+| **All-flags listener** | Single listener registered with empty `FlagKey` | SDK-specific API: `on('change')`, `LDAllFlagsListener`, etc. |
+| **Old/new values in callback** | Yes (value listeners include `OldValue`/`NewValue`) | SDK-dependent: .NET yes; JS/Android no |
+| **Identify** | N/A | May fire listeners when `Identify` switches context and flag values differ |
+| **Targeting rules** | Evaluated server-side based on provided context | Pre-evaluated by LD; client receives the result |
+
+---
+
+### Can the Callback Architecture Work for Client-Side?
+
+**Yes.** The HTTP callback architecture is test-harness-level infrastructure—it sits between the test harness and the SDK test service. The test service (not the test harness) adapts to each SDK's native listener API. For client-side SDKs, the test service would:
+
+1. Register a `client.on('change:flag-key', ...)` (or platform-equivalent) listener internally
+2. When the listener fires, POST a `ListenerNotification` JSON body to the callback URL supplied in the `registerFlagChangeListener` or `registerFlagValueChangeListener` command
+3. The test harness receives the notification via `ListenerCallback.ExpectFlagChangeNotification()` or `ExpectValueChangeNotification()`
+
+The command wire protocol (`registerFlagChangeListener`, `registerFlagValueChangeListener`, `unregisterListener`) and the callback payload (`ListenerNotification`) remain **identical** between server-side and client-side. Only the test service implementation changes.
+
+**One important difference**: for client-side SDKs, the `Context` field in `RegisterFlagValueChangeListenerParams` is meaningless (the client has its own context). Test service implementers for client-side SDKs should ignore it. The test harness will either omit it or the test code should not send it for client-side tests.
+
+---
+
+### Streaming Data Format for Client-Side
+
+Client-side SDKs receive a different streaming payload from server-side SDKs. Instead of a full `FeatureFlag` model, they receive evaluated results:
+
+```json
+// Server-side patch: full FeatureFlag JSON
+{ "key": "flag-key", "version": 2, "on": false, "offVariation": 0, "variations": ["new-value", "other"], ... }
+
+// Client-side patch: evaluated result only (ClientSDKFlagWithKey)
+{ "key": "flag-key", "value": "new-value", "version": 2, "variation": 0 }
+```
+
+The existing `pushFlagUpdate` helper in listener tests uses `jsonhelpers.ToJSON(flag)` where `flag` is an `ldmodel.FeatureFlag`. For client-side tests, this must be replaced with `mockld.ClientSDKFlagWithKey` data.
+
+Additionally, JS-based client-side SDKs connect to the **polling** endpoint for initial data, and then SSE for streaming updates. The `CommonStreamingTests.setupDataSystems` method already handles this pattern with its switch on `c.sdkKind`.
+
+---
+
+### Plan: Sharing Tests Between Server and Client Side
+
+#### Approach: Refactor to `CommonListenerTests` Struct
+
+To support both SDK kinds, we should convert the standalone functions in `common_tests_listeners.go` to use the `commonTestsBase` struct pattern (the same approach as `CommonStreamingTests`, `CommonEventTests`, etc.). This enables SDK-kind-aware data setup, context handling, and streaming updates within the same test functions.
+
+The refactored type would look like:
+
+```go
+type CommonListenerTests struct {
+    commonTestsBase
+}
+
+func NewCommonListenerTests(t *ldtest.T) CommonListenerTests {
+    return CommonListenerTests{newCommonTestsBase(t, "CommonListenerTests")}
+}
+```
+
+Key helpers that need SDK-kind-aware variants:
+
+| Helper | Server-Side | Client-Side |
+|---|---|---|
+| `makeListenerFlag` | `ldmodel.FeatureFlag` | `mockld.ClientSDKFlagWithKey` |
+| `createClientForListeners` | `NewServerSDKDataBuilder()` | `NewClientSDKDataBuilder()` + polling endpoint for JS SDKs |
+| `pushFlagUpdate` | `jsonhelpers.ToJSON(featureFlag)` | `jsonhelpers.ToJSON(clientSDKFlagWithKey)` |
+| Context in register params | Provided explicitly | Omitted or use client's initial context |
+
+#### Tests That Can Be Shared (with SDK-kind-aware setup)
+
+| Test | Shareable? | Notes |
+|---|---|---|
+| `flagValueChangeListenerReceivesNotification` | ✅ Yes | Adjust data format and omit context for client-side |
+| `flagValueChangeListenerNoNotificationWhenUnchanged` | ✅ Yes | Same adjustments |
+| `multipleValueListenersBothNotified` | ✅ Yes | Same adjustments |
+| `flagChangeListenerReceivesNotification` | ✅ Yes | Works if SDKs support `FlagKey`-filtered general listeners |
+| `flagChangeListenerFiltersByFlagKey` | ✅ Yes | Android natively filters per key; JS uses `change:key` |
+| `flagChangeListenerEmptyKeyReceivesAllFlags` | ⚠️ Partial | API differs (JS: `on('change')`, Android: `LDAllFlagsListener`, .NET: single event always); may need SDK-kind-specific commands |
+| `flagChangeListenerFiresOnConfigChange` | ❌ Server-side only | Client-side only receives evaluated results; "config change without value change" is invisible to client |
+| `valueListenerIsContextSpecific` | ❌ Server-side only | Client-side has a single current context; cannot test per-context isolation this way |
+
+#### Tests That Need Client-Side-Specific Variants
+
+1. **Identify test** (already deferred from Phase 3): A test that calls `Identify` with a new context and verifies the listener fires when flag values differ for the new context. This is a client-side-only concern because server-side SDKs don't have an `Identify` operation.
+
+#### Implementation Steps for Client-Side Support
+
+The steps below are captured in the Implementation Plan under Phase 3B.
+
+1. **Refactor `common_tests_listeners.go`** to use a `CommonListenerTests` struct embedding `commonTestsBase`
+2. **Add SDK-kind-aware helpers**: `makeListenerFlagForSDK`, `createClientForListenerTests`, `pushListenerFlagUpdate` that branch on `c.isClientSide`
+3. **Update `testsuite_entry_point.go`** to call `doCommonListenerTests` from `doAllClientSideTests` once the refactoring is complete
+4. **Implement Identify test** for client-side (deferred)
+
+---
+
 ## Proposed Test Harness Design
 
 ### Design Decision: Command Structure
@@ -1151,20 +1329,52 @@ func (c CommonListenerTests) rapidFlagChanges(t *ldtest.T) {
 - Client API for listener management
 - Helper functions for common patterns
 
-### Phase 3: Test Implementation
+### Phase 3: Test Implementation (Server-Side) ✅ Complete
 
 **Tasks:**
-1. Create `common_tests_listeners.go`
-2. Implement core test scenarios:
-   - Basic value change
-   - Multiple listeners
-   - Unregister
-   - Context-specific
-3. Add tests to suite entry points
+1. Create `common_tests_listeners.go` with standalone test functions ✅
+2. Implement core test scenarios: ✅
+   - `flagChangeListenerReceivesNotification`
+   - `flagChangeListenerFiresOnConfigChange`
+   - `flagChangeListenerFiltersByFlagKey`
+   - `flagChangeListenerEmptyKeyReceivesAllFlags`
+   - `flagValueChangeListenerReceivesNotification`
+   - `flagValueChangeListenerNoNotificationWhenUnchanged`
+   - `multipleValueListenersBothNotified`
+   - `valueListenerIsContextSpecific`
+3. Register `doCommonListenerTests` in `doAllServerSideTests` ✅
 
-**Deliverables:**
-- Complete test suite
-- Integration with existing test structure
+**Status**: Complete and verified against Go Server SDK.
+
+### Phase 3B: Test Implementation (Client-Side)
+
+**Goal**: Extend existing listener tests to also run against client-side SDKs, where the test logic is similar but data setup, streaming format, and context handling differ.
+
+**Tasks:**
+1. **Refactor `common_tests_listeners.go`** to use a `CommonListenerTests` struct embedding `commonTestsBase` (same pattern as `CommonStreamingTests`)
+2. **Add SDK-kind-aware data helpers**:
+   - `makeListenerFlagForSDK(key, version, value)` — returns `ServerSDKData` or `ClientSDKData`
+   - `createClientForListenerTests(t)` — handles polling endpoint for JS SDKs
+   - `pushListenerFlagUpdate(dataSystem, key, version, value)` — sends `ClientSDKFlagWithKey` for client-side, `FeatureFlag` for server-side
+3. **Mark server-side-only tests** with `t.RequireCapability(servicedef.CapabilityServerSide)` or move to a separate `doServerSideListenerTests` group
+4. **Add Identify test** for client-side: verifies that a listener fires when `Identify` changes the context and flag values differ for the new context
+5. **Register `doCommonListenerTests` in `doAllClientSideTests`** once refactoring is complete
+
+**Tests that require refactoring to work for client-side:**
+
+| Test | Action needed |
+|---|---|
+| `flagValueChangeListenerReceivesNotification` | Omit context from register params for client-side; use client-side data format |
+| `flagValueChangeListenerNoNotificationWhenUnchanged` | Same |
+| `multipleValueListenersBothNotified` | Same |
+| `flagChangeListenerReceivesNotification` | Same; test service uses `on('change:key')` or equivalent |
+| `flagChangeListenerFiltersByFlagKey` | Same |
+| `flagChangeListenerEmptyKeyReceivesAllFlags` | Same; test service uses `on('change')` or `LDAllFlagsListener` |
+| `flagChangeListenerFiresOnConfigChange` | Server-side only (client-side sees evaluated results, not config) |
+| `valueListenerIsContextSpecific` | Server-side only (client-side has one context) |
+
+**New tests for client-side only:**
+- `listenerFiresOnIdentify`: call `Identify` with a new context; verify value change listener fires when the flag value differs for the new context
 
 ### Phase 4: SDK Implementation (Ongoing)
 
@@ -1572,26 +1782,217 @@ Priority should be based on SDK usage metrics to maximize impact. Suggested appr
 
 ### SDK-Specific Considerations
 
-1. **Go SDK**
-   - Uses channels, not callbacks
-   - Test service needs goroutine to consume channel
-   - How to handle channel buffer overflow?
+See [Client-Side SDK Analysis](#client-side-sdk-analysis) for a full breakdown of client-side listener APIs and the test sharing plan.
 
-2. **JavaScript/Node.js**
-   - Event emitter pattern
-   - May have different syntax for specific vs all flags
+1. **Go Server SDK** ✅ Implemented
+   - Uses channels, not callbacks; test service spins a goroutine per listener
+   - `FlagTracker.AddFlagChangeListener()` returns a channel; test service drains it and POSTs to callback URL
+   - Integrated and passing tests; see `go-server-sdk` test service implementation
 
-3. **Mobile SDKs**
-   - May have background/foreground behavior
-   - Listener registration during initialization
+2. **JavaScript / React Native (js-core)**
+   - Event emitter: `client.on('change:key', cb)` for specific flags, `client.on('change', cb)` for all flags
+   - No old/new values in callback; test service must use `variation()` to get current value for `ListenerNotification`
+   - For value change listeners: the test service re-evaluates the flag after receiving the event
+   - JS client-side SDKs need a polling endpoint alongside the streaming endpoint (initial data via polling)
 
-4. **Roku**
-   - Uses `observeField` - different pattern entirely
-   - May need special handling
+3. **.NET Client SDK (`dotnet-core`)**
+   - Single `FlagTracker.FlagValueChanged` event for all flags; event args include `Key`, `OldValue`, `NewValue`
+   - For `registerFlagChangeListener` (general): subscribe to the event, filter by `Key` if `FlagKey` is set
+   - For `registerFlagValueChangeListener`: subscribe and use the provided old/new values directly
+   - Fires on `Identify` when flag values change for the new context
+
+4. **Android SDK**
+   - `registerFeatureFlagListener(key, listener)` for per-flag (no values in callback; must call `variation()`)
+   - `LDAllFlagsListener` for all-flags changes
+   - For `registerFlagChangeListener` with empty `FlagKey`: use `LDAllFlagsListener`
+   - For `registerFlagValueChangeListener`: use per-flag listener + call `variation()` for old/new values
+
+5. **Mobile SDKs (general)**
+   - May have background/foreground behavior affecting streaming
+   - Streaming data format is `ClientSDKFlagWithKey` (evaluated result), not the full flag model
+
+6. **Roku**
+   - Uses `observeField` — a different event pattern
+   - May need special handling or suppression of listener tests
 
 ---
 
-## References
+## JS Test Service Implementation Guide
+
+This section is a self-contained reference for implementing `flag-change-listeners` support in the **`js-core`** test service. It is intended to be read in a fresh Cursor session scoped to the `js-core` repository.
+
+### Background
+
+The sdk-test-harness defines a contract between itself and each SDK's **test service** (a small HTTP server that wraps the SDK). The test harness sends commands to the test service; the test service calls the SDK and then POSTs a callback to a URL provided by the harness.
+
+For flag change listeners, the test service must:
+1. Advertise the `"flag-change-listeners"` capability in its `/` status response
+2. Handle three new commands: `registerFlagChangeListener`, `registerFlagValueChangeListener`, `unregisterListener`
+3. When a listener fires, HTTP POST a `ListenerNotification` JSON body to the `callbackUri` supplied in the command params
+
+### Reference Implementation
+
+The **hooks** feature in `js-core` is the closest existing analog and should be used as a pattern. Find the hooks test service implementation (search for `"evaluation-hooks"` or `HookExecutionPayload` in the test service code) to understand:
+- How a new capability is added to the status response
+- How a new command is dispatched in the command handler
+- How an HTTP callback is POSTed from the test service
+
+### New Commands
+
+#### `registerFlagChangeListener`
+
+Registers a general flag change listener. The listener fires whenever the flag's configuration changes (regardless of whether the evaluated value changes). If `flagKey` is empty, the listener fires for any flag.
+
+**JSON params** (field `registerFlagChangeListener` in the command body):
+```json
+{
+  "listenerId": "listener-1",
+  "flagKey": "my-flag",
+  "callbackUri": "http://test-harness-host/callback/123"
+}
+```
+
+**JS SDK mapping:**
+```typescript
+// Specific flag
+client.on(`change:${flagKey}`, handler);
+
+// All flags (flagKey is empty string)
+client.on('change', handler);
+```
+
+**When the listener fires**, POST to `callbackUri`:
+```json
+{
+  "listenerId": "listener-1",
+  "flagKey": "my-flag"
+}
+```
+
+> **Important:** For a general flag change listener, do NOT include `oldValue` or `newValue` in the notification. The test harness only checks `flagKey`.
+
+> **JS caveat:** The `'change:key'` event fires with the current context as argument; the `'change'` event fires with `(context, changedFlagKeys[])`. For the general listener, you only need to POST the notification — no flag evaluation needed.
+
+#### `registerFlagValueChangeListener`
+
+Registers a value change listener. The listener fires only when the flag's evaluated value actually changes.
+
+**JSON params** (field `registerFlagValueChangeListener` in the command body):
+```json
+{
+  "listenerId": "listener-1",
+  "flagKey": "my-flag",
+  "context": { "kind": "user", "key": "user-key" },
+  "defaultValue": "default",
+  "callbackUri": "http://test-harness-host/callback/123"
+}
+```
+
+> **JS caveat:** The `context` field should be **ignored** for client-side SDKs. The JS client evaluates for its own current context; the context sent by the harness is meaningless and should not be used.
+
+**JS SDK mapping:**
+```typescript
+// Must capture oldValue at registration time, then re-evaluate after each change
+let oldValue = client.variation(flagKey, defaultValue);
+
+const handler = (context) => {
+  const newValue = client.variation(flagKey, defaultValue);
+  if (/* newValue !== oldValue */) {
+    // POST notification
+    oldValue = newValue;
+  }
+};
+
+client.on(`change:${flagKey}`, handler);
+```
+
+> **Important note on value change detection:** The JS SDK's `'change:key'` event already fires only when the value changes, so the `oldValue !== newValue` check may be redundant. However, capturing `oldValue` at registration time and including both in the notification is required because the harness asserts on both `OldValue` and `NewValue` in `ExpectValueChangeNotification`.
+
+**When the listener fires**, POST to `callbackUri`:
+```json
+{
+  "listenerId": "listener-1",
+  "flagKey": "my-flag",
+  "oldValue": "value1",
+  "newValue": "new-value"
+}
+```
+
+#### `unregisterListener`
+
+Removes a previously registered listener (either kind).
+
+**JSON params** (field `unregisterListener` in the command body):
+```json
+{
+  "listenerId": "listener-1"
+}
+```
+
+**JS SDK mapping:**
+```typescript
+client.off(eventName, handler);
+```
+
+The test service must keep a map of `listenerId → { eventName, handler }` so it can call `client.off()` with the right arguments.
+
+### Callback HTTP Protocol
+
+- **Method**: POST
+- **URL**: the `callbackUri` from the command params
+- **Body**: JSON (`ListenerNotification` as shown above)
+- **Expected response**: any 2xx; ignore the body
+- **No retries**: fire-and-forget; if the POST fails, do not retry
+
+### Listener Map (Bookkeeping)
+
+The test service needs a map keyed by `listenerId` to:
+1. Retrieve the handler for `unregisterListener`
+2. Avoid memory leaks from orphaned listeners
+
+Suggested shape:
+```typescript
+interface ListenerEntry {
+  eventName: string;    // e.g. 'change:my-flag' or 'change'
+  handler: Function;
+}
+const listeners = new Map<string, ListenerEntry>();
+```
+
+### Capability Declaration
+
+In the `/` status response, add:
+```json
+"flag-change-listeners"
+```
+
+to the `capabilities` array.
+
+### Streaming Setup for Listener Tests
+
+The test harness listener tests always use **streaming** (not polling) to push flag updates. For JS-based SDKs, the test harness will set up two data sources:
+1. A **polling** endpoint (for initial data — JS SDKs always poll first)
+2. A **streaming/SSE** endpoint (for updates)
+
+The test service does not need to do anything special here — this is handled by the test harness side. The test service just needs to connect to whatever endpoints the harness configures.
+
+### Test Coverage
+
+The test harness will run these tests against your implementation (once `"flag-change-listeners"` is in the capabilities):
+
+**Flag change listener (general)**
+- `receives notification when flag changes` — specific key, value changes
+- `fires on config change even when value unchanged` — **SKIPPED** for client-side (server-side only)
+- `filters by flag key` — only fires for the subscribed flag, not others
+- `with empty flag key receives all flag changes` — `client.on('change', ...)` path
+
+**Flag value change listener**
+- `receives notification when value changes` — must include oldValue and newValue
+- `does not notify when value is unchanged` — same value pushed, no POST expected
+- `multiple listeners both receive notification` — two listeners for same flag, both fire
+- `is context specific` — **SKIPPED** for client-side (server-side only)
+
+---
 
 ### LaunchDarkly Documentation
 - [Flag Changes (General)](https://launchdarkly.com/docs/sdk/features/flag-changes)
@@ -1644,4 +2045,5 @@ Priority should be based on SDK usage metrics to maximize impact. Suggested appr
 | 2026-02-13 | Update | Analyzed "Async Callback Handling": confirmed 5-second timeout standard (matching hooks/events), confirmed SDKs don't batch listener notifications |
 | 2026-02-13 | Update | Analyzed "Error Cases" and "Thread Safety": documented existing test harness patterns from hooks and client independence tests; decided to follow these established patterns |
 | 2026-02-13 | Update | Analyzed all "Technical Questions" (HTTP semantics, ID format, cleanup): documented callback service patterns from hooks; all questions now decided using existing conventions |
+| 2026-02-19 | Update | Added Client-Side SDK Analysis section: surveyed JS/React Native, .NET Client, and Android listener APIs; concluded callback architecture works for client-side; documented key differences in data format and context handling; created Phase 3B plan for refactoring tests to support both SDK kinds |
 

--- a/.cursor/change-listener-tests-research.md
+++ b/.cursor/change-listener-tests-research.md
@@ -1,0 +1,1647 @@
+# Flag Change Listener Tests - Research Document
+
+**Status**: Planning  
+**Last Updated**: 2026-02-12  
+**Related Documentation**: [LaunchDarkly Flag Changes Documentation](https://launchdarkly.com/docs/sdk/features/flag-changes)
+
+## Table of Contents
+- [Overview](#overview)
+- [Current State](#current-state)
+- [Go SDK Implementation Analysis](#go-sdk-implementation-analysis)
+- [Multi-SDK Implementation Analysis](#multi-sdk-implementation-analysis)
+  - [Cross-SDK Comparison](#cross-sdk-comparison)
+  - [Universal Design Patterns](#universal-design-patterns)
+  - [Implications for Test Harness](#implications-for-test-harness)
+- [Proposed Test Harness Design](#proposed-test-harness-design)
+- [Implementation Plan](#implementation-plan)
+- [Open Questions](#open-questions)
+- [References](#references)
+
+---
+
+## Overview
+
+This document describes the design and implementation plan for adding flag change listener tests to the SDK test harness. Flag change listeners allow applications to react to feature flag changes immediately through push notifications rather than polling.
+
+### What are Flag Change Listeners?
+
+Flag change listeners are SDK features that notify application code when feature flag configurations or values change. They provide a push-based alternative to polling for flag changes.
+
+**Use Cases:**
+- Update UI immediately when a flag changes
+- React to promotional flag changes
+- Enable/disable feature code paths efficiently
+- Show/hide outage bulletins
+- Grant entitlements dynamically
+
+### SDK Support
+
+Flag change listeners are supported across:
+- **Server-side SDKs**: .NET, Go, Java, Node.js, Python, Ruby
+- **Client-side SDKs**: .NET (client), Android, C++, Electron, Flutter, iOS, JavaScript, Node.js (client), React Native, Roku
+
+---
+
+## Current State
+
+### Test Harness Status
+
+After reviewing the test harness codebase, **flag change listeners are NOT currently tested**.
+
+**Evidence:**
+- No dedicated test files for listeners (no `*listener*.go` or `*change*.go` files)
+- No commands in `servicedef/command_params.go` for listener lifecycle
+- No capability flags in the service spec for listener support
+- Existing stream update tests (`common_tests_stream_updates.go`) verify flag updates by **polling** the evaluation API, not via push notifications
+
+**What Currently Exists:**
+- Tests that push flag updates via streaming (`mockld.StreamingService.PushUpdate()`)
+- Helper functions that poll the client to check if values changed:
+  - `checkForUpdatedValue()` - polls once
+  - `pollUntilFlagValueUpdated()` - polls repeatedly with timeout
+- These verify the SDK receives updates correctly but don't test listener APIs
+
+---
+
+## Go SDK Implementation Analysis
+
+We analyzed the [Go server SDK](https://github.com/launchdarkly/go-server-sdk) implementation as a reference.
+
+### Architecture
+
+**Interface Location**: `interfaces/flag_tracker.go`  
+**Implementation**: `internal/flag_tracker_impl.go`  
+**Tests**: `ldclient_listeners_test.go`, `ldclient_listeners_fdv2_test.go`
+
+### Two Listener Types
+
+#### 1. General Flag Change Listener
+
+```go
+AddFlagChangeListener() <-chan FlagChangeEvent
+```
+
+**Characteristics:**
+- Returns a Go channel receiving `FlagChangeEvent`
+- Fires when **any** flag configuration changes
+- Event contains only `Key` (flag key) - no values
+- Also fires for prerequisite or segment changes
+- **Does not guarantee value changed** - just that configuration changed
+
+**Event Structure:**
+```go
+type FlagChangeEvent struct {
+    Key string  // The flag key that changed
+}
+```
+
+#### 2. Flag Value Change Listener
+
+```go
+AddFlagValueChangeListener(
+    flagKey string,
+    context ldcontext.Context,
+    defaultValue ldvalue.Value,
+) <-chan FlagValueChangeEvent
+```
+
+**Characteristics:**
+- Tracks a **specific flag and evaluation context**
+- Immediately evaluates flag upon registration (gets initial value)
+- Re-evaluates whenever underlying flag changes
+- Only sends event if **value actually changed** (not just config)
+- Requires evaluation context even for global flags
+
+**Event Structure:**
+```go
+type FlagValueChangeEvent struct {
+    Key      string        // Flag key
+    OldValue ldvalue.Value // Previous value
+    NewValue ldvalue.Value // New value
+}
+```
+
+### Implementation Details
+
+**Channel-Based Architecture:**
+- Go uses channels (goroutines) rather than callbacks
+- Caller is responsible for consuming from channels
+- Important: Unconsumed events can block SDK goroutines
+
+**Value Change Implementation:**
+```go
+func runValueChangeListener(
+    flagCh <-chan interfaces.FlagChangeEvent,
+    valueCh chan<- interfaces.FlagValueChangeEvent,
+    evaluateFn func(flagKey string, context ldcontext.Context, defaultValue ldvalue.Value) ldvalue.Value,
+    flagKey string,
+    context ldcontext.Context,
+    defaultValue ldvalue.Value,
+)
+```
+
+**How it works:**
+1. Evaluates flag immediately to get initial value
+2. Subscribes to general flag change events
+3. Filters for the specific flag key
+4. Re-evaluates on each change
+5. Compares old vs new value
+6. Only sends event if value changed
+
+**Broadcaster Pattern:**
+- Uses internal `Broadcaster[FlagChangeEvent]`
+- All listeners subscribe to this broadcaster
+- Broadcaster pushes events to all registered listeners
+
+### Client Access
+
+```go
+client := MakeClient(sdkKey, waitTime)
+tracker := client.GetFlagTracker()
+
+// General listener
+ch1 := tracker.AddFlagChangeListener()
+
+// Value listener
+ch2 := tracker.AddFlagValueChangeListener(flagKey, context, defaultValue)
+```
+
+### Test Examples
+
+From `ldclient_listeners_test.go`:
+
+```go
+// Test general flag change events
+ch1 := client.GetFlagTracker().AddFlagChangeListener()
+ch2 := client.GetFlagTracker().AddFlagChangeListener()
+
+testData.Update(testData.Flag(flagKey))
+
+event1 := <-ch1  // Receive event
+assert.Equal(t, flagKey, event1.Key)
+
+// Test value change events
+user := lduser.NewUser("important-user")
+ch := client.GetFlagTracker().AddFlagValueChangeListener(flagKey, user, ldvalue.Null())
+
+testData.Update(testData.Flag(flagKey).VariationForUser(user.Key(), true))
+
+event := <-ch
+assert.Equal(t, flagKey, event.Key)
+assert.Equal(t, ldvalue.Bool(false), event.OldValue)
+assert.Equal(t, ldvalue.Bool(true), event.NewValue)
+```
+
+### Key Insights
+
+1. **Channel vs Callback**: Go uses channels, but most languages use callbacks/events - test harness needs language-agnostic approach
+2. **Two Distinct APIs**: Config changes vs value changes - value changes are more application-relevant
+3. **Context Required**: Even "global" flags need a context for value listeners
+4. **Immediate Evaluation**: Value listeners evaluate on registration, not just changes
+5. **Filtering in SDK**: SDK handles filtering general changes to specific flags internally
+
+---
+
+## Multi-SDK Implementation Analysis
+
+To inform a comprehensive test harness design, we analyzed flag change listener implementations across three additional SDKs representing different language paradigms and architectural patterns.
+
+### .NET SDK Implementation
+
+**Repository**: [launchdarkly/dotnet-core](https://github.com/launchdarkly/dotnet-core)  
+**Interface Location**: `pkgs/sdk/server/src/Interfaces/IFlagTracker.cs`  
+**Implementation**: `pkgs/sdk/server/src/Internal/FlagTrackerImpl.cs`
+
+#### Architecture Pattern: .NET Events
+
+The .NET SDK uses C# events (delegate-based observers) for listener notifications:
+
+```csharp
+public interface IFlagTracker
+{
+    // General flag change event
+    event EventHandler<FlagChangeEvent> FlagChanged;
+    
+    // Factory method for value change handler
+    EventHandler<FlagChangeEvent> FlagValueChangeHandler(
+        string flagKey,
+        Context context,
+        EventHandler<FlagValueChangeEvent> handler
+    );
+}
+```
+
+#### Two-Tier Event System
+
+**1. General Flag Changes:**
+```csharp
+client.FlagTracker.FlagChanged += (sender, eventArgs) => {
+    Console.WriteLine("Flag changed: " + eventArgs.Key);
+};
+```
+
+**2. Value-Specific Changes (Factory Pattern):**
+```csharp
+var listenForNewValue = client.FlagTracker.FlagValueChangeHandler(
+    flagKey,
+    contextForFlagEvaluation,
+    (sender, changeArgs) => {
+        Console.WriteLine($"Flag '{changeArgs.Key}' changed from " +
+            $"{changeArgs.OldValue} to {changeArgs.NewValue}");
+    }
+);
+client.FlagTracker.FlagChanged += listenForNewValue;
+```
+
+#### Event Structures
+
+```csharp
+public struct FlagChangeEvent {
+    public string Key { get; }
+}
+
+public struct FlagValueChangeEvent {
+    public string Key { get; }
+    public LdValue OldValue { get; }
+    public LdValue NewValue { get; }
+}
+```
+
+#### Implementation Pattern: Monitor Class
+
+The .NET SDK uses an internal `FlagValueChangeMonitor` class that:
+1. Evaluates the flag immediately on creation
+2. Stores the current value with thread-safe locking
+3. Subscribes to general flag changes
+4. Re-evaluates on each change and compares
+5. Only invokes handler if value changed
+
+```csharp
+private sealed class FlagValueChangeMonitor {
+    private readonly object _valueLock = new object();
+    private LdValue _value;
+    
+    internal void OnFlagChanged(object sender, FlagChangeEvent eventArgs) {
+        if (eventArgs.Key != _flagKey) return;
+        
+        var newValue = _evaluateFn(_flagKey, _context);
+        LdValue oldValue = LdValue.Null;
+        bool changed = false;
+        
+        lock (_valueLock) {
+            if (!_value.Equals(newValue)) {
+                changed = true;
+                oldValue = _value;
+                _value = newValue;
+            }
+        }
+        
+        if (changed) {
+            _handler(sender, new FlagValueChangeEvent(_flagKey, oldValue, newValue));
+        }
+    }
+}
+```
+
+#### Key Insights for .NET
+- **Event-based pattern**: Standard C# events (not channels or promises)
+- **Factory method**: Creates and returns a handler to attach to main event
+- **Thread safety**: Explicit locking for value storage
+- **Synchronous invocation**: Handlers called directly on event thread
+
+---
+
+### JavaScript SDK Implementation
+
+**Repository**: [launchdarkly/js-core](https://github.com/launchdarkly/js-core)  
+**Client Location**: `packages/shared/sdk-client/src/LDClientImpl.ts`  
+**Emitter**: `packages/shared/sdk-client/src/LDEmitter.ts`
+
+#### Architecture Pattern: EventEmitter
+
+The JavaScript SDK uses an event emitter pattern similar to Node.js:
+
+```typescript
+type EventName = 
+  | 'change'                    // All flag changes
+  | `change:${string}`          // Specific flag changes (e.g., 'change:my-flag')
+  | 'dataSourceStatus'
+  | 'error'
+  | 'initialized'
+  | 'ready';
+
+class LDEmitter {
+  on(name: EventName, listener: Function): void
+  off(name: EventName, listener?: Function): void
+  emit(name: EventName, ...detail: any[]): void
+}
+```
+
+#### Usage Patterns
+
+**1. Listen to All Flag Changes:**
+```javascript
+client.on('change', (changes) => {
+  console.log('Flags changed:', Object.keys(changes));
+});
+```
+
+**2. Listen to Specific Flag:**
+```javascript
+client.on('change:my-flag-key', (current, previous) => {
+  console.log(`Flag changed from ${previous} to ${current}`);
+});
+```
+
+#### Event Payload
+
+Unlike Go and .NET which provide structured event objects, JavaScript passes current and previous values directly:
+
+```javascript
+// General change event - receives all changed flags
+client.on('change', (changedFlags) => {
+  // changedFlags = { 'flag-1': { current: true, previous: false }, ... }
+});
+
+// Specific flag change - receives values only
+client.on('change:flag-key', (currentValue, previousValue) => {
+  // currentValue = true, previousValue = false
+});
+```
+
+#### Implementation Details
+
+**LDEmitter Implementation:**
+```typescript
+class LDEmitter {
+  private _listeners: Map<EventName, Function[]> = new Map();
+
+  on(name: EventName, listener: Function) {
+    if (!this._listeners.has(name)) {
+      this._listeners.set(name, [listener]);
+    } else {
+      this._listeners.get(name)?.push(listener);
+    }
+  }
+
+  off(name: EventName, listener?: Function) {
+    if (!listener) {
+      // Remove all listeners for this event
+      this._listeners.delete(name);
+    } else {
+      // Remove specific listener
+      const updated = existingListeners.filter(fn => fn !== listener);
+      this._listeners.set(name, updated);
+    }
+  }
+
+  emit(name: EventName, ...detail: any[]) {
+    this._listeners.get(name)?.forEach(listener => {
+      try {
+        listener(...detail);
+      } catch (err) {
+        this._logger?.error(`Error invoking handler: ${err}`);
+      }
+    });
+  }
+}
+```
+
+#### Key Insights for JavaScript
+- **String-based event names**: Uses convention `'change:flag-key'` for specificity
+- **Multiple signatures**: General vs specific flag listeners have different payloads
+- **Error isolation**: Exceptions in one listener don't affect others
+- **No structured events**: Values passed directly, not wrapped in event objects
+- **Client-side oriented**: Designed for browser/React Native environments
+
+---
+
+### Python SDK Implementation
+
+**Repository**: [launchdarkly/python-server-sdk](https://github.com/launchdarkly/python-server-sdk)  
+**Interface Location**: `ldclient/interfaces.py`  
+**Implementation**: `ldclient/impl/flag_tracker.py`  
+**Tests**: `ldclient/testing/impl/test_flag_tracker.py`
+
+#### Architecture Pattern: Callback Functions
+
+The Python SDK uses simple callable functions as listeners:
+
+```python
+class FlagTracker:
+    @abstractmethod
+    def add_listener(self, listener: Callable[[FlagChange], None]):
+        """Register a listener for all flag changes"""
+        pass
+    
+    @abstractmethod
+    def remove_listener(self, listener: Callable[[FlagChange], None]):
+        """Unregister a listener"""
+        pass
+    
+    @abstractmethod
+    def add_flag_value_change_listener(
+        self, 
+        key: str, 
+        context: Context, 
+        listener: Callable[[FlagValueChange], None]
+    ):
+        """Register a listener for a specific flag's value changes"""
+        pass
+```
+
+#### Event Structures
+
+```python
+class FlagChange:
+    def __init__(self, key: str):
+        self.__key = key
+    
+    @property
+    def key(self) -> str:
+        return self.__key
+
+class FlagValueChange:
+    def __init__(self, key, old_value, new_value):
+        self.__key = key
+        self.__old_value = old_value
+        self.__new_value = new_value
+    
+    @property
+    def key(self):
+        return self.__key
+    
+    @property
+    def old_value(self):
+        return self.__old_value
+    
+    @property
+    def new_value(self):
+        return self.__new_value
+```
+
+#### Usage Pattern
+
+```python
+# General flag changes
+def on_flag_changed(change):
+    print(f"Flag changed: {change.key}")
+
+client.flag_tracker.add_listener(on_flag_changed)
+
+# Specific flag value changes
+def on_value_changed(change):
+    print(f"Flag {change.key} changed from {change.old_value} to {change.new_value}")
+
+context = Context.create("user-key")
+client.flag_tracker.add_flag_value_change_listener(
+    "my-flag", 
+    context, 
+    on_value_changed
+)
+```
+
+#### Test Example
+
+From `test_flag_tracker.py`:
+
+```python
+def test_flag_change_listener_notified_when_value_changes():
+    responses = ['initial', 'second', 'second', 'final']
+    
+    def eval_fn(key, context):
+        return responses.pop(0)
+    
+    listeners = Listeners()
+    tracker = FlagTrackerImpl(listeners, eval_fn)
+    
+    spy = SpyListener()
+    tracker.add_flag_value_change_listener('flag-key', None, spy)
+    
+    listeners.notify(FlagChange('flag-key'))  # First change
+    assert len(spy.statuses) == 1
+    
+    listeners.notify(FlagChange('flag-key'))  # No change (second -> second)
+    assert len(spy.statuses) == 1  # Still 1
+    
+    listeners.notify(FlagChange('flag-key'))  # Third change
+    assert len(spy.statuses) == 2
+    
+    assert spy.statuses[0].old_value == 'initial'
+    assert spy.statuses[0].new_value == 'second'
+    assert spy.statuses[1].old_value == 'second'
+    assert spy.statuses[1].new_value == 'final'
+```
+
+#### Implementation Pattern: Listeners Broadcaster
+
+The Python SDK uses an internal `Listeners` class that maintains a registry and broadcasts to all:
+
+```python
+class FlagTrackerImpl:
+    def __init__(self, listeners: Listeners, eval_fn):
+        self._listeners = listeners
+        self._eval_fn = eval_fn
+    
+    def add_flag_value_change_listener(self, key, context, listener):
+        # Create a wrapper that filters and re-evaluates
+        current_value = self._eval_fn(key, context)
+        
+        def value_change_handler(change):
+            nonlocal current_value
+            if change.key != key:
+                return
+            new_value = self._eval_fn(key, context)
+            if new_value != current_value:
+                listener(FlagValueChange(key, current_value, new_value))
+                current_value = new_value
+        
+        self._listeners.add(value_change_handler)
+        return value_change_handler  # Return for later removal
+```
+
+#### Key Insights for Python
+- **Simple callables**: Any callable accepting the event object
+- **Property-based access**: Event objects use `@property` decorators
+- **Closure-based filtering**: Value change listeners use closures to track state
+- **Returns listener handle**: Can use returned value to unregister
+- **No explicit threading**: Synchronous notification (thread safety handled elsewhere)
+
+---
+
+### Cross-SDK Comparison
+
+| Aspect | Go | .NET | JavaScript | Python |
+|--------|----|----|------------|--------|
+| **Notification Mechanism** | Channels | Events | EventEmitter | Callbacks |
+| **Registration Pattern** | Returns channel | Event subscription | `on(name, fn)` | `add_listener(fn)` |
+| **Unregistration** | `Remove(channel)` | Event unsubscription | `off(name, fn)` | `remove_listener(fn)` |
+| **Value Change API** | Separate method | Factory method | Same API, different name | Separate method |
+| **Event Structure** | Struct | Struct | Function params | Class |
+| **Threading Model** | Goroutines | Delegates (thread-safe) | Single-threaded | Thread-agnostic |
+| **Error Handling** | Channels (non-blocking) | Sync (can throw) | Try-catch per listener | Sync (can throw) |
+| **Type System** | Strongly typed | Strongly typed | TypeScript optional | Duck-typed |
+
+### Universal Design Patterns
+
+Despite different implementation approaches, all SDKs share:
+
+1. **Two-tier listening**: General flag changes + specific value changes
+2. **Immediate evaluation**: Value listeners evaluate on registration
+3. **Change detection**: Only notify if value actually changed
+4. **Context binding**: Value listeners bind to a specific evaluation context
+5. **Filtering in SDK**: SDK internally filters general changes to specific flags
+6. **Cleanup support**: All provide unregistration mechanisms
+
+### Implications for Test Harness
+
+The test harness design must accommodate:
+
+1. **Language-agnostic callback mechanism**: Use HTTP callbacks (POST to URL)
+2. **Flexible event payload**: JSON structure that works for all SDKs
+3. **Async handling**: Some SDKs are async (Go channels, JS promises), others sync
+4. **Context requirement**: All SDKs require context for value listeners (even global flags)
+5. **Unregistration semantics**: Support listener cleanup testing
+6. **Error isolation**: Test services should handle SDK exceptions gracefully
+
+---
+
+## Proposed Test Harness Design
+
+### Design Decision: Command Structure
+
+#### Question: Separate Commands vs Unified Command?
+
+Should the test harness use:
+- **Option A**: Two separate commands (`registerFlagChangeListener`, `registerFlagValueChangeListener`)
+- **Option B**: One unified command with a type parameter
+
+#### Decision: ✅ Separate Commands
+
+**Rationale:**
+
+| **Separate Commands (Chosen)** | **Unified Command** |
+|-------------------------------|---------------------|
+| ✅ Type safety - required fields enforced at compile time | ❌ Runtime validation required |
+| ✅ Matches SDK APIs directly | ❌ Doesn't match SDK method signatures |
+| ✅ Simple implementation - direct command→SDK mapping | ❌ Requires branching/switching logic |
+| ✅ Clear intent from command name | ❌ Must inspect type parameter to understand |
+| ✅ Better validation errors at compile time | ❌ Runtime errors for missing Context |
+| ✅ Follows existing pattern (hooks, migrations) | ❌ No precedent in test harness |
+| ✅ Easier to test in isolation | ❌ Tests must handle multiple payload formats |
+| ✅ Self-documenting code | ❌ Requires conditional documentation |
+| ❌ More code (2 commands, 2 params) | ✅ Less code overall |
+| ❌ Some duplication (ListenerID, CallbackURI) | ✅ No duplication |
+
+**Key insight**: The two listener types have fundamentally different parameters (value-change requires Context and DefaultValue), which makes them poor candidates for unification. Separate commands provide type safety and clarity.
+
+**Existing Pattern**: The hooks implementation (`testapi_hooks.go`, `mockld/hook_callback_service.go`) demonstrates the callback pattern we're following.
+
+### 1. New Capability Flag
+
+Add to `docs/service_spec.md`:
+
+```markdown
+#### Capability `"flag-change-listeners"`
+
+This means that the SDK supports subscribing to flag change notifications. The SDK should 
+provide a mechanism to register listeners/callbacks that are invoked when flag changes occur.
+
+For SDKs that support both general flag change events and value change events, the test 
+harness will test both types:
+- **General flag change listeners**: Test that the SDK notifies when any flag configuration changes
+- **Value change listeners**: Test that the SDK notifies when a flag's evaluated value changes 
+  for a specific context
+
+Both types of listeners are important for complete SDK coverage and ensuring the SDK correctly 
+implements the flag change notification contract.
+```
+
+### 2. New Service Commands
+
+Add to `servicedef/command_params.go`:
+
+#### Command: Register Flag Change Listener
+
+For general flag configuration changes (doesn't track evaluated values):
+
+```go
+const CommandRegisterFlagChangeListener = "registerFlagChangeListener"
+
+type RegisterFlagChangeListenerParams struct {
+    ListenerID  string `json:"listenerId"`  // Unique identifier
+    FlagKey     string `json:"flagKey"`     // Flag to listen to (empty = all flags)
+    CallbackURI string `json:"callbackUri"` // Where to POST events
+}
+```
+
+**Behavior:**
+- Test service registers a flag-change listener using SDK's native API (e.g., `AddFlagChangeListener`)
+- Stores mapping of `listenerId` → listener handle + callbackUri
+- When SDK detects flag configuration change, test service POSTs to callbackUri
+- If `flagKey` is empty, listens to all flag changes; if specified, filters to that flag
+
+#### Command: Register Flag Value Change Listener
+
+For value changes of a specific flag for a specific context:
+
+```go
+const CommandRegisterFlagValueChangeListener = "registerFlagValueChangeListener"
+
+type RegisterFlagValueChangeListenerParams struct {
+    ListenerID   string            `json:"listenerId"`   // Unique identifier
+    FlagKey      string            `json:"flagKey"`      // Flag to listen to (required)
+    Context      ldcontext.Context `json:"context"`      // Evaluation context (required)
+    DefaultValue ldvalue.Value     `json:"defaultValue"` // Default if flag missing (required)
+    CallbackURI  string            `json:"callbackUri"`  // Where to POST events
+}
+```
+
+**Behavior:**
+- Test service registers a value-change listener using SDK's native API (e.g., `AddFlagValueChangeListener`)
+- SDK immediately evaluates flag for the given context to capture initial value
+- Stores mapping of `listenerId` → listener handle + callbackUri + metadata
+- When SDK detects flag value changed for this context, test service POSTs to callbackUri
+- Only notifies if the evaluated value actually changed (not just configuration)
+
+#### Command: Unregister Listener
+
+Single unregister command works for both listener types:
+
+```go
+const CommandUnregisterListener = "unregisterListener"
+
+type UnregisterListenerParams struct {
+    ListenerID string `json:"listenerId"` // ID from registration
+}
+```
+
+**Behavior:**
+- Look up listener by ID (works for either type)
+- Unregister using SDK's native API
+- Remove from internal mapping
+
+### 3. Callback Payload Structures
+
+#### Payload: Flag Change Notification
+
+When a flag configuration changes, test service POSTs to the callbackUri:
+
+```json
+{
+  "listenerId": "listener-1",
+  "flagKey": "example-flag-key",
+  "timestamp": 1707753600000
+}
+```
+
+**Fields:**
+- `listenerId` - matches the ID from registration
+- `flagKey` - the flag whose configuration changed
+- `timestamp` - milliseconds since epoch
+
+**Note**: This notification indicates configuration changed, not that any specific value changed.
+
+#### Payload: Flag Value Change Notification
+
+When a flag's evaluated value changes for a specific context, test service POSTs to the callbackUri:
+
+```json
+{
+  "listenerId": "listener-2",
+  "flagKey": "example-flag-key",
+  "oldValue": {
+    "type": "boolean",
+    "value": false
+  },
+  "newValue": {
+    "type": "boolean", 
+    "value": true
+  },
+  "timestamp": 1707753600000
+}
+```
+
+**Fields:**
+- `listenerId` - matches the ID from registration
+- `flagKey` - the flag that changed
+- `oldValue` - previous evaluated value (typed JSON, or null if unknown)
+- `newValue` - new evaluated value (typed JSON)
+- `timestamp` - milliseconds since epoch
+
+**Note**: This notification only occurs when the evaluated value actually changed for the registered context.
+
+### 4. Test Service Implementation Requirements
+
+Each SDK's test service must:
+
+1. **Maintain Listener Registry**
+   - Map: `listenerId` → `{listenerType, sdkListenerHandle, callbackUri, metadata}`
+   - `listenerType`: "flag-change" or "value-change"
+   - `metadata`: Varies by type (flagKey, context, defaultValue as applicable)
+
+2. **On RegisterFlagChangeListener**:
+   - Use SDK's native flag-change listener API
+   - Store callbackUri and listener metadata
+   - When SDK fires event, POST flag-change notification to callbackUri
+
+3. **On RegisterFlagValueChangeListener**:
+   - Use SDK's native value-change listener API
+   - Store callbackUri, context, and listener metadata  
+   - SDK evaluates immediately (some SDKs provide initial value)
+   - When SDK fires event with old/new values, POST value-change notification to callbackUri
+
+4. **On Listener Invocation**:
+   - **Flag-change listener**: Construct notification with listenerId, flagKey, timestamp
+   - **Value-change listener**: Construct notification with listenerId, flagKey, oldValue, newValue, timestamp
+   - POST to callbackUri (non-blocking, ideally in goroutine/async)
+   - Handle HTTP errors gracefully (log, don't crash)
+
+5. **On UnregisterListener**:
+   - Look up by listenerId (type doesn't matter)
+   - Call SDK's unregister API with stored handle
+   - Remove from registry
+
+### 5. Test Harness Components
+
+**Reference Implementation**: See `sdktests/testapi_hooks.go` and `mockld/hook_callback_service.go` for the canonical callback pattern.
+
+#### New Test API: `sdktests/testapi_listeners.go`
+
+```go
+// Unified notification type that can represent either listener type
+type ListenerNotification struct {
+    ListenerID string
+    FlagKey    string
+    OldValue   o.Maybe[ldvalue.Value] // Present only for value-change notifications
+    NewValue   o.Maybe[ldvalue.Value] // Present only for value-change notifications
+    Timestamp  int64
+}
+
+type ListenerCallback struct {
+    endpoint      *harness.MockEndpoint
+    notifications chan ListenerNotification
+}
+
+// NewListenerCallback creates a callback endpoint and starts collecting notifications
+// Pattern follows mockld.HookCallbackService
+func NewListenerCallback(t *ldtest.T) *ListenerCallback
+
+// AwaitNotification waits for any notification with timeout
+func (l *ListenerCallback) AwaitNotification(timeout time.Duration) (ListenerNotification, bool)
+
+// ExpectFlagChangeNotification asserts a flag-change notification is received
+func (l *ListenerCallback) ExpectFlagChangeNotification(
+    t *ldtest.T,
+    expectedKey string,
+    timeout time.Duration,
+)
+
+// ExpectValueChangeNotification asserts a value-change notification is received
+func (l *ListenerCallback) ExpectValueChangeNotification(
+    t *ldtest.T,
+    expectedKey string,
+    expectedNewValue ldvalue.Value,
+    timeout time.Duration,
+)
+
+// ExpectNoNotification asserts no notification is received within timeout
+func (l *ListenerCallback) ExpectNoNotification(t *ldtest.T, timeout time.Duration)
+```
+
+#### SDK Client Methods: `sdktests/testapi_sdk_client.go`
+
+```go
+// RegisterFlagChangeListener tells the SDK to register a general flag-change listener
+func (c *SDKClient) RegisterFlagChangeListener(
+    t *ldtest.T,
+    listenerId string,
+    flagKey string,  // empty string = listen to all flags
+    callback *ListenerCallback,
+) error
+
+// RegisterFlagValueChangeListener tells the SDK to register a value-change listener
+func (c *SDKClient) RegisterFlagValueChangeListener(
+    t *ldtest.T,
+    listenerId string,
+    flagKey string,
+    context ldcontext.Context,
+    defaultValue ldvalue.Value,
+    callback *ListenerCallback,
+) error
+
+// UnregisterListener tells the SDK to remove a listener (works for both types)
+func (c *SDKClient) UnregisterListener(t *ldtest.T, listenerId string) error
+```
+
+### 6. Test Scenarios
+
+Create new test file: `sdktests/common_tests_listeners.go`
+
+#### Server-Side Tests
+
+```go
+type CommonListenerTests struct {
+    commonTestsBase
+}
+
+func NewCommonListenerTests(t *ldtest.T, testName string, baseSDKConfigurers ...SDKConfigurer) CommonListenerTests
+
+func (c CommonListenerTests) Run(t *ldtest.T) {
+    // General flag-change listener tests
+    t.Run("flag change listener receives config change", c.flagChangeListenerReceivesConfigChange)
+    t.Run("flag change listener receives all flag changes", c.flagChangeListenerReceivesAllFlags)
+    t.Run("flag change listener with specific key", c.flagChangeListenerWithSpecificKey)
+    
+    // Value-change listener tests
+    t.Run("value listener receives flag value change", c.valueListenerReceivesValueChange)
+    t.Run("value listener receives correct old and new values", c.valueListenerReceivesCorrectValues)
+    t.Run("value listener not called when value unchanged", c.valueListenerNotCalledWhenUnchanged)
+    t.Run("multiple value listeners all notified", c.multipleValueListenersNotified)
+    t.Run("unregistered listener stops receiving events", c.unregisteredListenerStops)
+    t.Run("value listener for different context not notified", c.valueListenerForDifferentContext)
+    t.Run("value listener receives changes from prerequisites", c.valueListenerReceivesPrerequisiteChanges)
+    t.Run("value listener works with flag deletion", c.valueListenerWorksWithDeletion)
+}
+```
+
+**Test: Flag Change Listener - Config Change**
+```go
+func (c CommonListenerTests) flagChangeListenerReceivesConfigChange(t *ldtest.T) {
+    // Setup: Create flag with initial config
+    dataSystem, configurers := c.setupDataSystems(t, 
+        c.makeSDKDataWithFlag(1, ldvalue.String("value")))
+    
+    client := NewSDKClient(t, configurers...)
+    callback := NewListenerCallback(t)
+    
+    // Register general flag-change listener
+    client.RegisterFlagChangeListener(t, "listener-1", "flag-key", callback)
+    
+    // Act: Push flag config update (even if value stays same)
+    dataSystem.PushUpdate("flag", "flag-key", 2, 
+        c.makeFlagData("flag-key", 2, ldvalue.String("value"))) // same value
+    
+    // Assert: Flag-change notification received
+    callback.ExpectFlagChangeNotification(t, "flag-key", time.Second)
+}
+```
+
+**Test: Flag Change Listener - All Flags**
+```go
+func (c CommonListenerTests) flagChangeListenerReceivesAllFlags(t *ldtest.T) {
+    dataSystem, configurers := c.setupDataSystems(t, 
+        c.makeSDKDataWithFlags(map[string]ldvalue.Value{
+            "flag-1": ldvalue.Bool(true),
+            "flag-2": ldvalue.String("a"),
+        }))
+    
+    client := NewSDKClient(t, configurers...)
+    callback := NewListenerCallback(t)
+    
+    // Register listener for all flags (empty flagKey)
+    client.RegisterFlagChangeListener(t, "listener-1", "", callback)
+    
+    // Update flag-1
+    dataSystem.PushUpdate("flag", "flag-1", 2, 
+        c.makeFlagData("flag-1", 2, ldvalue.Bool(false)))
+    callback.ExpectFlagChangeNotification(t, "flag-1", time.Second)
+    
+    // Update flag-2
+    dataSystem.PushUpdate("flag", "flag-2", 2,
+        c.makeFlagData("flag-2", 2, ldvalue.String("b")))
+    callback.ExpectFlagChangeNotification(t, "flag-2", time.Second)
+}
+```
+
+**Test: Value Change Listener - Basic**
+```go
+func (c CommonListenerTests) valueListenerReceivesValueChange(t *ldtest.T) {
+    // Setup: Create flag with initial value
+    dataSystem, configurers := c.setupDataSystems(t, 
+        c.makeSDKDataWithFlag(1, ldvalue.String("initial")))
+    
+    client := NewSDKClient(t, configurers...)
+    callback := NewListenerCallback(t)
+    
+    // Register value-change listener
+    client.RegisterFlagValueChangeListener(t, "listener-1", "flag-key", 
+        testContext, ldvalue.String("default"), callback)
+    
+    // Act: Push flag update
+    dataSystem.PushUpdate("flag", "flag-key", 2, 
+        c.makeFlagData("flag-key", 2, ldvalue.String("updated")))
+    
+    // Assert: Value-change notification received with old/new values
+    callback.ExpectValueChangeNotification(t, "flag-key", 
+        ldvalue.String("updated"), time.Second)
+}
+```
+
+**Test: Value Listener - No Notification When Value Unchanged**
+```go
+func (c CommonListenerTests) valueListenerNotCalledWhenUnchanged(t *ldtest.T) {
+    // Setup with flag value "stable"
+    dataSystem, configurers := c.setupDataSystems(t, 
+        c.makeSDKDataWithFlag(1, ldvalue.String("stable")))
+    
+    client := NewSDKClient(t, configurers...)
+    callback := NewListenerCallback(t)
+    client.RegisterFlagValueChangeListener(t, "listener-1", "flag-key",
+        testContext, ldvalue.String("default"), callback)
+    
+    // Update flag config but keep value same
+    dataSystem.PushUpdate("flag", "flag-key", 2,
+        c.makeFlagData("flag-key", 2, ldvalue.String("stable")))
+    
+    // Assert: No notification received (value didn't change)
+    callback.ExpectNoNotification(t, time.Millisecond * 100)
+}
+```
+
+**Test: Multiple Value Listeners**
+```go
+func (c CommonListenerTests) multipleValueListenersNotified(t *ldtest.T) {
+    dataSystem, configurers := c.setupDataSystems(t,
+        c.makeSDKDataWithFlag(1, ldvalue.Bool(false)))
+    
+    client := NewSDKClient(t, configurers...)
+    callback1 := NewListenerCallback(t)
+    callback2 := NewListenerCallback(t)
+    
+    client.RegisterFlagValueChangeListener(t, "listener-1", "flag-key",
+        testContext, ldvalue.Bool(false), callback1)
+    client.RegisterFlagValueChangeListener(t, "listener-2", "flag-key",
+        testContext, ldvalue.Bool(false), callback2)
+    
+    dataSystem.PushUpdate("flag", "flag-key", 2,
+        c.makeFlagData("flag-key", 2, ldvalue.Bool(true)))
+    
+    // Both listeners should receive notification
+    callback1.ExpectValueChangeNotification(t, "flag-key", ldvalue.Bool(true), time.Second)
+    callback2.ExpectValueChangeNotification(t, "flag-key", ldvalue.Bool(true), time.Second)
+}
+}
+```
+
+**Test: Unregister Stops Notifications**
+```go
+func (c CommonListenerTests) unregisteredListenerStops(t *ldtest.T) {
+    dataSystem, configurers := c.setupDataSystems(t,
+        c.makeSDKDataWithFlag(1, ldvalue.String("v1")))
+    
+    client := NewSDKClient(t, configurers...)
+    callback := NewListenerCallback(t)
+    
+    client.RegisterFlagValueChangeListener(t, "listener-1", "flag-key",
+        testContext, ldvalue.String("default"), callback)
+    
+    // First change - should receive
+    dataSystem.PushUpdate("flag", "flag-key", 2,
+        c.makeFlagData("flag-key", 2, ldvalue.String("v2")))
+    callback.AwaitNotification(time.Second)
+    
+    // Unregister
+    client.UnregisterListener(t, "listener-1")
+    
+    // Second change - should NOT receive
+    dataSystem.PushUpdate("flag", "flag-key", 3,
+        c.makeFlagData("flag-key", 3, ldvalue.String("v3")))
+    callback.ExpectNoNotification(t, time.Millisecond * 100)
+}
+```
+
+**Test: Context-Specific Value Listeners**
+```go
+func (c CommonListenerTests) valueListenerForDifferentContext(t *ldtest.T) {
+    context1 := ldcontext.New("user-1")
+    context2 := ldcontext.New("user-2")
+    
+    // Setup flag that targets user-1 specifically
+    dataSystem, configurers := c.setupDataSystems(t,
+        makeFlagTargetingUser("flag-key", "user-1", ldvalue.Bool(true), ldvalue.Bool(false)))
+    
+    client := NewSDKClient(t, configurers...)
+    callback1 := NewListenerCallback(t)
+    callback2 := NewListenerCallback(t)
+    
+    // Register listeners for different contexts
+    client.RegisterFlagValueChangeListener(t, "listener-1", "flag-key",
+        context1, ldvalue.Bool(false), callback1)
+    client.RegisterFlagValueChangeListener(t, "listener-2", "flag-key",
+        context2, ldvalue.Bool(false), callback2)
+    
+    // Change flag to target user-2 instead
+    dataSystem.PushUpdate("flag", "flag-key", 2,
+        makeFlagTargetingUser("flag-key", "user-2", ldvalue.Bool(true), ldvalue.Bool(false)))
+    
+    // Only listener-2 should be notified (value changed for user-2)
+    callback2.ExpectValueChangeNotification(t, "flag-key", ldvalue.Bool(true), time.Second)
+    callback1.ExpectNoNotification(t, time.Millisecond * 100)
+}
+```
+
+#### Client-Side Tests
+
+For client-side SDKs, additional scenarios:
+
+```go
+func (c CommonListenerTests) listenerNotifiedOnIdentify(t *ldtest.T) {
+    // Register listener, then call identify() with new context
+    // Verify listener notified if flag value changed for new context
+}
+
+func (c CommonListenerTests) listenerNotifiedOnForeground(t *ldtest.T) {
+    // Mobile SDK: verify listener notified after app foregrounds
+}
+```
+
+#### Edge Cases / Error Conditions
+
+```go
+func (c CommonListenerTests) listenerWorksWithDeletion(t *ldtest.T) {
+    // Verify listener receives default value when flag deleted
+}
+
+func (c CommonListenerTests) listenerWorksAfterReconnect(t *ldtest.T) {
+    // Simulate disconnect/reconnect, verify listener still works
+}
+
+func (c CommonListenerTests) rapidFlagChanges(t *ldtest.T) {
+    // Multiple rapid changes, verify all are delivered
+}
+```
+
+---
+
+## Implementation Plan
+
+### Phase 1: Foundation
+
+**Tasks:**
+1. Add `"flag-change-listeners"` capability to service spec:
+   - Add `CapabilityFlagChangeListeners = "flag-change-listeners"` constant to `servicedef/service_params.go` in the test harness
+   - Update `docs/service_spec.md` with capability description
+2. Define command structures in `servicedef/command_params.go`:
+   - `RegisterFlagChangeListenerParams`
+   - `RegisterFlagValueChangeListenerParams`
+   - `UnregisterListenerParams`
+3. Create callback payload JSON schema documentation
+4. Define `ListenerNotification` structure for callback responses
+
+**Deliverables:**
+- Updated service spec document with `flag-change-listeners` capability
+- Go type definitions for commands and callback payloads
+- Callback endpoint specification
+
+### Phase 2: Test Harness Infrastructure
+
+**Tasks:**
+1. Implement `ListenerCallback` in `sdktests/testapi_listeners.go`
+   - Mock HTTP endpoint for receiving callbacks
+   - Channel-based notification collection
+   - Assertion helpers
+2. Add client methods to `SDKClient`
+   - `RegisterListener()`
+   - `UnregisterListener()`
+3. Create test helpers in `helpers.go`
+
+**Deliverables:**
+- Working listener callback infrastructure
+- Client API for listener management
+- Helper functions for common patterns
+
+### Phase 3: Test Implementation
+
+**Tasks:**
+1. Create `common_tests_listeners.go`
+2. Implement core test scenarios:
+   - Basic value change
+   - Multiple listeners
+   - Unregister
+   - Context-specific
+3. Add tests to suite entry points
+
+**Deliverables:**
+- Complete test suite
+- Integration with existing test structure
+
+### Phase 4: SDK Implementation (Ongoing)
+
+**Per SDK:**
+1. Add capability flag to test service:
+   - Update the SDK's test service (e.g., `go-server-sdk/testservice/service.go`) to include `servicedef.CapabilityFlagChangeListeners` in its capabilities array
+   - This tells the test harness that this SDK supports flag change listener tests
+2. Implement command handlers in the test service:
+   - Handle `registerFlagChangeListener` command
+   - Handle `registerFlagValueChangeListener` command
+   - Handle `unregisterListener` command
+3. Wire up SDK listener APIs:
+   - Use SDK's native listener API (e.g., `FlagTracker.AddFlagChangeListener()` for Go)
+   - Create HTTP client to POST callbacks to the provided `callbackUri`
+   - Manage listener lifecycle (registration, notification, cleanup)
+4. Test against harness:
+   - Run test harness against the SDK test service
+   - Verify all listener tests pass
+5. Document any SDK-specific quirks in the test service implementation
+
+**Using Test Suppressions During Development:**
+
+Each SDK repository contains a `testharness-suppressions.txt` file that lists test cases to skip. This can be used during listener implementation for:
+
+1. **Feature Not Supported**: If an SDK doesn't support flag change listeners at all, or doesn't support specific listener types (general vs value change)
+2. **Partial Implementation**: During incremental development, suppress tests for features not yet implemented in the test service
+3. **SDK-Specific Limitations**: Document and suppress tests for edge cases that don't apply to a particular SDK
+
+**Example workflow:**
+- Start Phase 4 with all listener tests in `testharness-suppressions.txt`
+- Implement basic listener support
+- Remove suppressions incrementally as features are completed
+- Final state: Only permanent suppressions (if any) remain for unsupported features
+
+**Priority Order:**
+
+Priority should be based on SDK usage metrics to maximize impact. Suggested approach:
+1. Gather usage data from LaunchDarkly's internal metrics or customer surveys
+2. Prioritize the most commonly used server-side and client-side SDKs
+3. Consider implementation diversity (ensure we test different language patterns)
+
+**Potential candidates for early implementation:**
+- Go (reference implementation - already analyzed in this document)
+- Node.js (popular, async model)
+- Java (enterprise usage, different listener pattern)
+- Python (popular, simple callback model)
+- .NET (enterprise usage, event-based pattern)
+- JavaScript/Browser (client-side, event emitter pattern)
+
+**Note**: Actual priority order should be determined based on customer usage data before beginning Phase 4.
+
+### Phase 5: Documentation & Refinement
+
+**Tasks:**
+1. Update test harness README
+2. Create implementation guide for SDK test services
+3. Document common pitfalls
+4. Add troubleshooting guide
+5. Review and incorporate feedback
+
+---
+
+## Open Questions
+
+### Design Decisions Made
+
+1. **General vs Value Listeners**
+   - ✅ **DECIDED** - Test harness will support testing both general flag change listeners and value change listeners
+
+2. **Command Structure**
+   - ✅ **DECIDED** - Use separate commands (`registerFlagChangeListener`, `registerFlagValueChangeListener`) rather than unified command with type parameter
+   - **Rationale**: Type safety, matches SDK APIs, simpler implementation
+   - See "Design Decision: Command Structure" section above for full analysis
+
+3. **Initial Value Handling**
+   - ✅ **DECIDED** - Tests will NOT expect an initial value notification upon listener registration
+   - **Rationale**: Go, Python, and .NET SDKs do not send initial notifications for value-change listeners. Only JavaScript sends initial change events, but during initialization (`identify()`), not listener registration.
+   - **Impact**: No new capability needed, no conditional test logic required
+   - See detailed analysis in "Design Decisions Needed" section below
+
+4. **Async Callback Handling**
+   - ✅ **DECIDED** - Use 5-second timeout for listener callbacks (matching existing hook/event timeout pattern)
+   - **Rationale**: Consistent with test harness standards. SDKs don't batch listener notifications.
+   - **Impact**: Use `time.Second * 5` for positive assertions, shorter timeouts (100ms-1s) for negative assertions
+   - See detailed analysis in "Design Decisions Needed" section below
+
+5. **Error Cases**
+   - ✅ **DECIDED** - Follow the hooks pattern: test service supports optional error parameter to simulate callback failures
+   - **Rationale**: Consistent with how hooks tests verify error handling. SDKs must handle callback errors gracefully without crashing.
+   - **Impact**: Add optional error parameter to register commands, test that SDK continues working when callbacks fail
+   - See detailed analysis in "Design Decisions Needed" section below
+
+6. **Thread Safety / Concurrent Access**
+   - ✅ **DECIDED** - Test multiple listeners receiving notifications concurrently using `sync.WaitGroup` pattern
+   - **Rationale**: Follows established patterns from hooks and client independence tests. Focus on correctness, not implementation.
+   - **Impact**: Use goroutines + WaitGroup in tests with multiple listeners
+   - See detailed analysis in "Design Decisions Needed" section below
+
+### Technical Questions - All Decided
+
+7. **Callback HTTP Semantics**
+   - ✅ **DECIDED** - Use POST method, 200/400/500 response codes, no retry logic (same as hooks)
+   - **Rationale**: "For simplicity, and to make it clear that these calls should never be cached, the method is always POST"
+   - **Impact**: SDK test service POSTs to callback URI once, logs failures, no retries
+   - See detailed analysis in "Design Decisions Needed" section below
+
+8. **Listener ID Format**
+   - ✅ **DECIDED** - Arbitrary string chosen by test, no enforced format (same as hook names)
+   - **Rationale**: Consistent with hook naming. Test author chooses descriptive names.
+   - **Impact**: Use descriptive IDs like "listener-1", append numeric suffix for multiples
+   - See detailed analysis in "Design Decisions Needed" section below
+
+9. **Cleanup / Lifecycle**
+   - ✅ **DECIDED** - Automatic cleanup on client close + explicit unregister command (same as hooks)
+   - **Rationale**: "The object's lifecycle is tied to the test scope that created it; it will be automatically closed"
+   - **Impact**: Callback service has `Close()` method called via `defer`, SDK cleans up listeners on close
+   - See detailed analysis in "Design Decisions Needed" section below
+
+### Design Decisions Needed
+
+1. **Initial Value Handling**
+   
+   **Question**: Should listeners receive an initial notification immediately upon registration, or only when the flag subsequently changes?
+   
+   **SDK Behavior Analysis**:
+   
+   | SDK | Sends Initial Value? | Evidence |
+   |-----|---------------------|----------|
+   | **Go** | ❌ No | `flag_tracker_impl.go`: Evaluates current value on registration but only sends events on subsequent changes. Test confirms: `th.AssertNoMoreValues(t, ch1, timeout)` after registration. |
+   | **Python** | ❌ No | `test_flag_tracker.py`: After `add_flag_value_change_listener()`, test asserts `len(spy.statuses) == 0` |
+   | **JavaScript** | ⚠️ Partial | Emits all flags as changed during `identify()` (initialization), but this is a general change event, not specific to individual value change listeners |
+   | **.NET** | ❌ No (inferred) | Similar pattern to Go/Python - monitors for changes, not initial state |
+   
+   **Test Impact Analysis**:
+   
+   - **No new capability needed**: This is not a distinct SDK feature, just different implementation behavior
+   - **Test approach**: Tests should NOT expect or require an initial value notification
+   - **Rationale**: 
+     - Most SDKs (Go, Python, .NET) do not send initial values for value-change listeners
+     - The initial value can be obtained by simply evaluating the flag
+     - Value-change listeners are intended to react to *changes*, not initial state
+     - JavaScript's behavior is different (emits on `identify()`), but this is about initialization events, not listener registration
+   
+   **Decision**: ✅ **DECIDED**
+   - Tests will NOT expect an initial value notification upon listener registration
+   - Tests will only verify notifications occur when flags subsequently change
+   - No conditional logic or capability flags needed
+   - This simplifies test implementation and aligns with majority SDK behavior
+
+2. **Async Callback Handling**
+   
+   **Question 1**: How long should tests wait for callbacks?
+   
+   **Existing Test Harness Patterns**:
+   
+   | Callback Type | Timeout Value | Location |
+   |--------------|---------------|----------|
+   | **Hook callbacks** | 5 seconds | `sdktests/testapi_hooks.go`: `const hookReceiveTimeout = time.Second * 5` |
+   | **Event payloads** | 5 seconds | `sdktests/common_tests_events_base.go`: `const defaultEventTimeout = time.Second * 5` |
+   | **Stream connections** | 2 seconds (positive case) / 100ms (negative case) | `sdktests/server_side_stream_retry.go` |
+   
+   **Pattern**: The test harness consistently uses **5 seconds** as the standard timeout for async operations like callbacks and events. Shorter timeouts (100ms-2s) are used only for negative assertions ("expect no more X").
+   
+   **Question 2**: Do SDKs batch notifications?
+   
+   **SDK Behavior Analysis**:
+   
+   - **Go SDK**: Uses buffered channels with buffer size of 10 (`internal/broadcasters.go`: `const subscriberChannelBufferLength = 10`)
+     - Events are sent individually: `ch.sendCh <- value` in `Broadcast()`
+     - Buffer prevents blocking but doesn't batch - just queues up to 10 individual events
+     - Each flag change generates a separate event
+   
+   - **Other SDKs**: No evidence of batching listener notifications
+     - Event emitters (JavaScript), delegates (.NET), and callbacks (Python) all fire immediately per change
+     - Batching would complicate the listener API and isn't needed for flag changes (unlike analytics events)
+   
+   **Conclusion**: SDKs do NOT batch flag change notifications. Each flag change generates an individual, immediate notification.
+   
+   **Decision**: ✅ **DECIDED**
+   - Use **5 seconds** as the standard timeout for listener callbacks (consistent with hooks and events)
+   - No special handling for "batched" notifications needed - expect one callback per flag change
+   - Use shorter timeout (e.g., 100ms-1s) for negative assertions like "expect no notification"
+   - Pattern already exists in test harness: `helpers.TryReceive(channel, hookReceiveTimeout)`
+
+3. **Error Cases**
+   
+   **Question**: Should we test listener exceptions/errors? What if callback URL is unreachable?
+   
+   **Existing Test Harness Pattern (from Hooks)**:
+   
+   The test harness already has a well-established pattern for testing error handling in callbacks, used in the hooks tests (`common_tests_hooks.go`):
+   
+   **Error Configuration Pattern**:
+   ```go
+   // From servicedef/sdk_config.go
+   type SDKConfigHookInstance struct {
+       Name        string
+       CallbackURI string
+       Data        map[HookStage]SDKConfigEvaluationHookData
+       Errors      map[HookStage]o.Maybe[string]  // <-- Error configuration
+   }
+   ```
+   
+   **Test Example** (`errorInBeforeStageDoesNotAffectAfterStage`):
+   ```go
+   // Configure hook to throw error at specific stage
+   createClientForHooksWithErrors(t, names, hookData, 
+       map[servicedef.HookStage]o.Maybe[string]{
+           servicedef.BeforeEvaluation: o.Some("something is rotten in the state of Denmark!"),
+       }, configurers...)
+   
+   // Test verifies:
+   // 1. Error doesn't crash the SDK
+   // 2. Subsequent stages still execute
+   // 3. Error data is not propagated (data from failed stage is empty)
+   ```
+   
+   **Key Principle** (from test comment):
+   > "The client MUST handle exceptions which are thrown (or errors returned, if idiomatic for the language) during the execution of a stage or handler allowing operations to complete unaffected."
+   
+   **Decision**: ✅ **DECIDED** - Follow the hooks pattern
+   - **Test Approach**: 
+     - Test service should support an optional `error` parameter in register listener commands
+     - When set, the test service makes the listener callback fail (throws exception or returns error)
+     - Tests verify: SDK doesn't crash, other listeners still receive notifications, listener can be unregistered
+   - **Callback Unreachable**: Test this by providing an invalid callback URI (e.g., `http://localhost:1/invalid`)
+     - SDK test service should log the error but not crash
+     - Other listeners should continue working
+   - **No retry logic**: SDKs should not retry failed callback POSTs (same as hooks)
+
+4. **Thread Safety / Concurrent Access**
+   
+   **Question**: Should we test concurrent listener registrations? Thread-safety of listener invocation?
+   
+   **Existing Test Harness Pattern (from Client Independence)**:
+   
+   The test harness uses `sync.WaitGroup` for coordinating multiple concurrent operations (`client_side_client_independence.go`):
+   
+   ```go
+   // Example: Two clients operating concurrently
+   w := sync.WaitGroup{}
+   w.Add(2)
+   go func() {
+       defer w.Done()
+       _ = eventsA.ExpectAnalyticsEvents(t, defaultEventTimeout)
+   }()
+   go func() {
+       defer w.Done()
+       _ = eventsB.ExpectAnalyticsEvents(t, defaultEventTimeout)
+   }()
+   w.Wait()
+   ```
+   
+   **Pattern for Multiple Listeners** (from Hooks):
+   ```go
+   // ExpectAtLeastOneCallForEachHook waits for a single call from N hooks
+   func (h *Hooks) ExpectAtLeastOneCallForEachHook(t *ldtest.T, hookNames []string) {
+       out := make(chan o.Maybe[servicedef.HookExecutionPayload])
+       
+       for _, hookName := range hookNames {
+           go func(name string) {
+               out <- helpers.TryReceive(h.instances[name].hookService.CallChannel, hookReceiveTimeout)
+           }(hookName)
+       }
+       
+       // Collect all results
+       var payloads []servicedef.HookExecutionPayload
+       for i := 0; i < totalCalls; i++ {
+           if val := <-out; val.IsDefined() {
+               payloads = append(payloads, val.Value())
+           }
+       }
+   }
+   ```
+   
+   **Decision**: ✅ **DECIDED** - Follow established concurrency patterns
+   - **Multiple Listeners**: Register multiple listeners on same flag (already in proposed tests: `multipleValueListenersNotified`)
+     - Use goroutines + WaitGroup to collect notifications concurrently
+     - Verify all listeners receive notifications
+   - **Concurrent Registration**: Not explicitly tested (similar to how hooks doesn't test concurrent hook registration)
+     - SDKs internally handle thread-safety of listener management
+     - Focus tests on correctness of notifications, not thread-safety implementation details
+   - **Pattern**: Use `sync.WaitGroup` when coordinating multiple concurrent operations in tests
+
+### Technical Questions
+
+1. **Callback HTTP Semantics**
+   
+   **Question**: What HTTP method, response codes, and retry behavior should we use?
+   
+   **Existing Test Harness Pattern (from Hook Callbacks)**:
+   
+   From `mockld/hook_callback_service.go` and `mockld/callback_helpers.go`:
+   
+   ```go
+   // Hook callback endpoint handler
+   endpointHandler := http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+       bytes, err := io.ReadAll(req.Body)
+       logger.Printf("Received from hook: %s", string(bytes))
+       if err != nil {
+           logger.Printf("Could not read body from hook.")
+           w.WriteHeader(http.StatusBadRequest)  // 400 for read errors
+           return
+       }
+       var response servicedef.HookExecutionPayload
+       err = json.Unmarshal(bytes, &response)
+       if err != nil {
+           logger.Printf("Could not unmarshal hook payload.")
+           w.WriteHeader(http.StatusBadRequest)  // 400 for unmarshaling errors
+           return
+       }
+       
+       go func() {
+           h.CallChannel <- response
+       }()
+       
+       w.WriteHeader(http.StatusOK)  // 200 for success
+   })
+   ```
+   
+   **From `mockld/callback_helpers.go` documentation**:
+   > "For simplicity, and to make it clear that these calls should never be cached, the method is always POST"
+   
+   **Response codes used**:
+   - `http.StatusOK` (200) - Success
+   - `http.StatusBadRequest` (400) - Invalid request body or JSON
+   - `http.StatusInternalServerError` (500) - Handler error
+   - `http.StatusNoContent` (204) - DELETE to close endpoint
+   
+   **Decision**: ✅ **DECIDED** - Follow the callback service pattern
+   - **HTTP Method**: POST (never cached, clear semantics)
+   - **Response Codes**:
+     - 200 (StatusOK) for successful receipt
+     - 400 (StatusBadRequest) for malformed JSON
+     - 500 (StatusInternalServerError) for test harness errors
+   - **Retry Logic**: None - SDK test service sends once, logs failures
+   - **Pattern**: Same as hooks - simple POST, no retry, log errors
+
+2. **Listener ID Format**
+   
+   **Question**: What format/constraints should listener IDs have?
+   
+   **Existing Test Harness Pattern (from Hooks)**:
+   
+   Hook names in tests are simple descriptive strings:
+   ```go
+   hookName := "executesBeforeEvaluationStage"
+   hookName := "beforeEvaluationDataPropagatesToAfter"
+   ```
+   
+   For multiple instances, append index:
+   ```go
+   const numHooks = 3
+   var names []string
+   for i := 0; i < numHooks; i++ {
+       names = append(names, "fallibleHook-"+strconv.Itoa(i))
+   }
+   ```
+   
+   **Pattern**: Arbitrary string chosen by test, no enforced format or constraints
+   
+   **Decision**: ✅ **DECIDED** - Follow the hook naming pattern
+   - **Format**: Arbitrary string, test author chooses
+   - **Constraints**: None enforced by harness or SDK
+   - **Convention**: Use descriptive names in tests (e.g., "listener-1", "value-listener-for-flag-key")
+   - **Multiple listeners**: Append numeric suffix if needed (e.g., "listener-0", "listener-1", "listener-2")
+   - **Uniqueness**: Test author's responsibility (same as hook names)
+
+3. **Cleanup**
+   
+   **Question**: How should listener lifecycle be managed? Auto-cleanup or explicit?
+   
+   **Existing Test Harness Pattern (from Hooks, SDKClient, Events)**:
+   
+   Test objects are automatically cleaned up using `defer`:
+   ```go
+   // From common_tests_hooks.go
+   client, hooks := createClientForHooks(t, []string{hookName}, nil, configurers...)
+   defer hooks.Close()  // Auto-cleanup at end of test
+   
+   // Close() implementations
+   func (h *Hooks) Close() {
+       for _, instance := range h.instances {
+           instance.hookService.Close()  // Close each callback endpoint
+       }
+   }
+   ```
+   
+   **Pattern**: Objects have `Close()` method, called via `defer` after creation
+   
+   **From `testapi_sdk_client.go` documentation**:
+   > "The object's lifecycle is tied to the test scope that created it; it will be automatically closed"
+   
+   **Decision**: ✅ **DECIDED** - Follow the automatic cleanup pattern
+   - **Listener Lifecycle**: 
+     - Test service should clean up all listeners when SDK client closes
+     - Listeners can also be explicitly unregistered via `unregisterListener` command
+   - **Test Pattern**:
+     - Callback service has `Close()` method
+     - Called via `defer` after creation
+     - Tests can also explicitly test unregister functionality
+   - **Verification**: Tests can verify cleanup by:
+     1. Closing client, changing flag, expecting no notification
+     2. Explicitly unregistering listener, changing flag, expecting no notification
+
+### SDK-Specific Considerations
+
+1. **Go SDK**
+   - Uses channels, not callbacks
+   - Test service needs goroutine to consume channel
+   - How to handle channel buffer overflow?
+
+2. **JavaScript/Node.js**
+   - Event emitter pattern
+   - May have different syntax for specific vs all flags
+
+3. **Mobile SDKs**
+   - May have background/foreground behavior
+   - Listener registration during initialization
+
+4. **Roku**
+   - Uses `observeField` - different pattern entirely
+   - May need special handling
+
+---
+
+## References
+
+### LaunchDarkly Documentation
+- [Flag Changes (General)](https://launchdarkly.com/docs/sdk/features/flag-changes)
+- [Go SDK Reference](https://pkg.go.dev/github.com/launchdarkly/go-server-sdk/v7)
+
+### SDK Implementations Analyzed
+
+#### Go Server SDK
+- **Repository**: [launchdarkly/go-server-sdk](https://github.com/launchdarkly/go-server-sdk)
+- **Interface**: `interfaces/flag_tracker.go`
+- **Implementation**: `internal/flag_tracker_impl.go`
+- **Tests**: `ldclient_listeners_test.go`, `ldclient_listeners_fdv2_test.go`
+- **Pattern**: Go channels
+
+#### .NET Server SDK
+- **Repository**: [launchdarkly/dotnet-core](https://github.com/launchdarkly/dotnet-core)
+- **Interface**: `pkgs/sdk/server/src/Interfaces/IFlagTracker.cs`
+- **Implementation**: `pkgs/sdk/server/src/Internal/FlagTrackerImpl.cs`
+- **Pattern**: C# Events (delegates)
+
+#### JavaScript SDK
+- **Repository**: [launchdarkly/js-core](https://github.com/launchdarkly/js-core)
+- **Client**: `packages/sdk/browser/src/LDClient.ts`
+- **Emitter**: `packages/shared/sdk-client/src/LDEmitter.ts`
+- **Pattern**: EventEmitter
+
+#### Python Server SDK
+- **Repository**: [launchdarkly/python-server-sdk](https://github.com/launchdarkly/python-server-sdk)
+- **Interface**: `ldclient/interfaces.py` (class `FlagTracker`)
+- **Implementation**: `ldclient/impl/flag_tracker.py`
+- **Tests**: `ldclient/testing/impl/test_flag_tracker.py`
+- **Pattern**: Callback functions
+
+### Test Harness
+- [Test Harness Repository](https://github.com/launchdarkly/sdk-test-harness)
+- [Service Specification](./docs/service_spec.md)
+- [Writing Tests Guide](./docs/writing_tests.md)
+
+---
+
+## Change Log
+
+| Date | Author | Changes |
+|------|--------|---------|
+| 2026-02-12 | Initial | Created document with Go SDK analysis and design proposal |
+| 2026-02-13 | Update | Added multi-SDK analysis covering .NET, JavaScript, and Python implementations |
+| 2026-02-13 | Update | Decided on separate commands for flag-change vs value-change listeners; updated all code examples to reflect two command types and payloads |
+| 2026-02-13 | Update | Clarified capability definition location (test harness) vs. capability reporting (SDK test services); expanded Phase 1 and Phase 4 implementation details |
+| 2026-02-13 | Update | Analyzed "Initial Value Handling" across Go, Python, JavaScript, and .NET SDKs; decided tests will NOT expect initial notifications, simplifying implementation |
+| 2026-02-13 | Update | Analyzed "Async Callback Handling": confirmed 5-second timeout standard (matching hooks/events), confirmed SDKs don't batch listener notifications |
+| 2026-02-13 | Update | Analyzed "Error Cases" and "Thread Safety": documented existing test harness patterns from hooks and client independence tests; decided to follow these established patterns |
+| 2026-02-13 | Update | Analyzed all "Technical Questions" (HTTP semantics, ID format, cleanup): documented callback service patterns from hooks; all questions now decided using existing conventions |
+

--- a/.cursor/identify-findings.md
+++ b/.cursor/identify-findings.md
@@ -1,0 +1,136 @@
+# Identify and Flag Change Listeners — Research Findings
+
+**Date**: 2026-02-19  
+**Context**: Researching whether a test case can verify that flag change listeners fire when a client-side SDK's `Identify` is called.
+
+---
+
+## What is `Identify`?
+
+`Identify` exists in **both server-side and client-side SDKs**, but the two meanings are entirely different. This distinction is critical for flag change listeners.
+
+### Server-Side SDKs: `Identify` = analytics event only
+
+All server-side SDKs expose an `identify()` method, but it only sends an **analytics (telemetry) event** to LaunchDarkly so LD knows about that context. It has no effect on flag evaluation or on flag change listeners.
+
+| SDK | Method | Effect |
+|---|---|---|
+| **Go** | `client.Identify(context)` | Sends an identify event to LD's event processor; no flag evaluation, no listener trigger |
+| **Java** | `client.identify(context)` | Calls `eventProcessor.recordIdentifyEvent(context)`; no flag evaluation |
+| **.NET Server** | `client.Identify(context)` | Calls `_eventProcessor.RecordIdentifyEvent(...)`; no flag evaluation |
+| **Python** | `client.identify(context)` | Calls `self._send_event(self._event_factory_default.new_identify_event(context))`; no flag evaluation |
+
+None of these server-side `identify()` calls change the SDK's evaluation state, trigger a flag re-evaluation, or fire flag change listeners. Server-side SDKs evaluate flags for whatever context is passed to each individual `variation()` call and maintain no single "current context."
+
+### Client-Side SDKs: `Identify` = context switch + fresh flag fetch
+
+In client-side SDKs, `identify()` is a fundamentally different operation. It **switches the SDK's current evaluation context** (e.g. from an anonymous user to a known user after login), fetches fresh flag evaluations for the new context from LaunchDarkly, and can therefore trigger flag change listeners if any flag values differ for the new context.
+
+This is well-documented in Confluence: ["Start/Identify and Waiting for Flag Data / Error (Audited Aug 2023)"](https://launchdarkly.atlassian.net/wiki/spaces/PD/pages/2532606366) covers the behavior of `identify` across iOS, Android, Flutter, React Native, and .NET client SDKs, specifically noting that `identify` causes the SDK to fetch new flag values for the new context.
+
+---
+
+## How Listeners Interact with `Identify`
+
+For **client-side SDKs**: when `Identify` fetches fresh flag evaluations for the new context, a flag value change listener **should fire** if the flag's evaluated value is different for the new context than it was for the old one.
+
+For **server-side SDKs**: `Identify` only sends an analytics event and has no effect on listeners whatsoever.
+
+This distinction matters for the test harness: any test of "listener fires on Identify" must target client-side SDKs only.
+
+### Client-Side SDK-Specific Behavior
+
+| SDK | Fires on Identify? | Notes |
+|---|---|---|
+| **JavaScript / React Native** | ✅ Yes | `client.on('change')` and `client.on('change:key')` fire whenever the flag manager detects value changes, including after `Identify` |
+| **.NET Client SDK** | ✅ Yes (with caveats) | `IFlagTracker.FlagValueChanged` fires on `Identify` when flag values differ. However, it does **not** fire when offline + `Identify` + stored data is loaded — it only fires for fresh data from LD or `TestData` |
+| **Android SDK** | ✅ Yes | `FeatureFlagChangeListener` fires when flag values change for the new context after `Identify` |
+
+### Server-Side SDKs
+
+| SDK | Fires on Identify? | Notes |
+|---|---|---|
+| **Go Server SDK** | ❌ No | `identify()` sends an analytics event only; no listener trigger |
+| **Java Server SDK** | ❌ No | `identify()` sends an analytics event only; no listener trigger |
+| **.NET Server SDK** | ❌ No | `identify()` sends an analytics event only; no listener trigger |
+| **Python Server SDK** | ❌ No | `identify()` sends an analytics event only; no listener trigger |
+
+---
+
+## The Test Case Proposal
+
+The request was to verify:
+> "A notification is received when the SDK client's configuration is changed. For example, when the 'Identify' action is performed. This is different than when a flag's config is updated."
+
+### Analysis
+
+- **Server-side SDKs**: `identify()` sends an analytics event only — it has no effect on flag evaluation or listeners. There is nothing to test for listeners here.
+- **Client-side SDKs**: After `identify()` fetches fresh flag values for the new context, a value change listener **should** fire if any flag value differs.
+
+### Conclusion
+
+The test is **client-side only**. Since at the time of this discussion the test harness did not yet support client-side listener tests, the test was **deferred** to Phase 3B (client-side listener implementation).
+
+Confirmed: "OK, let's implement test 2 now, and defer test 1 for when we implement client-side SDK tests."
+
+---
+
+## Proposed Test Design (Deferred)
+
+When Phase 3B is implemented, the test would look roughly like:
+
+```go
+func (c CommonListenerTests) listenerFiresOnIdentify(t *ldtest.T) {
+    t.RequireCapability(servicedef.CapabilityClientSide)
+
+    // Set up flag that returns different values for two different contexts.
+    // context1 sees "value-for-user-1", context2 sees "value-for-user-2".
+    // ... (client-side data setup using ClientSDKData) ...
+
+    // Initialize client with context1.
+    client := NewSDKClient(t, WithClientSideInitialContext(context1), ...)
+
+    // Register a value change listener for "flag1".
+    callback := NewListenerCallback(requireContext(t).harness, t.DebugLogger())
+    defer callback.Close()
+    client.RegisterFlagValueChangeListener(t, servicedef.RegisterFlagValueChangeListenerParams{
+        ListenerID:   "listener-1",
+        FlagKey:      "flag1",
+        CallbackURI:  callback.GetURL(),
+        // Note: no Context field needed for client-side (client uses its current context)
+    })
+
+    // Identify as context2 (a different user).
+    client.SendIdentifyEvent(t, servicedef.IdentifyEventParams{Context: context2})
+
+    // The listener should fire because "flag1" has a different value for context2.
+    callback.ExpectValueChangeNotification(t, "flag1", valueForUser1, valueForUser2)
+}
+```
+
+### Key Implementation Notes
+
+1. **Context in `RegisterFlagValueChangeListenerParams`**: Client-side SDKs ignore the `Context` field — they always use the client's own current context. Test code should omit it.
+2. **Data setup**: Client-side tests use `ClientSDKData` (pre-evaluated flag results), not full `FeatureFlag` model JSON. The two contexts must be represented as separate data sets or by using LD targeting — but since client-side data is pre-evaluated, the test service needs to serve different values depending on which context the client requests.
+3. **`Identify` command**: The test harness needs a command to call `Identify` on the SDK client (this likely already exists as part of client-side event tests).
+4. **.NET caveat**: The .NET Client SDK documents that `FlagValueChanged` does **not** fire when the SDK loads stored/cached flag data offline. Tests should ensure the SDK is online and fetching fresh data to reliably trigger the listener.
+
+---
+
+## Confluence Search Results
+
+Searched Confluence for pages mentioning "identify" + "SDK" and "identify" + "flag change". No pages were found that specifically cover the intersection of flag change listeners and identify. The most relevant pages found:
+
+- ["Start/Identify and Waiting for Flag Data / Error (Audited Aug 2023)"](https://launchdarkly.atlassian.net/wiki/spaces/PD/pages/2532606366) — Documents client-side `identify` behavior across iOS, Android, Flutter, React Native, and .NET client; confirms `identify` triggers a network fetch for fresh flag values
+- ["One pager: don't publish index or identify events for anonymous contexts in server-side SDKs"](https://launchdarkly.atlassian.net/wiki/spaces/ENG/pages/2838462539) — Discusses the analytics-only nature of `identify` in server-side SDKs; confirms `identify` in server-side is about index/identify events sent to LD's event pipeline, not about flag evaluation
+
+## References
+
+- `.cursor/change-listener-tests-research.md` — Section "Client-Side SDK Analysis" → "Tests That Need Client-Side-Specific Variants"
+- Go Server SDK — `ldclient.go` line ~459: `func (client *LDClient) Identify(context ldcontext.Context) error` — calls `eventProcessor.RecordIdentifyEvent()` only
+- Java Server SDK — `LDClient.java` line ~317: `public void identify(LDContext context)` — calls `eventProcessor.recordIdentifyEvent(context)` only
+- .NET Server SDK — `LdClient.cs` line ~605: `public void Identify(Context context)` — calls `_eventProcessor.RecordIdentifyEvent(...)` only
+- Python Server SDK — `ldclient/client.py` line ~443: `def identify(self, context)` — calls `self._send_event(self._event_factory_default.new_identify_event(context))` only
+- `.NET Client SDK` — `pkgs/sdk/client/src/Interfaces/IFlagTracker.cs` (docs on `FlagValueChanged`, including the identify caveat)
+- `js-core` — `packages/shared/sdk-client/src/LDClientImpl.ts` (lines ~147–153: `_flagManager.on(...)` emits `change` events after any flag update including after Identify)
+- `android-client-sdk` — `LDClientInterface.java` (`registerFeatureFlagListener`)

--- a/.cursor/previous-version-findings.md
+++ b/.cursor/previous-version-findings.md
@@ -1,0 +1,130 @@
+# "Previous / Stale Flag Version" and Listeners — Research Findings
+
+**Date**: 2026-02-19  
+**Context**: Researching whether a flag change listener should remain silent when the SDK receives a flag update whose version number is *lower* than the version the SDK already knows about.
+
+---
+
+## The Original Hypothesis
+
+The user requested:
+> "A test to verify that no notification is sent if the flag's version is changed to a number that is less than the version that the SDK currently knows about."
+
+The intuition is reasonable: if an SDK has flag version 5 and receives an update claiming version 3, it should treat the update as stale/out-of-order and discard it, which means no listener notification.
+
+This is a well-known pattern in **FDv1** streaming, where each flag carries its own `version` field and the SDK uses it to detect out-of-order or replayed messages.
+
+---
+
+## What We Tried
+
+Two test functions were added:
+
+- `flagChangeListenerNoNotificationForStaleVersion` — registers a general flag change listener, pushes a flag update with a *lower* version number, and expects **no** notification.
+- `flagValueChangeListenerNoNotificationForStaleVersion` — same but for a value change listener.
+
+Both tests **failed**: the SDK notified listeners even when the pushed flag version was lower than the current version.
+
+---
+
+## Root Cause: FDv2 Ignores Per-Flag Model Versions
+
+The test harness operates in **FDv2 streaming mode**. FDv2 has a fundamentally different approach to versioning from FDv1:
+
+### FDv1 (per-flag versioning)
+Each flag update message contains a `"version"` field. The SDK compares this to its stored version; if the incoming version is ≤ stored version, the update is discarded as stale.
+
+### FDv2 (payload-level versioning)
+FDv2 replaces per-flag version checks with a **payload sequence number** carried in the `payload-transferred` event. The SDK uses this sequence number to decide whether a full payload is current, but individual flag object `version` fields have **no role in staleness detection**.
+
+From the Go SDK's FDv2 tests (`sdktests/common_tests_stream_fdv2.go`), the test `IgnoresModelVersion` explicitly verifies that the SDK **does** process and apply flag updates regardless of their individual `version` field — proving that per-flag version checking is intentionally absent in FDv2.
+
+### How `pushFlagUpdate` works in the test harness
+
+```go
+func (c CommonListenerTests) pushFlagUpdate(dataSystem *SDKDataSystem, key string, version int, value ldvalue.Value) {
+    flag := c.makeListenerFlag(key, version, value)
+    streaming := dataSystem.Synchronizers[0].streaming
+    streaming.PushUpdate("flag", key, version, jsonhelpers.ToJSON(flag))
+    streaming.PushPayloadTransferred("updated", version)  // ← the payload sequence number
+}
+```
+
+The second argument to `PushUpdate` (the `version int`) is used as the `payload-transferred` sequence number in `PushPayloadTransferred`. In FDv2, **this** number is what matters for ordering. The `version` field embedded inside the flag JSON (`flag.Version`) is effectively decorative as far as FDv2 staleness logic is concerned.
+
+---
+
+## FDv2 Adoption Across SDKs
+
+The test harness is currently on the `feat/fdv2` branch and uses the FDv2 streaming protocol exclusively. Understanding which SDKs have adopted FDv2 is critical to knowing where the stale-version test is valid.
+
+### Server-Side SDKs — All use FDv2
+
+| SDK | FDv2? | Evidence |
+|---|---|---|
+| **Go** | ✅ Yes | `internal/datasystem/` uses FDv2 protocol; `IgnoresModelVersion` test confirms per-flag versions are decorative |
+| **Java** | ✅ Yes | `datasources/FDv2SourceResult.java` — dedicated FDv2 result type throughout data source layer |
+| **Python** | ✅ Yes | `ldclient/impl/datasystem/fdv2.py` — named `FDv2` class; uses `payload-transferred` and `xfer-full` event names |
+| **.NET Server** | ✅ Yes | `LdClient.cs` calls `FDv2DataSystem.Create(...)` |
+
+All four server-side SDKs have adopted FDv2, which means per-flag version checking is absent in all of them. The stale-version test cannot be applied to any server-side SDK via the current test harness.
+
+### Client-Side SDKs — No FDv2 (network protocol)
+
+| SDK | FDv2? | Per-flag version check? | Notes |
+|---|---|---|---|
+| **Android** | ❌ No | ✅ Yes | `ContextDataManager.upsertFlag()` explicitly rejects updates where `oldFlag.getVersion() >= flag.getVersion()` |
+| **JS / React Native** | ⚠️ Internal only | Unknown | Uses FDv1 streaming protocol (PUT/PATCH with evaluated results); `shared/common` contains `FDv1PayloadAdaptor` that converts FDv1 responses into FDv2-style events internally. Per-flag version checking at the storage layer is unclear. |
+| **.NET Client** | Unknown | Unknown | Not yet researched |
+| **iOS** | Unknown | Unknown | Not yet researched |
+| **Flutter** | Unknown | Unknown | Not yet researched |
+
+The Android SDK is the clearest case: it uses FDv1 per-flag version checking. The `ContextDataManager` source (line 239) explicitly implements:
+
+```java
+// In ContextDataManager.upsertFlag():
+if (oldFlag != null && oldFlag.getVersion() >= flag.getVersion()) {
+    return false;  // reject the stale update; no listener fires
+}
+```
+
+---
+
+## Conclusion
+
+**The stale-version test is not viable for the current test harness when targeting FDv2 SDKs.**
+
+- All current server-side SDKs use FDv2, which does not check per-flag version numbers. Pushing a flag with a lower `version` in FDv2 is processed normally, and listeners will fire.
+- The test harness currently only supports FDv2 streaming, so the stale-version scenario cannot be exercised against any of the already-integrated server-side SDKs.
+
+**However, the test IS viable for client-side SDKs that use FDv1 (most notably Android).** When Phase 3B (client-side listener tests) is implemented:
+
+- The test harness pushes a streaming update with a lower `version` than what the SDK already has
+- The client-side SDK (e.g. Android) checks per-flag versions and rejects the update
+- No listener notification fires
+- The test asserts silence using `ExpectNoNotification`
+
+This would be a client-side-only test, gated with `t.RequireCapability(servicedef.CapabilityClientSide)`.
+
+Both original server-side test functions (`flagChangeListenerNoNotificationForStaleVersion` and `flagValueChangeListenerNoNotificationForStaleVersion`) were removed from `common_tests_listeners.go` for this reason.
+
+---
+
+## Implications for Future Work
+
+1. **Client-side stale-version test**: Can be implemented in Phase 3B for FDv1 client-side SDKs (Android confirmed). JS/React Native behavior at the storage layer should be verified before adding them to the test target list.
+2. **FDv2 staleness (payload-transferred version)**: A lower `payload-transferred` state version in FDv2 *should* be ignored by FDv2 SDKs. This could be a testable scenario but is separate from per-flag version checking and requires dedicated test harness infrastructure.
+3. **FDv1 server-side SDKs**: If any older server-side SDKs are ever integrated that don't support FDv2, a stale-version test would be valid for them. Such SDKs would not declare the `flag-change-listeners` capability (or would suppress the test), so this is not a concern for the current implementation.
+
+---
+
+## References
+
+- `sdktests/common_tests_stream_fdv2.go` — `IgnoresModelVersion` test; explicitly verifies Go SDK processes flag updates regardless of per-flag `version` field in FDv2
+- `mockld/streaming_service.go` — `PushUpdate` and `PushPayloadTransferred` implementation
+- Java SDK — `lib/sdk/server/src/main/java/com/launchdarkly/sdk/server/datasources/FDv2SourceResult.java`
+- Python SDK — `ldclient/impl/datasystem/fdv2.py`, `ldclient/interfaces.py` (defines `PAYLOAD_TRANSFERRED = "payload-transferred"` and `TRANSFER_FULL = "xfer-full"`)
+- .NET Server SDK — `LdClient.cs` line ~168: `_dataSystem = FDv2DataSystem.Create(...)`
+- Android SDK — `ContextDataManager.java` line ~239: per-flag version gate (`oldFlag.getVersion() >= flag.getVersion()`)
+- JS/React Native — `packages/shared/common/src/internal/fdv2/FDv1PayloadAdaptor.ts` — FDv1 streaming responses adapted into FDv2 payload processing internally; `payloadProcessor.ts` — no per-object version checking at this layer
+- `sdktests/common_tests_listeners.go` (git history) — `flagChangeListenerNoNotificationForStaleVersion` and `flagValueChangeListenerNoNotificationForStaleVersion` tests were added and then removed

--- a/docs/service_spec.md
+++ b/docs/service_spec.md
@@ -199,6 +199,17 @@ A test hook must:
       * `stage` (string, optional): If executing a stage, for example `beforeEvaluation`, this should be the stage.
   - Return data from the stages as specified via the `data` configuration. For instance the return value from the `beforeEvaluation` hook should be `data['beforeEvaluation']` merged with the input data for the stage.
 
+#### Capability `"flag-change-listeners"`
+
+This means that the SDK has support for flag change listeners and can notify the test harness when flags change.
+
+The SDK must support registering listeners that monitor for flag changes. When a flag changes, the SDK test service should POST notification data to the callback URI provided during listener registration.
+
+The test harness supports testing two types of listeners:
+- **General flag change listeners**: Notified when any flag's configuration changes
+- **Flag value change listeners**: Notified when a specific flag's evaluated value changes for a given context
+
+For details on the commands and callback payloads, see the `registerFlagChangeListener`, `registerFlagValueChangeListener`, and `unregisterListener` commands.
 
 #### Capability `"tls:verify-peer"`
 

--- a/mockld/listener_callback_service.go
+++ b/mockld/listener_callback_service.go
@@ -1,0 +1,69 @@
+package mockld
+
+import (
+	"encoding/json"
+	"io"
+	"net/http"
+
+	"github.com/launchdarkly/sdk-test-harness/v2/framework"
+	"github.com/launchdarkly/sdk-test-harness/v2/framework/harness"
+	"github.com/launchdarkly/sdk-test-harness/v2/servicedef"
+)
+
+// ListenerCallbackService is a mock HTTP server that receives flag change listener notifications
+// POSTed by an SDK test service. Each registered listener should have its own instance so that
+// notifications can be attributed to the correct listener in test assertions.
+type ListenerCallbackService struct {
+	payloadEndpoint *harness.MockEndpoint
+	CallChannel     chan servicedef.ListenerNotification
+}
+
+// GetURL returns the callback URI to provide when registering a listener. The SDK test service
+// will POST a ListenerNotification JSON body to this URL when the listener fires.
+func (l *ListenerCallbackService) GetURL() string {
+	return l.payloadEndpoint.BaseURL()
+}
+
+// Close shuts down the mock HTTP endpoint and releases its resources.
+func (l *ListenerCallbackService) Close() {
+	l.payloadEndpoint.Close()
+}
+
+// NewListenerCallbackService creates a ListenerCallbackService with a mock HTTP endpoint
+// ready to receive notifications. Call Close() when done.
+func NewListenerCallbackService(
+	testHarness *harness.TestHarness,
+	logger framework.Logger,
+) *ListenerCallbackService {
+	l := &ListenerCallbackService{
+		CallChannel: make(chan servicedef.ListenerNotification),
+	}
+
+	endpointHandler := http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+		bytes, err := io.ReadAll(req.Body)
+		logger.Printf("Received listener notification: %s", string(bytes))
+		if err != nil {
+			logger.Printf("Could not read body from listener callback.")
+			w.WriteHeader(http.StatusBadRequest)
+			return
+		}
+		var notification servicedef.ListenerNotification
+		err = json.Unmarshal(bytes, &notification)
+		if err != nil {
+			logger.Printf("Could not unmarshal listener notification.")
+			w.WriteHeader(http.StatusBadRequest)
+			return
+		}
+
+		go func() {
+			l.CallChannel <- notification
+		}()
+
+		w.WriteHeader(http.StatusOK)
+	})
+
+	l.payloadEndpoint = testHarness.NewMockEndpoint(
+		endpointHandler, logger, harness.MockEndpointDescription("listener notification"))
+
+	return l
+}

--- a/mockld/polling_service.go
+++ b/mockld/polling_service.go
@@ -137,6 +137,16 @@ func (p *PollingService) pollingHandler(getDataFn func(*PollingService, *http.Re
 
 func (p *PollingService) standardPollingHandler() http.Handler {
 	return p.pollingHandler(func(p *PollingService, r *http.Request) []byte {
+		// Client-side SDKs expect FDv1 format: a flat map of flag keys to evaluated flag objects.
+		if clientData, ok := p.currentData.(ClientSDKData); ok {
+			data, err := json.Marshal(clientData)
+			if err != nil {
+				p.debugLogger.Printf("failed to marshal client SDK data: %v", err)
+				return nil
+			}
+			return data
+		}
+
 		fdv2SdkData, ok := p.currentData.(FDv2SDKData)
 		if !ok {
 			p.debugLogger.Println("poller cannot handle non-fdv2 sdk data at this time")

--- a/sdktests/common_tests_listeners.go
+++ b/sdktests/common_tests_listeners.go
@@ -1,0 +1,287 @@
+package sdktests
+
+import (
+	"github.com/launchdarkly/go-test-helpers/v2/jsonhelpers"
+
+	"github.com/launchdarkly/go-sdk-common/v3/ldattr"
+	"github.com/launchdarkly/go-sdk-common/v3/ldcontext"
+	"github.com/launchdarkly/go-sdk-common/v3/ldvalue"
+	"github.com/launchdarkly/go-server-sdk-evaluation/v3/ldbuilders"
+	"github.com/launchdarkly/go-server-sdk-evaluation/v3/ldmodel"
+
+	"github.com/launchdarkly/sdk-test-harness/v2/framework/ldtest"
+	"github.com/launchdarkly/sdk-test-harness/v2/mockld"
+	"github.com/launchdarkly/sdk-test-harness/v2/servicedef"
+)
+
+func doCommonListenerTests(t *ldtest.T) {
+	t.RequireCapability(servicedef.CapabilityFlagChangeListeners)
+	t.Run("flag change listener", doFlagChangeListenerTests)
+	t.Run("flag value change listener", doFlagValueChangeListenerTests)
+}
+
+func doFlagChangeListenerTests(t *ldtest.T) {
+	t.Run("receives notification when flag changes", flagChangeListenerReceivesNotification)
+	t.Run("fires on config change even when value unchanged", flagChangeListenerFiresOnConfigChange)
+	t.Run("filters by flag key", flagChangeListenerFiltersByFlagKey)
+	t.Run("with empty flag key receives all flag changes", flagChangeListenerEmptyKeyReceivesAllFlags)
+}
+
+func doFlagValueChangeListenerTests(t *ldtest.T) {
+	t.Run("receives notification when value changes", flagValueChangeListenerReceivesNotification)
+	t.Run("does not notify when value is unchanged", flagValueChangeListenerNoNotificationWhenUnchanged)
+	t.Run("multiple listeners both receive notification", multipleValueListenersBothNotified)
+	t.Run("is context specific", valueListenerIsContextSpecific)
+}
+
+// makeListenerFlag builds a server-side feature flag for listener tests. The flag evaluates to
+// value as its off-variation, so any context will receive that value.
+func makeListenerFlag(key string, version int, value ldvalue.Value) ldmodel.FeatureFlag {
+	return ldbuilders.NewFlagBuilder(key).Version(version).
+		On(false).OffVariation(0).Variations(value, ldvalue.String("other")).Build()
+}
+
+// createClientForListeners sets up a client with two flags (flag1 and flag2) pre-loaded via
+// streaming, both initially evaluating to "value1". Use dataSystem.Synchronizers[0].streaming
+// to push flag updates and trigger listener notifications.
+func createClientForListeners(t *ldtest.T) (*SDKClient, *SDKDataSystem) {
+	flag1 := makeListenerFlag("flag1", 1, ldvalue.String("value1"))
+	flag2 := makeListenerFlag("flag2", 1, ldvalue.String("value1"))
+	data := mockld.NewServerSDKDataBuilder().Flag(flag1, flag2).Build()
+
+	dataSystem := NewSDKDataSystem(t, data)
+	client := NewSDKClient(t, dataSystem)
+
+	return client, dataSystem
+}
+
+// pushFlagUpdate pushes a flag update through the streaming service and signals that the payload
+// is complete. version must increase with each call; it is used as both the flag version and the
+// payload-transferred sequence number.
+func pushFlagUpdate(dataSystem *SDKDataSystem, key string, version int, value ldvalue.Value) {
+	flag := makeListenerFlag(key, version, value)
+
+	streaming := dataSystem.Synchronizers[0].streaming
+	streaming.PushUpdate("flag", key, version, jsonhelpers.ToJSON(flag))
+	streaming.PushPayloadTransferred("updated", version)
+}
+
+// --- Flag change listener tests ---
+
+func flagChangeListenerReceivesNotification(t *ldtest.T) {
+	client, dataSystem := createClientForListeners(t)
+
+	callback := NewListenerCallback(requireContext(t).harness, t.DebugLogger())
+	defer callback.Close()
+
+	client.RegisterFlagChangeListener(t, servicedef.RegisterFlagChangeListenerParams{
+		ListenerID:  "listener-1",
+		FlagKey:     "flag1",
+		CallbackURI: callback.GetURL(),
+	})
+
+	pushFlagUpdate(dataSystem, "flag1", 2, ldvalue.String("new-value"))
+
+	callback.ExpectFlagChangeNotification(t, "flag1")
+}
+
+func flagChangeListenerFiresOnConfigChange(t *ldtest.T) {
+	client, dataSystem := createClientForListeners(t)
+
+	callback := NewListenerCallback(requireContext(t).harness, t.DebugLogger())
+	defer callback.Close()
+
+	client.RegisterFlagChangeListener(t, servicedef.RegisterFlagChangeListenerParams{
+		ListenerID:  "listener-1",
+		FlagKey:     "flag1",
+		CallbackURI: callback.GetURL(),
+	})
+
+	// Push an update that changes the flag's version but not its evaluated value.
+	// The general flag change listener must fire regardless of value changes, because
+	// it tracks configuration changes (e.g. targeting rule edits), not just value changes.
+	pushFlagUpdate(dataSystem, "flag1", 2, ldvalue.String("value1"))
+
+	callback.ExpectFlagChangeNotification(t, "flag1")
+}
+
+func flagChangeListenerEmptyKeyReceivesAllFlags(t *ldtest.T) {
+	client, dataSystem := createClientForListeners(t)
+
+	callback := NewListenerCallback(requireContext(t).harness, t.DebugLogger())
+	defer callback.Close()
+
+	// An empty FlagKey means the listener should receive changes for any flag.
+	client.RegisterFlagChangeListener(t, servicedef.RegisterFlagChangeListenerParams{
+		ListenerID:  "listener-1",
+		FlagKey:     "",
+		CallbackURI: callback.GetURL(),
+	})
+
+	// Update flag1 — listener should fire.
+	pushFlagUpdate(dataSystem, "flag1", 2, ldvalue.String("new-value"))
+	callback.ExpectFlagChangeNotification(t, "flag1")
+
+	// Update flag2 — listener should fire again.
+	// Use version 3 so the payload-transferred sequence number also increments.
+	pushFlagUpdate(dataSystem, "flag2", 3, ldvalue.String("new-value"))
+	callback.ExpectFlagChangeNotification(t, "flag2")
+}
+
+func flagChangeListenerFiltersByFlagKey(t *ldtest.T) {
+	client, dataSystem := createClientForListeners(t)
+
+	callback := NewListenerCallback(requireContext(t).harness, t.DebugLogger())
+	defer callback.Close()
+
+	// Register listener only for flag1.
+	client.RegisterFlagChangeListener(t, servicedef.RegisterFlagChangeListenerParams{
+		ListenerID:  "listener-1",
+		FlagKey:     "flag1",
+		CallbackURI: callback.GetURL(),
+	})
+
+	// Update flag2 — should NOT trigger the listener.
+	pushFlagUpdate(dataSystem, "flag2", 2, ldvalue.String("new-value"))
+	callback.ExpectNoNotification(t, "flag1")
+
+	// Update flag1 — SHOULD trigger the listener.
+	pushFlagUpdate(dataSystem, "flag1", 2, ldvalue.String("another-value"))
+	callback.ExpectFlagChangeNotification(t, "flag1")
+}
+
+// --- Flag value change listener tests ---
+
+func flagValueChangeListenerReceivesNotification(t *ldtest.T) {
+	client, dataSystem := createClientForListeners(t)
+
+	context := ldcontext.New("user-key")
+	oldValue := ldvalue.String("value1")
+	newValue := ldvalue.String("new-value")
+	defaultValue := ldvalue.String("default")
+
+	callback := NewListenerCallback(requireContext(t).harness, t.DebugLogger())
+	defer callback.Close()
+
+	client.RegisterFlagValueChangeListener(t, servicedef.RegisterFlagValueChangeListenerParams{
+		ListenerID:   "listener-1",
+		FlagKey:      "flag1",
+		Context:      context,
+		DefaultValue: defaultValue,
+		CallbackURI:  callback.GetURL(),
+	})
+
+	pushFlagUpdate(dataSystem, "flag1", 2, newValue)
+
+	callback.ExpectValueChangeNotification(t, "flag1", oldValue, newValue)
+}
+
+func flagValueChangeListenerNoNotificationWhenUnchanged(t *ldtest.T) {
+	client, dataSystem := createClientForListeners(t)
+
+	context := ldcontext.New("user-key")
+
+	callback := NewListenerCallback(requireContext(t).harness, t.DebugLogger())
+	defer callback.Close()
+
+	client.RegisterFlagValueChangeListener(t, servicedef.RegisterFlagValueChangeListenerParams{
+		ListenerID:   "listener-1",
+		FlagKey:      "flag1",
+		Context:      context,
+		DefaultValue: ldvalue.String("default"),
+		CallbackURI:  callback.GetURL(),
+	})
+
+	// Update flag1 with a new version but the same evaluated value — should NOT trigger notification.
+	pushFlagUpdate(dataSystem, "flag1", 2, ldvalue.String("value1"))
+	callback.ExpectNoNotification(t, "flag1")
+}
+
+func multipleValueListenersBothNotified(t *ldtest.T) {
+	client, dataSystem := createClientForListeners(t)
+
+	context := ldcontext.New("user-key")
+	oldValue := ldvalue.String("value1")
+	newValue := ldvalue.String("new-value")
+	defaultValue := ldvalue.String("default")
+
+	callback1 := NewListenerCallback(requireContext(t).harness, t.DebugLogger())
+	defer callback1.Close()
+	callback2 := NewListenerCallback(requireContext(t).harness, t.DebugLogger())
+	defer callback2.Close()
+
+	// Register two independent listeners for the same flag and context.
+	client.RegisterFlagValueChangeListener(t, servicedef.RegisterFlagValueChangeListenerParams{
+		ListenerID:   "listener-1",
+		FlagKey:      "flag1",
+		Context:      context,
+		DefaultValue: defaultValue,
+		CallbackURI:  callback1.GetURL(),
+	})
+	client.RegisterFlagValueChangeListener(t, servicedef.RegisterFlagValueChangeListenerParams{
+		ListenerID:   "listener-2",
+		FlagKey:      "flag1",
+		Context:      context,
+		DefaultValue: defaultValue,
+		CallbackURI:  callback2.GetURL(),
+	})
+
+	pushFlagUpdate(dataSystem, "flag1", 2, newValue)
+
+	// Both listeners must receive the notification independently.
+	callback1.ExpectValueChangeNotification(t, "flag1", oldValue, newValue)
+	callback2.ExpectValueChangeNotification(t, "flag1", oldValue, newValue)
+}
+
+func valueListenerIsContextSpecific(t *ldtest.T) {
+	context1 := ldcontext.New("user-1")
+	context2 := ldcontext.New("user-2")
+	defaultValue := ldvalue.String("default")
+
+	// Initially both contexts see "value1" (flag is off, returns the same off-variation for all).
+	flag1 := makeListenerFlag("flag1", 1, ldvalue.String("value1"))
+	data := mockld.NewServerSDKDataBuilder().Flag(flag1).Build()
+	dataSystem := NewSDKDataSystem(t, data)
+	client := NewSDKClient(t, dataSystem)
+
+	callback1 := NewListenerCallback(requireContext(t).harness, t.DebugLogger())
+	defer callback1.Close()
+	callback2 := NewListenerCallback(requireContext(t).harness, t.DebugLogger())
+	defer callback2.Close()
+
+	client.RegisterFlagValueChangeListener(t, servicedef.RegisterFlagValueChangeListenerParams{
+		ListenerID:   "listener-1",
+		FlagKey:      "flag1",
+		Context:      context1,
+		DefaultValue: defaultValue,
+		CallbackURI:  callback1.GetURL(),
+	})
+	client.RegisterFlagValueChangeListener(t, servicedef.RegisterFlagValueChangeListenerParams{
+		ListenerID:   "listener-2",
+		FlagKey:      "flag1",
+		Context:      context2,
+		DefaultValue: defaultValue,
+		CallbackURI:  callback2.GetURL(),
+	})
+
+	// Push an updated flag that returns "updated-value" for user-1 via a targeting rule,
+	// and "value1" (unchanged) for everyone else via the fallthrough.
+	updatedFlag := ldbuilders.NewFlagBuilder("flag1").Version(2).
+		On(true).
+		FallthroughVariation(0).
+		Variations(ldvalue.String("value1"), ldvalue.String("updated-value")).
+		AddRule(ldbuilders.NewRuleBuilder().ID("target-rule").Variation(1).Clauses(
+			ldbuilders.Clause(ldattr.KeyAttr, ldmodel.OperatorIn, ldvalue.String("user-1")),
+		)).
+		Build()
+
+	streaming := dataSystem.Synchronizers[0].streaming
+	streaming.PushUpdate("flag", "flag1", 2, jsonhelpers.ToJSON(updatedFlag))
+	streaming.PushPayloadTransferred("updated", 2)
+
+	// context1 (user-1): value changed from "value1" to "updated-value" → notification expected.
+	callback1.ExpectValueChangeNotification(t, "flag1", ldvalue.String("value1"), ldvalue.String("updated-value"))
+
+	// context2 (user-2): value unchanged ("value1" → "value1") → no notification expected.
+	callback2.ExpectNoNotification(t, "flag1")
+}

--- a/sdktests/common_tests_listeners.go
+++ b/sdktests/common_tests_listeners.go
@@ -54,29 +54,96 @@ func (c CommonListenerTests) makeListenerFlag(key string, version int, value ldv
 		On(false).OffVariation(0).Variations(value, ldvalue.String("other")).Build()
 }
 
-// createClient sets up a client with two flags (flag1 and flag2) pre-loaded via streaming,
-// both initially evaluating to "value1". Use dataSystem.Synchronizers[0].streaming to push
-// flag updates and trigger listener notifications.
+// makeClientSideListenerFlag builds a client-side flag entry for listener tests.
+func (c CommonListenerTests) makeClientSideListenerFlag(key string, version int, value ldvalue.Value) mockld.ClientSDKFlagWithKey { //nolint:lll
+	return mockld.ClientSDKFlagWithKey{
+		Key:           key,
+		ClientSDKFlag: mockld.ClientSDKFlag{Version: version, Value: value},
+	}
+}
+
+// setupListenerDataSystems creates a streaming-capable data system for listener tests and returns
+// the configurers needed to wire it into the SDK client. Always uses streaming as the main
+// synchronizer so that tests can push flag updates at will via pushFlagUpdate.
+//
+// Configurer ordering is critical: SDKDataSystem.Configure overwrites DataSystem.Synchronizers
+// entirely, so only the last SDKDataSystem in the chain takes effect. For SDK kinds that need
+// both a polling endpoint AND a streaming endpoint (JS), we apply the streaming SDKDataSystem
+// first and then append the polling URL with WithPollingSynchronizer, which appends rather than
+// overwrites.
+func (c CommonListenerTests) setupListenerDataSystems(
+	t *ldtest.T, initialData mockld.SDKData,
+) (*SDKDataSystem, []SDKConfigurer) {
+	// The streaming data system is the one we push updates through and return as the primary handle.
+	dataSystem := NewSDKDataSystem(t, initialData, DataSystemOptionStreaming())
+
+	switch c.sdkKind {
+	case mockld.ServerSideSDK:
+		return dataSystem, []SDKConfigurer{dataSystem}
+
+	case mockld.RokuSDK:
+		fallthrough
+	case mockld.MobileSDK:
+		// Mobile SDKs require a polling endpoint to exist even when streaming is primary.
+		// The polling configurer runs before dataSystem so the streaming URL wins.
+		emptyPollingDataSource := NewSDKDataSystem(t, nil, DataSystemOptionPolling())
+		return dataSystem, []SDKConfigurer{emptyPollingDataSource, dataSystem}
+
+	case mockld.JSClientSDK:
+		// JS-based SDKs always poll for initial data, then open an SSE connection for updates.
+		// Both URLs must reach the browser entity. We cannot use two SDKDataSystem configurers
+		// because the second overwrites the first's synchronizer list. Instead we apply
+		// dataSystem (streaming) first to set Synchronizers = [{Streaming: url}], then append
+		// the polling URL with WithPollingSynchronizer, which appends rather than overwrites,
+		// giving Synchronizers = [{Streaming: url}, {Polling: url}].
+		pollingDataSource := NewSDKDataSystem(t, initialData, DataSystemOptionPolling())
+		pollingURL := pollingDataSource.Synchronizers[0].Endpoint().BaseURL()
+		return dataSystem, []SDKConfigurer{
+			dataSystem,
+			WithPollingSynchronizer(servicedef.SDKConfigPollingParams{BaseURI: pollingURL}),
+		}
+
+	default:
+		panic("unknown SDK kind for listener tests")
+	}
+}
+
+// createClient sets up a client with two flags (flag1 and flag2) pre-loaded, both initially
+// evaluating to "value1". Call pushFlagUpdate to push changes and trigger listener notifications.
 func (c CommonListenerTests) createClient(t *ldtest.T) (*SDKClient, *SDKDataSystem) {
-	flag1 := c.makeListenerFlag("flag1", 1, ldvalue.String("value1"))
-	flag2 := c.makeListenerFlag("flag2", 1, ldvalue.String("value1"))
-	data := mockld.NewServerSDKDataBuilder().Flag(flag1, flag2).Build()
+	var initialData mockld.SDKData
+	if c.isClientSide {
+		initialData = mockld.NewClientSDKDataBuilder().
+			FlagWithValue("flag1", 1, ldvalue.String("value1"), 0).
+			FlagWithValue("flag2", 1, ldvalue.String("value1"), 0).
+			Build()
+	} else {
+		flag1 := c.makeListenerFlag("flag1", 1, ldvalue.String("value1"))
+		flag2 := c.makeListenerFlag("flag2", 1, ldvalue.String("value1"))
+		initialData = mockld.NewServerSDKDataBuilder().Flag(flag1, flag2).Build()
+	}
 
-	dataSystem := NewSDKDataSystem(t, data)
-	client := NewSDKClient(t, c.baseSDKConfigurationPlus(dataSystem)...)
-
+	dataSystem, configurers := c.setupListenerDataSystems(t, initialData)
+	client := NewSDKClient(t, c.baseSDKConfigurationPlus(configurers...)...)
 	return client, dataSystem
 }
 
-// pushFlagUpdate pushes a flag update through the streaming service and signals that the payload
-// is complete. version must increase with each call; it is used as both the flag version and the
-// payload-transferred sequence number.
+// pushFlagUpdate pushes a flag update through the streaming service.
+//
+// Server-side SDKs use FDv2 streaming (put-object + payload-transferred).
+// Client-side SDKs (browser, mobile) use FDv1 streaming (patch), because the
+// client-side StreamingProcessor only listens for "put", "patch", and "delete"
+// events and silently ignores FDv2 event names.
 func (c CommonListenerTests) pushFlagUpdate(dataSystem *SDKDataSystem, key string, version int, value ldvalue.Value) {
-	flag := c.makeListenerFlag(key, version, value)
-
 	streaming := dataSystem.Synchronizers[0].streaming
-	streaming.PushUpdate("flag", key, version, jsonhelpers.ToJSON(flag))
-	streaming.PushPayloadTransferred("updated", version)
+	if c.isClientSide {
+		clientFlag := c.makeClientSideListenerFlag(key, version, value)
+		streaming.PushEvent("patch", clientFlag)
+	} else {
+		flag := c.makeListenerFlag(key, version, value)
+		streaming.PushUpdate("flag", key, version, jsonhelpers.ToJSON(flag))
+		streaming.PushPayloadTransferred("updated", version)
+	}
 }
 
 // --- Flag change listener tests ---
@@ -99,6 +166,11 @@ func (c CommonListenerTests) flagChangeListenerReceivesNotification(t *ldtest.T)
 }
 
 func (c CommonListenerTests) flagChangeListenerFiresOnConfigChange(t *ldtest.T) {
+	// General flag change listeners track configuration changes, not just value changes.
+	// Client-side SDKs only receive pre-evaluated values and have no concept of "config change
+	// without value change", so this test applies to server-side SDKs only.
+	t.RequireCapability(servicedef.CapabilityServerSide)
+
 	client, dataSystem := c.createClient(t)
 
 	callback := NewListenerCallback(requireContext(t).harness, t.DebugLogger())
@@ -247,6 +319,10 @@ func (c CommonListenerTests) multipleValueListenersBothNotified(t *ldtest.T) {
 }
 
 func (c CommonListenerTests) valueListenerIsContextSpecific(t *ldtest.T) {
+	// Client-side SDKs evaluate flags for a single, fixed context set at initialization.
+	// Registering listeners for multiple independent contexts is a server-side-only concept.
+	t.RequireCapability(servicedef.CapabilityServerSide)
+
 	context1 := ldcontext.New("user-1")
 	context2 := ldcontext.New("user-2")
 	defaultValue := ldvalue.String("default")

--- a/sdktests/common_tests_listeners.go
+++ b/sdktests/common_tests_listeners.go
@@ -14,43 +14,56 @@ import (
 	"github.com/launchdarkly/sdk-test-harness/v2/servicedef"
 )
 
+// CommonListenerTests groups together flag change listener tests that are shared between
+// server-side and client-side SDKs. Embed commonTestsBase to gain SDK-kind awareness so
+// that later commits can branch on isClientSide for data format and context handling.
+type CommonListenerTests struct {
+	commonTestsBase
+}
+
+// NewCommonListenerTests constructs a CommonListenerTests for the current test scope.
+func NewCommonListenerTests(t *ldtest.T) CommonListenerTests {
+	return CommonListenerTests{newCommonTestsBase(t, "CommonListenerTests")}
+}
+
 func doCommonListenerTests(t *ldtest.T) {
 	t.RequireCapability(servicedef.CapabilityFlagChangeListeners)
-	t.Run("flag change listener", doFlagChangeListenerTests)
-	t.Run("flag value change listener", doFlagValueChangeListenerTests)
+	c := NewCommonListenerTests(t)
+	t.Run("flag change listener", c.doFlagChangeListenerTests)
+	t.Run("flag value change listener", c.doFlagValueChangeListenerTests)
 }
 
-func doFlagChangeListenerTests(t *ldtest.T) {
-	t.Run("receives notification when flag changes", flagChangeListenerReceivesNotification)
-	t.Run("fires on config change even when value unchanged", flagChangeListenerFiresOnConfigChange)
-	t.Run("filters by flag key", flagChangeListenerFiltersByFlagKey)
-	t.Run("with empty flag key receives all flag changes", flagChangeListenerEmptyKeyReceivesAllFlags)
+func (c CommonListenerTests) doFlagChangeListenerTests(t *ldtest.T) {
+	t.Run("receives notification when flag changes", c.flagChangeListenerReceivesNotification)
+	t.Run("fires on config change even when value unchanged", c.flagChangeListenerFiresOnConfigChange)
+	t.Run("filters by flag key", c.flagChangeListenerFiltersByFlagKey)
+	t.Run("with empty flag key receives all flag changes", c.flagChangeListenerEmptyKeyReceivesAllFlags)
 }
 
-func doFlagValueChangeListenerTests(t *ldtest.T) {
-	t.Run("receives notification when value changes", flagValueChangeListenerReceivesNotification)
-	t.Run("does not notify when value is unchanged", flagValueChangeListenerNoNotificationWhenUnchanged)
-	t.Run("multiple listeners both receive notification", multipleValueListenersBothNotified)
-	t.Run("is context specific", valueListenerIsContextSpecific)
+func (c CommonListenerTests) doFlagValueChangeListenerTests(t *ldtest.T) {
+	t.Run("receives notification when value changes", c.flagValueChangeListenerReceivesNotification)
+	t.Run("does not notify when value is unchanged", c.flagValueChangeListenerNoNotificationWhenUnchanged)
+	t.Run("multiple listeners both receive notification", c.multipleValueListenersBothNotified)
+	t.Run("is context specific", c.valueListenerIsContextSpecific)
 }
 
 // makeListenerFlag builds a server-side feature flag for listener tests. The flag evaluates to
 // value as its off-variation, so any context will receive that value.
-func makeListenerFlag(key string, version int, value ldvalue.Value) ldmodel.FeatureFlag {
+func (c CommonListenerTests) makeListenerFlag(key string, version int, value ldvalue.Value) ldmodel.FeatureFlag {
 	return ldbuilders.NewFlagBuilder(key).Version(version).
 		On(false).OffVariation(0).Variations(value, ldvalue.String("other")).Build()
 }
 
-// createClientForListeners sets up a client with two flags (flag1 and flag2) pre-loaded via
-// streaming, both initially evaluating to "value1". Use dataSystem.Synchronizers[0].streaming
-// to push flag updates and trigger listener notifications.
-func createClientForListeners(t *ldtest.T) (*SDKClient, *SDKDataSystem) {
-	flag1 := makeListenerFlag("flag1", 1, ldvalue.String("value1"))
-	flag2 := makeListenerFlag("flag2", 1, ldvalue.String("value1"))
+// createClient sets up a client with two flags (flag1 and flag2) pre-loaded via streaming,
+// both initially evaluating to "value1". Use dataSystem.Synchronizers[0].streaming to push
+// flag updates and trigger listener notifications.
+func (c CommonListenerTests) createClient(t *ldtest.T) (*SDKClient, *SDKDataSystem) {
+	flag1 := c.makeListenerFlag("flag1", 1, ldvalue.String("value1"))
+	flag2 := c.makeListenerFlag("flag2", 1, ldvalue.String("value1"))
 	data := mockld.NewServerSDKDataBuilder().Flag(flag1, flag2).Build()
 
 	dataSystem := NewSDKDataSystem(t, data)
-	client := NewSDKClient(t, dataSystem)
+	client := NewSDKClient(t, c.baseSDKConfigurationPlus(dataSystem)...)
 
 	return client, dataSystem
 }
@@ -58,8 +71,8 @@ func createClientForListeners(t *ldtest.T) (*SDKClient, *SDKDataSystem) {
 // pushFlagUpdate pushes a flag update through the streaming service and signals that the payload
 // is complete. version must increase with each call; it is used as both the flag version and the
 // payload-transferred sequence number.
-func pushFlagUpdate(dataSystem *SDKDataSystem, key string, version int, value ldvalue.Value) {
-	flag := makeListenerFlag(key, version, value)
+func (c CommonListenerTests) pushFlagUpdate(dataSystem *SDKDataSystem, key string, version int, value ldvalue.Value) {
+	flag := c.makeListenerFlag(key, version, value)
 
 	streaming := dataSystem.Synchronizers[0].streaming
 	streaming.PushUpdate("flag", key, version, jsonhelpers.ToJSON(flag))
@@ -68,8 +81,8 @@ func pushFlagUpdate(dataSystem *SDKDataSystem, key string, version int, value ld
 
 // --- Flag change listener tests ---
 
-func flagChangeListenerReceivesNotification(t *ldtest.T) {
-	client, dataSystem := createClientForListeners(t)
+func (c CommonListenerTests) flagChangeListenerReceivesNotification(t *ldtest.T) {
+	client, dataSystem := c.createClient(t)
 
 	callback := NewListenerCallback(requireContext(t).harness, t.DebugLogger())
 	defer callback.Close()
@@ -80,13 +93,13 @@ func flagChangeListenerReceivesNotification(t *ldtest.T) {
 		CallbackURI: callback.GetURL(),
 	})
 
-	pushFlagUpdate(dataSystem, "flag1", 2, ldvalue.String("new-value"))
+	c.pushFlagUpdate(dataSystem, "flag1", 2, ldvalue.String("new-value"))
 
 	callback.ExpectFlagChangeNotification(t, "flag1")
 }
 
-func flagChangeListenerFiresOnConfigChange(t *ldtest.T) {
-	client, dataSystem := createClientForListeners(t)
+func (c CommonListenerTests) flagChangeListenerFiresOnConfigChange(t *ldtest.T) {
+	client, dataSystem := c.createClient(t)
 
 	callback := NewListenerCallback(requireContext(t).harness, t.DebugLogger())
 	defer callback.Close()
@@ -100,13 +113,13 @@ func flagChangeListenerFiresOnConfigChange(t *ldtest.T) {
 	// Push an update that changes the flag's version but not its evaluated value.
 	// The general flag change listener must fire regardless of value changes, because
 	// it tracks configuration changes (e.g. targeting rule edits), not just value changes.
-	pushFlagUpdate(dataSystem, "flag1", 2, ldvalue.String("value1"))
+	c.pushFlagUpdate(dataSystem, "flag1", 2, ldvalue.String("value1"))
 
 	callback.ExpectFlagChangeNotification(t, "flag1")
 }
 
-func flagChangeListenerEmptyKeyReceivesAllFlags(t *ldtest.T) {
-	client, dataSystem := createClientForListeners(t)
+func (c CommonListenerTests) flagChangeListenerEmptyKeyReceivesAllFlags(t *ldtest.T) {
+	client, dataSystem := c.createClient(t)
 
 	callback := NewListenerCallback(requireContext(t).harness, t.DebugLogger())
 	defer callback.Close()
@@ -119,17 +132,17 @@ func flagChangeListenerEmptyKeyReceivesAllFlags(t *ldtest.T) {
 	})
 
 	// Update flag1 — listener should fire.
-	pushFlagUpdate(dataSystem, "flag1", 2, ldvalue.String("new-value"))
+	c.pushFlagUpdate(dataSystem, "flag1", 2, ldvalue.String("new-value"))
 	callback.ExpectFlagChangeNotification(t, "flag1")
 
 	// Update flag2 — listener should fire again.
 	// Use version 3 so the payload-transferred sequence number also increments.
-	pushFlagUpdate(dataSystem, "flag2", 3, ldvalue.String("new-value"))
+	c.pushFlagUpdate(dataSystem, "flag2", 3, ldvalue.String("new-value"))
 	callback.ExpectFlagChangeNotification(t, "flag2")
 }
 
-func flagChangeListenerFiltersByFlagKey(t *ldtest.T) {
-	client, dataSystem := createClientForListeners(t)
+func (c CommonListenerTests) flagChangeListenerFiltersByFlagKey(t *ldtest.T) {
+	client, dataSystem := c.createClient(t)
 
 	callback := NewListenerCallback(requireContext(t).harness, t.DebugLogger())
 	defer callback.Close()
@@ -142,18 +155,18 @@ func flagChangeListenerFiltersByFlagKey(t *ldtest.T) {
 	})
 
 	// Update flag2 — should NOT trigger the listener.
-	pushFlagUpdate(dataSystem, "flag2", 2, ldvalue.String("new-value"))
+	c.pushFlagUpdate(dataSystem, "flag2", 2, ldvalue.String("new-value"))
 	callback.ExpectNoNotification(t, "flag1")
 
 	// Update flag1 — SHOULD trigger the listener.
-	pushFlagUpdate(dataSystem, "flag1", 2, ldvalue.String("another-value"))
+	c.pushFlagUpdate(dataSystem, "flag1", 2, ldvalue.String("another-value"))
 	callback.ExpectFlagChangeNotification(t, "flag1")
 }
 
 // --- Flag value change listener tests ---
 
-func flagValueChangeListenerReceivesNotification(t *ldtest.T) {
-	client, dataSystem := createClientForListeners(t)
+func (c CommonListenerTests) flagValueChangeListenerReceivesNotification(t *ldtest.T) {
+	client, dataSystem := c.createClient(t)
 
 	context := ldcontext.New("user-key")
 	oldValue := ldvalue.String("value1")
@@ -171,13 +184,13 @@ func flagValueChangeListenerReceivesNotification(t *ldtest.T) {
 		CallbackURI:  callback.GetURL(),
 	})
 
-	pushFlagUpdate(dataSystem, "flag1", 2, newValue)
+	c.pushFlagUpdate(dataSystem, "flag1", 2, newValue)
 
 	callback.ExpectValueChangeNotification(t, "flag1", oldValue, newValue)
 }
 
-func flagValueChangeListenerNoNotificationWhenUnchanged(t *ldtest.T) {
-	client, dataSystem := createClientForListeners(t)
+func (c CommonListenerTests) flagValueChangeListenerNoNotificationWhenUnchanged(t *ldtest.T) {
+	client, dataSystem := c.createClient(t)
 
 	context := ldcontext.New("user-key")
 
@@ -193,12 +206,12 @@ func flagValueChangeListenerNoNotificationWhenUnchanged(t *ldtest.T) {
 	})
 
 	// Update flag1 with a new version but the same evaluated value — should NOT trigger notification.
-	pushFlagUpdate(dataSystem, "flag1", 2, ldvalue.String("value1"))
+	c.pushFlagUpdate(dataSystem, "flag1", 2, ldvalue.String("value1"))
 	callback.ExpectNoNotification(t, "flag1")
 }
 
-func multipleValueListenersBothNotified(t *ldtest.T) {
-	client, dataSystem := createClientForListeners(t)
+func (c CommonListenerTests) multipleValueListenersBothNotified(t *ldtest.T) {
+	client, dataSystem := c.createClient(t)
 
 	context := ldcontext.New("user-key")
 	oldValue := ldvalue.String("value1")
@@ -226,23 +239,23 @@ func multipleValueListenersBothNotified(t *ldtest.T) {
 		CallbackURI:  callback2.GetURL(),
 	})
 
-	pushFlagUpdate(dataSystem, "flag1", 2, newValue)
+	c.pushFlagUpdate(dataSystem, "flag1", 2, newValue)
 
 	// Both listeners must receive the notification independently.
 	callback1.ExpectValueChangeNotification(t, "flag1", oldValue, newValue)
 	callback2.ExpectValueChangeNotification(t, "flag1", oldValue, newValue)
 }
 
-func valueListenerIsContextSpecific(t *ldtest.T) {
+func (c CommonListenerTests) valueListenerIsContextSpecific(t *ldtest.T) {
 	context1 := ldcontext.New("user-1")
 	context2 := ldcontext.New("user-2")
 	defaultValue := ldvalue.String("default")
 
 	// Initially both contexts see "value1" (flag is off, returns the same off-variation for all).
-	flag1 := makeListenerFlag("flag1", 1, ldvalue.String("value1"))
+	flag1 := c.makeListenerFlag("flag1", 1, ldvalue.String("value1"))
 	data := mockld.NewServerSDKDataBuilder().Flag(flag1).Build()
 	dataSystem := NewSDKDataSystem(t, data)
-	client := NewSDKClient(t, dataSystem)
+	client := NewSDKClient(t, c.baseSDKConfigurationPlus(dataSystem)...)
 
 	callback1 := NewListenerCallback(requireContext(t).harness, t.DebugLogger())
 	defer callback1.Close()

--- a/sdktests/testapi_listeners.go
+++ b/sdktests/testapi_listeners.go
@@ -1,0 +1,108 @@
+package sdktests
+
+import (
+	"time"
+
+	"github.com/launchdarkly/go-sdk-common/v3/ldvalue"
+	"github.com/launchdarkly/sdk-test-harness/v2/framework"
+	"github.com/launchdarkly/sdk-test-harness/v2/framework/harness"
+	"github.com/launchdarkly/sdk-test-harness/v2/framework/helpers"
+	"github.com/launchdarkly/sdk-test-harness/v2/framework/ldtest"
+	o "github.com/launchdarkly/sdk-test-harness/v2/framework/opt"
+	"github.com/launchdarkly/sdk-test-harness/v2/mockld"
+	"github.com/launchdarkly/sdk-test-harness/v2/servicedef"
+
+	"github.com/stretchr/testify/assert"
+)
+
+const listenerReceiveTimeout = time.Second * 5
+const listenerNoNotificationTimeout = time.Millisecond * 500
+
+// ListenerCallback is used in flag change listener tests to receive and assert on listener
+// notifications from the SDK test service. Each instance manages a dedicated mock HTTP
+// endpoint that the SDK test service POSTs to when the registered listener fires.
+//
+// The general usage pattern is:
+//
+//	callback := NewListenerCallback(requireContext(t).harness, t.DebugLogger())
+//	defer callback.Close()
+//	client.RegisterFlagChangeListener(t, listenerID, flagKey, callback.GetURL())
+//	// ... trigger a flag change via the streaming service ...
+//	callback.ExpectFlagChangeNotification(t, flagKey)
+type ListenerCallback struct {
+	service *mockld.ListenerCallbackService
+}
+
+// NewListenerCallback creates a ListenerCallback with a dedicated mock HTTP endpoint ready to
+// receive notifications. Call Close() when done to release the endpoint.
+func NewListenerCallback(
+	testHarness *harness.TestHarness,
+	logger framework.Logger,
+) *ListenerCallback {
+	return &ListenerCallback{
+		service: mockld.NewListenerCallbackService(testHarness, logger),
+	}
+}
+
+// GetURL returns the callback URI to pass as the callbackUri field in a
+// registerFlagChangeListener or registerFlagValueChangeListener command.
+func (lc *ListenerCallback) GetURL() string {
+	return lc.service.GetURL()
+}
+
+// Close shuts down the mock HTTP endpoint.
+func (lc *ListenerCallback) Close() {
+	lc.service.Close()
+}
+
+// ExpectFlagChangeNotification waits up to listenerReceiveTimeout for a general flag change
+// notification for the given flag key. It fails the test if no notification arrives within the
+// timeout, or if the notification's flag key does not match. Returns the notification for
+// further inspection.
+func (lc *ListenerCallback) ExpectFlagChangeNotification(
+	t *ldtest.T,
+	flagKey string,
+) servicedef.ListenerNotification {
+	notification := helpers.RequireValueWithMessage(
+		t, lc.service.CallChannel, listenerReceiveTimeout,
+		"timed out waiting for flag change notification for flag %q", flagKey,
+	)
+
+	assert.Equal(t, flagKey, notification.FlagKey,
+		"flag change notification had unexpected flag key")
+
+	return notification
+}
+
+// ExpectValueChangeNotification waits up to listenerReceiveTimeout for a value change
+// notification for the given flag key, and asserts that the old and new values match.
+// It fails the test if no notification arrives within the timeout, or if any assertion fails.
+// Returns the notification for further inspection.
+func (lc *ListenerCallback) ExpectValueChangeNotification(
+	t *ldtest.T,
+	flagKey string,
+	oldValue ldvalue.Value,
+	newValue ldvalue.Value,
+) servicedef.ListenerNotification {
+	notification := helpers.RequireValueWithMessage(
+		t, lc.service.CallChannel, listenerReceiveTimeout,
+		"timed out waiting for value change notification for flag %q", flagKey,
+	)
+
+	assert.Equal(t, flagKey, notification.FlagKey,
+		"value change notification had unexpected flag key")
+	assert.Equal(t, o.Some(oldValue), notification.OldValue,
+		"value change notification had unexpected old value for flag %q", flagKey)
+	assert.Equal(t, o.Some(newValue), notification.NewValue,
+		"value change notification had unexpected new value for flag %q", flagKey)
+
+	return notification
+}
+
+// ExpectNoNotification asserts that no notification arrives within listenerNoNotificationTimeout.
+// Use this to verify that a listener did NOT fire (e.g., because the flag value did not change).
+// The flagKey parameter is used only in the failure message if a notification unexpectedly arrives.
+func (lc *ListenerCallback) ExpectNoNotification(t *ldtest.T, flagKey string) {
+	helpers.RequireNoMoreValuesWithMessage(t, lc.service.CallChannel, listenerNoNotificationTimeout,
+		"received unexpected listener notification for flag %q", flagKey)
+}

--- a/sdktests/testapi_sdk_client.go
+++ b/sdktests/testapi_sdk_client.go
@@ -415,6 +415,59 @@ func (c *SDKClient) ContextComparison(t *ldtest.T, params servicedef.ContextComp
 	return resp
 }
 
+// RegisterFlagChangeListener tells the SDK test service to register a general flag change listener
+// for the given flag key. The listener will POST a ListenerNotification to callbackURI whenever
+// the flag's configuration changes. Pass an empty flagKey to listen for changes to any flag.
+//
+// Any error from the test service causes the test to terminate immediately.
+func (c *SDKClient) RegisterFlagChangeListener(
+	t *ldtest.T,
+	params servicedef.RegisterFlagChangeListenerParams,
+) {
+	require.NoError(t, c.sdkClientEntity.SendCommandWithParams(
+		servicedef.CommandParams{
+			Command:                    servicedef.CommandRegisterFlagChangeListener,
+			RegisterFlagChangeListener: o.Some(params),
+		},
+		t.DebugLogger(),
+		nil,
+	))
+}
+
+// RegisterFlagValueChangeListener tells the SDK test service to register a value change listener
+// for the given flag key and context. The listener will POST a ListenerNotification to callbackURI
+// whenever the evaluated value of the flag changes for that context.
+//
+// Any error from the test service causes the test to terminate immediately.
+func (c *SDKClient) RegisterFlagValueChangeListener(
+	t *ldtest.T,
+	params servicedef.RegisterFlagValueChangeListenerParams,
+) {
+	require.NoError(t, c.sdkClientEntity.SendCommandWithParams(
+		servicedef.CommandParams{
+			Command:                         servicedef.CommandRegisterFlagValueChangeListener,
+			RegisterFlagValueChangeListener: o.Some(params),
+		},
+		t.DebugLogger(),
+		nil,
+	))
+}
+
+// UnregisterListener tells the SDK test service to unregister a previously registered listener
+// by its ID.
+//
+// Any error from the test service causes the test to terminate immediately.
+func (c *SDKClient) UnregisterListener(t *ldtest.T, params servicedef.UnregisterListenerParams) {
+	require.NoError(t, c.sdkClientEntity.SendCommandWithParams(
+		servicedef.CommandParams{
+			Command:            servicedef.CommandUnregisterListener,
+			UnregisterListener: o.Some(params),
+		},
+		t.DebugLogger(),
+		nil,
+	))
+}
+
 // GetSecureModeHash tells the SDK client to calculate a secure mode hash for a context. The test
 // harness will only call this method if the test service has the "secure-mode-hash" capability.
 func (c *SDKClient) GetSecureModeHash(t *ldtest.T, context ldcontext.Context) string {

--- a/sdktests/testapi_sdk_data_system.go
+++ b/sdktests/testapi_sdk_data_system.go
@@ -234,9 +234,16 @@ func NewSDKDataSystemWithoutEndpoints(
 		data = mockld.EmptyData(sdkKind)
 	}
 
+	// Client-side polling services must serve FDv1 format (flat flag map), because
+	// client-side SDKs parse the polling response through their streaming "put" handler
+	// which expects {flagKey: {value, version, ...}}, not the FDv2 PollingPayload envelope.
+	// Keep the original data for polling; only use FDv2 for streaming.
+	pollingData := data
+
 	switch v := data.(type) {
 	case mockld.ServerSDKData:
 		data = v.ConvertToFDv2SDKData(t)
+		pollingData = data
 	case mockld.ClientSDKData:
 		data = v.ConvertToFDv2SDKClientData(t, "initial")
 	default:
@@ -258,7 +265,7 @@ func NewSDKDataSystemWithoutEndpoints(
 	defaultIsPolling := sdkKind == mockld.JSClientSDK || sdkKind == mockld.PHPSDK
 	if config.polling.Value() || (!config.polling.IsDefined() && defaultIsPolling) {
 		sync := DataSynchronizer{
-			polling: mockld.NewPollingService(data, sdkKind, t.DebugLogger()).
+			polling: mockld.NewPollingService(pollingData, sdkKind, t.DebugLogger()).
 				WithGzipCompression(t.Capabilities().Has(servicedef.CapabilityPollingGzip)),
 		}
 		for _, opt := range config.pollingSynchronizerOpts {

--- a/sdktests/testsuite_entry_point.go
+++ b/sdktests/testsuite_entry_point.go
@@ -114,6 +114,7 @@ func doAllClientSideTests(t *ldtest.T) {
 	t.Run("autoEnvAttributes", doClientSideAutoEnvAttributesTests)
 	t.Run("client independence", doClientSideClientIndependenceTests)
 	t.Run("hooks", doCommonHooksTests)
+	t.Run("flag change listeners", doCommonListenerTests)
 	t.Run("wrapper", doClientSideWrapperTests)
 }
 

--- a/sdktests/testsuite_entry_point.go
+++ b/sdktests/testsuite_entry_point.go
@@ -96,6 +96,7 @@ func doAllServerSideTests(t *ldtest.T) {
 	t.Run("context type", doSDKContextTypeTests)
 	t.Run("migrations", doServerSideMigrationTests)
 	t.Run("hooks", doCommonHooksTests)
+	t.Run("flag change listeners", doCommonListenerTests)
 	t.Run("wrapper", doServerSideWrapperTests)
 	t.Run("persistent data store", doServerSidePersistentTests)
 }

--- a/servicedef/command_params.go
+++ b/servicedef/command_params.go
@@ -12,19 +12,22 @@ import (
 )
 
 const (
-	CommandEvaluateFlag             = "evaluate"
-	CommandEvaluateAllFlags         = "evaluateAll"
-	CommandIdentifyEvent            = "identifyEvent"
-	CommandCustomEvent              = "customEvent"
-	CommandAliasEvent               = "aliasEvent"
-	CommandFlushEvents              = "flushEvents"
-	CommandGetBigSegmentStoreStatus = "getBigSegmentStoreStatus"
-	CommandContextBuild             = "contextBuild"
-	CommandContextConvert           = "contextConvert"
-	CommandContextComparison        = "contextComparison"
-	CommandSecureModeHash           = "secureModeHash"
-	CommandMigrationVariation       = "migrationVariation"
-	CommandMigrationOperation       = "migrationOperation"
+	CommandEvaluateFlag                    = "evaluate"
+	CommandEvaluateAllFlags                = "evaluateAll"
+	CommandIdentifyEvent                   = "identifyEvent"
+	CommandCustomEvent                     = "customEvent"
+	CommandAliasEvent                      = "aliasEvent"
+	CommandFlushEvents                     = "flushEvents"
+	CommandGetBigSegmentStoreStatus        = "getBigSegmentStoreStatus"
+	CommandContextBuild                    = "contextBuild"
+	CommandContextConvert                  = "contextConvert"
+	CommandContextComparison               = "contextComparison"
+	CommandSecureModeHash                  = "secureModeHash"
+	CommandMigrationVariation              = "migrationVariation"
+	CommandMigrationOperation              = "migrationOperation"
+	CommandRegisterFlagChangeListener      = "registerFlagChangeListener"
+	CommandRegisterFlagValueChangeListener = "registerFlagValueChangeListener"
+	CommandUnregisterListener              = "unregisterListener"
 )
 
 type ValueType string
@@ -38,17 +41,20 @@ const (
 )
 
 type CommandParams struct {
-	Command            string                               `json:"command"`
-	Evaluate           o.Maybe[EvaluateFlagParams]          `json:"evaluate,omitempty"`
-	EvaluateAll        o.Maybe[EvaluateAllFlagsParams]      `json:"evaluateAll,omitempty"`
-	CustomEvent        o.Maybe[CustomEventParams]           `json:"customEvent,omitempty"`
-	IdentifyEvent      o.Maybe[IdentifyEventParams]         `json:"identifyEvent,omitempty"`
-	ContextBuild       o.Maybe[ContextBuildParams]          `json:"contextBuild,omitempty"`
-	ContextConvert     o.Maybe[ContextConvertParams]        `json:"contextConvert,omitempty"`
-	ContextComparison  o.Maybe[ContextComparisonPairParams] `json:"contextComparison,omitempty"`
-	SecureModeHash     o.Maybe[SecureModeHashParams]        `json:"secureModeHash,omitempty"`
-	MigrationVariation o.Maybe[MigrationVariationParams]    `json:"migrationVariation,omitempty"`
-	MigrationOperation o.Maybe[MigrationOperationParams]    `json:"migrationOperation,omitempty"`
+	Command                         string                                         `json:"command"`
+	Evaluate                        o.Maybe[EvaluateFlagParams]                    `json:"evaluate,omitempty"`
+	EvaluateAll                     o.Maybe[EvaluateAllFlagsParams]                `json:"evaluateAll,omitempty"`
+	CustomEvent                     o.Maybe[CustomEventParams]                     `json:"customEvent,omitempty"`
+	IdentifyEvent                   o.Maybe[IdentifyEventParams]                   `json:"identifyEvent,omitempty"`
+	ContextBuild                    o.Maybe[ContextBuildParams]                    `json:"contextBuild,omitempty"`
+	ContextConvert                  o.Maybe[ContextConvertParams]                  `json:"contextConvert,omitempty"`
+	ContextComparison               o.Maybe[ContextComparisonPairParams]           `json:"contextComparison,omitempty"`
+	SecureModeHash                  o.Maybe[SecureModeHashParams]                  `json:"secureModeHash,omitempty"`
+	MigrationVariation              o.Maybe[MigrationVariationParams]              `json:"migrationVariation,omitempty"`
+	MigrationOperation              o.Maybe[MigrationOperationParams]              `json:"migrationOperation,omitempty"`
+	RegisterFlagChangeListener      o.Maybe[RegisterFlagChangeListenerParams]      `json:"registerFlagChangeListener,omitempty"`      //nolint:lll
+	RegisterFlagValueChangeListener o.Maybe[RegisterFlagValueChangeListenerParams] `json:"registerFlagValueChangeListener,omitempty"` //nolint:lll
+	UnregisterListener              o.Maybe[UnregisterListenerParams]              `json:"unregisterListener,omitempty"`
 }
 
 type EvaluateFlagParams struct {
@@ -207,4 +213,27 @@ type HookExecutionPayload struct {
 	EvaluationSeriesData    o.Maybe[map[string]ldvalue.Value] `json:"evaluationSeriesData"`
 	EvaluationDetail        o.Maybe[EvaluateFlagResponse]     `json:"evaluationDetail"`
 	Stage                   o.Maybe[HookStage]                `json:"stage"`
+}
+
+// RegisterFlagChangeListenerParams defines parameters for registering a general flag change listener.
+// The listener will be notified whenever any flag's configuration changes.
+type RegisterFlagChangeListenerParams struct {
+	ListenerID  string `json:"listenerId"`
+	FlagKey     string `json:"flagKey"`
+	CallbackURI string `json:"callbackUri"`
+}
+
+// RegisterFlagValueChangeListenerParams defines parameters for registering a flag value change listener.
+// The listener will be notified when the evaluated value of the specified flag changes for the given context.
+type RegisterFlagValueChangeListenerParams struct {
+	ListenerID   string            `json:"listenerId"`
+	FlagKey      string            `json:"flagKey"`
+	Context      ldcontext.Context `json:"context"`
+	DefaultValue ldvalue.Value     `json:"defaultValue"`
+	CallbackURI  string            `json:"callbackUri"`
+}
+
+// UnregisterListenerParams defines parameters for unregistering a previously registered listener.
+type UnregisterListenerParams struct {
+	ListenerID string `json:"listenerId"`
 }

--- a/servicedef/command_params.go
+++ b/servicedef/command_params.go
@@ -237,3 +237,14 @@ type RegisterFlagValueChangeListenerParams struct {
 type UnregisterListenerParams struct {
 	ListenerID string `json:"listenerId"`
 }
+
+// ListenerNotification is the JSON payload POSTed by the SDK test service to a callback URI
+// when a flag change listener fires. OldValue and NewValue are only present for value change
+// notifications (registerFlagValueChangeListener), not for general flag change notifications
+// (registerFlagChangeListener).
+type ListenerNotification struct {
+	ListenerID string                 `json:"listenerId"`
+	FlagKey    string                 `json:"flagKey"`
+	OldValue   o.Maybe[ldvalue.Value] `json:"oldValue,omitempty"`
+	NewValue   o.Maybe[ldvalue.Value] `json:"newValue,omitempty"`
+}

--- a/servicedef/service_params.go
+++ b/servicedef/service_params.go
@@ -40,6 +40,7 @@ const (
 	CapabilityAnonymousRedaction          = "anonymous-redaction"
 	CapabilityPollingGzip                 = "polling-gzip"
 	CapabilityEvaluationHooks             = "evaluation-hooks"
+	CapabilityFlagChangeListeners         = "flag-change-listeners"
 	CapabilityClientPrereqEvents          = "client-prereq-events"
 	CapabilityPersistentDataStoreRedis    = "persistent-data-store-redis"
 	CapabilityPersistentDataStoreConsul   = "persistent-data-store-consul"


### PR DESCRIPTION
This pull request is part of a larger set of PRs that implement Flag Change Listener tests for both the server SDKs and the client SDKs. Here's the list of pull requests that I currently have open:
* [[sdk-test-harness] feat: Add test harness support for flag change listeners in Server SDKs](https://github.com/launchdarkly/sdk-test-harness/pull/317)
* [[go-server-sdk] feat(contract-tests): Implement flag change listener tests in the Go server SDK](https://github.com/launchdarkly/go-server-sdk/pull/349)
* [[js-core] feat(contract-tests): Implement flag change listener tests in the Node server SDK](https://github.com/launchdarkly/js-core/pull/1120)
* **[sdk-test-harness] feat: Add test harness support for flag change listeners in Client SDKs <-- This PR**
* [[js-core] feat(contract-tests): Implement flag change listener tests in the JavaScript browser SDK](https://github.com/launchdarkly/js-core/pull/1121)

**Requirements**

- [ ] I have added test coverage for new or changed functionality
- [ ] I have followed the repository's [pull request submission guidelines](../blob/master/CONTRIBUTING.md#submitting-pull-requests)
- [ ] I have validated my changes against all supported platform versions

**Related issues**

Provide links to any issues in this repository or elsewhere relating to this pull request.

**Describe the solution you've provided**

Provide a clear and concise description of what you expect to happen.

**Describe alternatives you've considered**

Provide a clear and concise description of any alternative solutions or features you've considered.

**Additional context**

Add any other context about the pull request here.
