### PR TITLE
ci: grant pull-requests:read so lint-pr-title workflow starts

### DIFF
--- a/.github/workflows/lint-pr-title.yml
+++ b/.github/workflows/lint-pr-title.yml
@@ -7,6 +7,9 @@ on:
       - edited
       - synchronize
 
+permissions:
+  pull-requests: read
+
 jobs:
   lint-pr-title:
     uses: launchdarkly/gh-actions/.github/workflows/lint-pr-title.yml@main


### PR DESCRIPTION
## Summary

Adds `permissions: pull-requests: read` at the workflow level in `.github/workflows/lint-pr-title.yml`.

The reusable workflow at `launchdarkly/gh-actions/.github/workflows/lint-pr-title.yml@main` was updated ([gh-actions#86](https://github.com/launchdarkly/gh-actions/pull/86)) to declare `permissions: pull-requests: read` at the job level. A reusable workflow can only request a subset of the permissions the caller grants — without an explicit `permissions` block in the caller, every run hits `startup_failure`. Same fix as [sdk-meta#429](https://github.com/launchdarkly/sdk-meta/pull/429).

## Review & Testing Checklist for Human

- [ ] Verify the `Lint PR title` workflow run on this PR exits `success` rather than `startup_failure`

### Notes

No product code is changed — workflow-only permissions fix. Only `pull-requests: read` is granted, matching the minimum scope the reusable workflow requires.

Link to Devin session: https://app.devin.ai/sessions/c7b96da5c9074500aa684bc9a9ba1c31
Requested by: @kinyoklion

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: workflow-only change that grants the minimal `pull-requests: read` permission to avoid GitHub Actions `startup_failure`; no product/runtime code is touched.
> 
> **Overview**
> Fixes the `Lint PR title` GitHub Actions workflow failing to start by explicitly granting `permissions: pull-requests: read` at the workflow level, ensuring the called reusable workflow has the access it requires.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5b4f8347dfc0c19d2b9c06510061320db66fdb20. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->