### PR TITLE
chore: add missing permission

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -49,6 +49,8 @@ jobs:
   release-sdk-test-harness:
     needs: ['release-please', 'create-tag']
     if: ${{ needs.release-please.outputs.release_created == 'true' }}
+    permissions:
+      contents: write
     uses: ./.github/workflows/release.yml
     with:
       tag: ${{ needs.release-please.outputs.tag_name }}


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Low risk workflow change that only adjusts GitHub Actions permissions; main impact is enabling tag/release operations that previously could fail due to insufficient rights.
> 
> **Overview**
> Adds an explicit **`contents: write`** permission to the `release-sdk-test-harness` job in `.github/workflows/release-please.yml`, aligning it with other release jobs and preventing failures when the called `release.yml` workflow needs to write to repository contents (e.g., tags/releases).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8aa9aeb370483b1b808f97f35fd9d11613738b2f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->