### PR TITLE
feat: Include hook coverage for PHP tests

### DIFF
--- a/sdktests/testsuite_entry_point.go
+++ b/sdktests/testsuite_entry_point.go
@@ -124,6 +124,7 @@ func doAllPHPTests(t *ldtest.T) {
 	t.Run("instance id", func(t *ldtest.T) {
 		NewCommonInstanceIDTests(t, "doPHPInstanceIdTests").RunPHP(t)
 	})
+	t.Run("hooks", doCommonHooksTests)
 }
 
 func allImportantServerSideCapabilities() framework.Capabilities {


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Low risk: only expands the PHP SDK test suite to include existing `hooks` coverage, with no production logic changes.
> 
> **Overview**
> Adds `hooks` coverage to the PHP SDK test suite by invoking the existing `doCommonHooksTests` group from `doAllPHPTests` in `sdktests/testsuite_entry_point.go`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 23e91e2f0ae68c7f2a5877fadff658580d7e2992. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->