### PR TITLE
ci: use draft releases to support immutable GitHub releases

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -21,9 +21,50 @@ jobs:
           token: ${{ secrets.GITHUB_TOKEN }}
           target-branch: v2
 
-  release-sdk-test-harness:
+  create-tag:
     needs: release-please
-    if: needs.release-please.outputs.release_created == 'true'
+    if: ${{ needs.release-please.outputs.release_created == 'true' }}
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - name: Create release tag
+        env:
+          TAG_NAME: ${{ needs.release-please.outputs.tag_name }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          if gh api "repos/${{ github.repository }}/git/ref/tags/${TAG_NAME}" >/dev/null 2>&1; then
+            echo "Tag ${TAG_NAME} already exists, skipping creation."
+          else
+            echo "Creating tag ${TAG_NAME}."
+            git config user.name "github-actions[bot]"
+            git config user.email "github-actions[bot]@users.noreply.github.com"
+            git tag "${TAG_NAME}"
+            git push origin "${TAG_NAME}"
+          fi
+
+  release-sdk-test-harness:
+    needs: ['release-please', 'create-tag']
+    if: ${{ needs.release-please.outputs.release_created == 'true' }}
     uses: ./.github/workflows/release.yml
     with:
       tag: ${{ needs.release-please.outputs.tag_name }}
+
+  publish-release:
+    needs: ['release-please', 'release-sdk-test-harness']
+    if: ${{ needs.release-please.outputs.release_created == 'true' }}
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - name: Publish release
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TAG_NAME: ${{ needs.release-please.outputs.tag_name }}
+        run: >
+          gh release edit "$TAG_NAME"
+          --repo ${{ github.repository }}
+          --draft=false

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -1,6 +1,7 @@
 {
   "packages" : {
     "." : {
+      "draft" : true,
       "release-type" : "go",
       "bump-minor-pre-major" : true,
       "versioning" : "default",

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -1,12 +1,13 @@
 {
-  "packages" : {
-    "." : {
-      "draft" : true,
-      "release-type" : "go",
-      "bump-minor-pre-major" : true,
-      "versioning" : "default",
-      "include-component-in-tag" : false,
-      "extra-files" : [
+  "packages": {
+    ".": {
+      "draft": true,
+      "force-tag-creation": true,
+      "release-type": "go",
+      "bump-minor-pre-major": true,
+      "versioning": "default",
+      "include-component-in-tag": false,
+      "extra-files": [
         "main.go"
       ]
     }


### PR DESCRIPTION
**Requirements**

- [x] I have added test coverage for new or changed functionality
- [x] I have followed the repository's [pull request submission guidelines](../blob/master/CONTRIBUTING.md#submitting-pull-requests)
- [x] I have validated my changes against all supported platform versions

N/A — CI-only changes, no application code or tests affected.

**Related issues**

Supports the org-wide migration to immutable GitHub releases. Once immutable releases are enabled, artifacts can no longer be uploaded after a release is published — so releases must be created as drafts first.

**Describe the solution you've provided**

This PR updates the release workflow to use draft releases, ensuring compatibility with GitHub's immutable releases feature. This repo uploads compiled Go binaries via goreleaser, so the draft→upload→publish pattern is required.

Changes:

1. **Draft releases & force-tag-creation** (`release-please-config.json`): Added `"draft": true` so release-please creates draft (unpublished) releases. Also added `"force-tag-creation": true` (not yet supported by release-please, but included so it takes effect automatically once a supporting version is available). JSON formatting was normalized (cosmetic).

2. **Manual tag creation** (`release-please.yml`): Added a `create-tag` job. Release-please does not create git tags for draft releases, so this job creates the tag manually before the build runs (goreleaser needs the tag). The step is idempotent — it checks for an existing tag via `gh api` first.

3. **Publish-release job** (`release-please.yml`): Added a `publish-release` job that un-drafts the release after `release-sdk-test-harness` uploads all artifacts.

The resulting job dependency chain is:
```
release-please → create-tag → release-sdk-test-harness → publish-release
```

No SLSA attestation changes are needed — this repo does not use the SLSA generator.

**Describe alternatives you've considered**

N/A — this follows the canonical pattern from `ld-relay` (branch v8). Repos that only use `actions/attest@v4` (attestation-only, no artifact uploads) use a simpler non-draft approach, but this repo uploads binaries via goreleaser so the draft pattern is required.

**Additional context**

**Key review items:**
- [ ] Verify `publish-release.needs` includes all jobs that upload to or modify the release (`release-sdk-test-harness` is the only one currently).
- [ ] The JSON reformatting in `release-please-config.json` is cosmetic (removed spaces before colons) — confirm no semantic changes beyond adding `draft` and `force-tag-creation`.
- [ ] Tag names are passed via `env:` vars in `run:` blocks to avoid script injection. `${{ github.repository }}` is safe in this context (GitHub-controlled, not user input).
- [ ] `force-tag-creation` is intentionally included despite not yet being supported — it is a no-op today.
- [ ] These changes only execute during the release flow (push to v2 triggering release-please), so they cannot be exercised by PR CI.

Link to Devin session: https://app.devin.ai/sessions/7d5bda4d9dbe4ae0b950b30a50485e60
Requested by: @keelerm84

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the release automation flow (tag creation and release publication), which could break or alter how production artifacts are cut if the job ordering/permissions are wrong. No runtime application code is touched.
> 
> **Overview**
> Switches Release Please to create **draft** GitHub releases and introduces a new workflow chain to support immutable releases: `release-please` now triggers a `create-tag` job (idempotently creating/pushing the tag needed by goreleaser), then runs the existing release workflow, and finally a new `publish-release` job undrafts the GitHub release after artifacts are uploaded.
> 
> Updates `release-please-config.json` to set `draft: true` and add `force-tag-creation: true` (plus JSON formatting normalization).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 0c913aae2f1016bc22ef4586c63f8dd5fa4e24c7. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->