### PR TITLE
fix: Only use h.RequireNever, not require.Never.

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -22,6 +22,13 @@ linters:
     - unconvert
     - unparam
     - whitespace
+    - forbidigo
+  settings:
+    forbidigo:
+      analyze-types: true
+      forbid:
+        - pattern: ^require\.Never$
+          msg: "use h.RequireNever instead — require.Never spawns goroutines that cause race conditions"
   exclusions:
     presets: []
     generated: lax

--- a/sdktests/common_tests_stream_fdv2.go
+++ b/sdktests/common_tests_stream_fdv2.go
@@ -470,7 +470,7 @@ func (c CommonStreamingTests) UpdatesAreNotCompleteUntilPayloadTransferredIsSent
 	dataSystem.Synchronizers[0].streaming.PushUpdate(
 		"flag", "new-flag-key", 1, c.makeFlagData("new-flag-key", 1, newInitialValue))
 
-	require.Never(
+	h.RequireNever(
 		t,
 		checkForUpdatedValue(t, client, "flag-key", context, initialValue, defaultValue, defaultValue),
 		time.Millisecond*100,
@@ -478,7 +478,7 @@ func (c CommonStreamingTests) UpdatesAreNotCompleteUntilPayloadTransferredIsSent
 		"flag value was updated, but it should not have been",
 	)
 
-	require.Never(
+	h.RequireNever(
 		t,
 		checkForUpdatedValue(t, client, "new-flag-key", context, defaultValue, newInitialValue, defaultValue),
 		time.Millisecond*100,
@@ -624,7 +624,7 @@ func (c CommonStreamingTests) CanDiscardPartialEventsOnError(t *ldtest.T) {
 	dataSystem.Synchronizers[0].streaming.PushPayloadTransferred("updated", 2)
 
 	context := ldcontext.New("context-key")
-	require.Never(
+	h.RequireNever(
 		t,
 		checkForUpdatedValue(t, client, "flag-key", context, initialValue, updatedValue, defaultValue),
 		time.Millisecond*100,
@@ -681,7 +681,7 @@ func (c CommonStreamingTests) DisconnectsOnGoodbye(t *ldtest.T) {
 	_ = streamEndpoint.RequireConnection(t, time.Second)
 
 	context := ldcontext.New("context-key")
-	require.Never(
+	h.RequireNever(
 		t,
 		checkForUpdatedValue(t, client, "flag-key", context, initialValue, updatedValue, defaultValue),
 		time.Millisecond*100,


### PR DESCRIPTION
**Requirements**

- [ ] I have added test coverage for new or changed functionality
- [ ] I have followed the repository's [pull request submission guidelines](../blob/master/CONTRIBUTING.md#submitting-pull-requests)
- [ ] I have validated my changes against all supported platform versions

**Related issues**

Provide links to any issues in this repository or elsewhere relating to this pull request.

**Describe the solution you've provided**

Provide a clear and concise description of what you expect to happen.

**Describe alternatives you've considered**

Provide a clear and concise description of any alternative solutions or features you've considered.

**Additional context**

Add any other context about the pull request here.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes are limited to lint configuration and test assertions, with no production logic changes. Main risk is potential flakiness if `h.RequireNever` behaves differently than `require.Never`.
> 
> **Overview**
> Prevents use of `testify/require.Never` by enabling `forbidigo` in `.golangci.yml` with a targeted rule and message directing contributors to `h.RequireNever`.
> 
> Updates `sdktests/common_tests_stream_fdv2.go` to replace `require.Never` calls with `h.RequireNever` in several streaming-state tests to avoid race-prone goroutine behavior.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 5d59da609dcaf69f0e62d6d7ecf02b500e301e90. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/launchdarkly/sdk-test-harness/pull/326" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
