### PR TITLE
test: Cover FDv2 request shapes in instance-id and tags tests

### DIFF
--- a/sdktests/common_tests_base.go
+++ b/sdktests/common_tests_base.go
@@ -1,6 +1,7 @@
 package sdktests
 
 import (
+	"encoding/json"
 	"fmt"
 	"regexp"
 
@@ -234,6 +235,32 @@ func (c commonTestsBase) sendArbitraryEvent(t *ldtest.T, client *SDKClient) {
 		params.Context = o.Some(ldcontext.New("user-key"))
 	}
 	client.SendCustomEvent(t, params)
+}
+
+// emptyFDv1FallbackBody returns an empty FDv1 polling payload in the format the
+// SDK kind expects: server-side SDKs receive a {"flags":..,"segments":..} object,
+// while client-side SDKs receive a flat map of flag evaluations. The FDv1 fallback
+// directive subtests only need initialization to complete (no flag values) so the
+// request header can be asserted, so the payload is empty in either format.
+//
+// Client-side support for the FDv1 Fallback Directive is in progress; serving the
+// correct format per kind keeps these subtests valid for both rather than feeding a
+// client-side SDK an unparseable server-side body.
+func (c commonTestsBase) emptyFDv1FallbackBody() []byte {
+	var body any
+	if c.isClientSide {
+		body = mockld.ClientSDKData{}
+	} else {
+		body = map[string]any{
+			"flags":    map[string]json.RawMessage{},
+			"segments": map[string]json.RawMessage{},
+		}
+	}
+	bytes, err := json.Marshal(body)
+	if err != nil {
+		panic(fmt.Errorf("failed to marshal empty FDv1 fallback body: %w", err))
+	}
+	return bytes
 }
 
 func (c commonTestsBase) withHTTPProxy(url string) SDKConfigurer {

--- a/sdktests/common_tests_instance_id.go
+++ b/sdktests/common_tests_instance_id.go
@@ -5,7 +5,6 @@ import (
 	"time"
 
 	"github.com/launchdarkly/go-sdk-common/v3/ldcontext"
-	"github.com/launchdarkly/go-sdk-common/v3/ldtime"
 	"github.com/launchdarkly/go-sdk-common/v3/ldvalue"
 	"github.com/launchdarkly/go-test-helpers/v2/httphelpers"
 	"github.com/launchdarkly/sdk-test-harness/v2/framework/harness"
@@ -174,9 +173,7 @@ func (c CommonInstanceIDTests) Run(t *ldtest.T) {
 			t.Defer(fdv1Endpoint.Close)
 
 			_ = NewSDKClient(t, c.baseSDKConfigurationPlus(
-				WithConfig(servicedef.SDKConfigParams{
-					StartWaitTimeMS: o.Some(ldtime.UnixMillisecondTime(5000)),
-				}),
+				WithWaitToStart(5*time.Second, false),
 				WithStreamingSynchronizer(servicedef.SDKConfigStreamingParams{
 					BaseURI: streamEndpoint.BaseURL(),
 				}),

--- a/sdktests/common_tests_instance_id.go
+++ b/sdktests/common_tests_instance_id.go
@@ -112,8 +112,8 @@ func (c CommonInstanceIDTests) Run(t *ldtest.T) {
 	if c.sdkKind.IsServerSide() {
 		t.Run("polling initializer requests", func(t *ldtest.T) {
 			initializerData := mockld.NewServerSDKDataBuilder().Build()
-			synchronizerData := mockld.NewServerSDKDataBuilder().
-				IntentCode("none").IntentReason("up-to-date").Build()
+			synchronizerData := mockld.FDv2SDKDataFromServerSDKData(
+				mockld.NewServerSDKDataBuilder().Build(), "none", "up-to-date", "initial")
 			dataSystem := NewSDKDataSystem(t, synchronizerData,
 				DataSystemOptionPollingInitializer(initializerData))
 			_ = NewSDKClient(t, c.baseSDKConfigurationPlus(dataSystem)...)
@@ -131,9 +131,10 @@ func (c CommonInstanceIDTests) Run(t *ldtest.T) {
 				harness.MockEndpointDescription("unauthorized primary streaming service"))
 			t.Defer(primaryEndpoint.Close)
 
+			secondaryData := mockld.FDv2SDKDataFromServerSDKData(
+				mockld.NewServerSDKDataBuilder().Build(), "xfer-full", "initial", "initial")
 			secondaryStream := mockld.NewStreamingService(
-				mockld.NewServerSDKDataBuilder().Build(),
-				requireContext(t).sdkKind, t.DebugLogger())
+				secondaryData, requireContext(t).sdkKind, t.DebugLogger())
 			secondaryEndpoint := requireContext(t).harness.NewMockEndpoint(
 				secondaryStream, t.DebugLogger(),
 				harness.MockEndpointDescription("secondary streaming service"))

--- a/sdktests/common_tests_instance_id.go
+++ b/sdktests/common_tests_instance_id.go
@@ -176,7 +176,7 @@ func (c CommonInstanceIDTests) Run(t *ldtest.T) {
 				httphelpers.HandlerWithResponse(
 					200,
 					http.Header{"Content-Type": []string{"application/json"}},
-					[]byte(`{"flags":{},"segments":{}}`)),
+					c.emptyFDv1FallbackBody()),
 				t.DebugLogger(),
 				harness.MockEndpointDescription("FDv1 polling service"))
 			t.Defer(fdv1Endpoint.Close)

--- a/sdktests/common_tests_instance_id.go
+++ b/sdktests/common_tests_instance_id.go
@@ -69,6 +69,38 @@ func (c CommonInstanceIDTests) Run(t *ldtest.T) {
 		check(events.Endpoint())
 	})
 
+	// instance-id identifies an SDK client instance; two distinct clients
+	// living in the same process must never share a value, or telemetry can't
+	// disambiguate them. Stand up two independent clients back to back and
+	// assert their instance-ids differ. Gated on !CapabilitySingleton since
+	// the test requires creating a second client while the first still exists.
+	if !t.Capabilities().Has(servicedef.CapabilitySingleton) {
+		t.Run("instance id differs between client instances", func(t *ldtest.T) {
+			captureInstanceID := func() string {
+				dataSystem := NewSDKDataSystem(t, nil, DataSystemOptionStreaming())
+				configurers := c.baseSDKConfigurationPlus(dataSystem)
+				if c.isClientSide {
+					// client-side SDKs in streaming mode may *also* need a
+					// polling data source
+					configurers = append(configurers,
+						NewSDKDataSystem(t, nil, DataSystemOptionPolling()))
+				}
+				_ = NewSDKClient(t, configurers...)
+				request := dataSystem.Synchronizers[0].Endpoint().RequireConnection(t, time.Second)
+				v := request.Headers.Get("X-LaunchDarkly-Instance-Id")
+				assert.NotEmpty(t, v, "X-LaunchDarkly-Instance-Id missing from request")
+				return v
+			}
+
+			first := captureInstanceID()
+			second := captureInstanceID()
+
+			assert.NotEqual(t, first, second,
+				"two distinct SDK client instances must have distinct "+
+					"X-LaunchDarkly-Instance-Id values")
+		})
+	}
+
 	// FDv2 introduces request shapes that are not exercised by the streaming
 	// or polling synchronizer subtests above: an Initializer request that
 	// precedes the synchronizer, a Secondary Synchronizer that is only

--- a/sdktests/common_tests_instance_id.go
+++ b/sdktests/common_tests_instance_id.go
@@ -29,11 +29,6 @@ func NewCommonInstanceIDTests(t *ldtest.T, testName string, baseSDKConfigurers .
 func (c CommonInstanceIDTests) Run(t *ldtest.T) {
 	t.RequireCapability(servicedef.CapabilityInstanceID)
 
-	verifyRequestHeader := func(t *ldtest.T, endpoint *harness.MockEndpoint) {
-		request := endpoint.RequireConnection(t, time.Second)
-		assert.NotEmpty(t, request.Headers.Get("X-LaunchDarkly-Instance-Id"))
-	}
-
 	t.Run("stream requests", func(t *ldtest.T) {
 		dataSystem := NewSDKDataSystem(t, nil, DataSystemOptionStreaming())
 		configurers := c.baseSDKConfigurationPlus(dataSystem)
@@ -43,14 +38,16 @@ func (c CommonInstanceIDTests) Run(t *ldtest.T) {
 				NewSDKDataSystem(t, nil, DataSystemOptionPolling()))
 		}
 		_ = NewSDKClient(t, configurers...)
-		verifyRequestHeader(t, dataSystem.Synchronizers[0].Endpoint())
+		check := newInstanceIDChecker(t)
+		check(dataSystem.Synchronizers[0].Endpoint())
 	})
 
 	if t.Capabilities().HasAny(servicedef.CapabilityClientSide, servicedef.CapabilityServerSidePolling) {
 		t.Run("poll requests", func(t *ldtest.T) {
 			dataSystem := NewSDKDataSystem(t, nil, DataSystemOptionPolling())
 			_ = NewSDKClient(t, c.baseSDKConfigurationPlus(dataSystem)...)
-			verifyRequestHeader(t, dataSystem.Synchronizers[0].Endpoint())
+			check := newInstanceIDChecker(t)
+			check(dataSystem.Synchronizers[0].Endpoint())
 		})
 	}
 
@@ -64,7 +61,12 @@ func (c CommonInstanceIDTests) Run(t *ldtest.T) {
 		c.sendArbitraryEvent(t, client)
 		client.FlushEvents(t)
 
-		verifyRequestHeader(t, events.Endpoint())
+		// The SDK contacts the data source during init and the events endpoint
+		// on flush; both must carry the same instance-id since they originate
+		// from the same client.
+		check := newInstanceIDChecker(t)
+		check(dataSystem.Synchronizers[0].Endpoint())
+		check(events.Endpoint())
 	})
 
 	// FDv2 introduces request shapes that are not exercised by the streaming
@@ -81,7 +83,9 @@ func (c CommonInstanceIDTests) Run(t *ldtest.T) {
 			dataSystem := NewSDKDataSystem(t, synchronizerData,
 				DataSystemOptionPollingInitializer(initializerData))
 			_ = NewSDKClient(t, c.baseSDKConfigurationPlus(dataSystem)...)
-			verifyRequestHeader(t, dataSystem.Initializers[0].Endpoint())
+			check := newInstanceIDChecker(t)
+			check(dataSystem.Initializers[0].Endpoint())
+			check(dataSystem.Synchronizers[0].Endpoint())
 		})
 
 		t.Run("secondary synchronizer requests after permanent fallback", func(t *ldtest.T) {
@@ -109,7 +113,9 @@ func (c CommonInstanceIDTests) Run(t *ldtest.T) {
 					BaseURI: secondaryEndpoint.BaseURL(),
 				}))...)
 
-			verifyRequestHeader(t, secondaryEndpoint)
+			check := newInstanceIDChecker(t)
+			check(primaryEndpoint)
+			check(secondaryEndpoint)
 		})
 	}
 
@@ -146,18 +152,40 @@ func (c CommonInstanceIDTests) Run(t *ldtest.T) {
 					BaseURI: fdv1Endpoint.BaseURL(),
 				}))...)
 
-			verifyRequestHeader(t, fdv1Endpoint)
+			check := newInstanceIDChecker(t)
+			check(streamEndpoint)
+			check(fdv1Endpoint)
 		})
+	}
+}
+
+// newInstanceIDChecker returns a function that asserts every observed request
+// carries a non-empty X-LaunchDarkly-Instance-Id header AND that the value is
+// identical across every endpoint observed by the returned checker. The
+// instance-id identifies the SDK client instance, so it must be stable for the
+// client's lifetime no matter which request shape carries it. Each subtest
+// creates its own SDK client and so should create its own checker -- the
+// latched value is per-client.
+func newInstanceIDChecker(t *ldtest.T) func(*harness.MockEndpoint) {
+	var observed string
+	return func(endpoint *harness.MockEndpoint) {
+		t.Helper()
+		request := endpoint.RequireConnection(t, time.Second)
+		v := request.Headers.Get("X-LaunchDarkly-Instance-Id")
+		if !assert.NotEmpty(t, v, "X-LaunchDarkly-Instance-Id missing from request") {
+			return
+		}
+		if observed == "" {
+			observed = v
+			return
+		}
+		assert.Equal(t, observed, v,
+			"X-LaunchDarkly-Instance-Id differs across requests from the same SDK client")
 	}
 }
 
 func (c CommonInstanceIDTests) RunPHP(t *ldtest.T) {
 	t.RequireCapability(servicedef.CapabilityInstanceID)
-
-	verifyRequestHeader := func(t *ldtest.T, endpoint *harness.MockEndpoint) {
-		request := endpoint.RequireConnection(t, time.Second)
-		assert.NotEmpty(t, request.Headers.Get("X-LaunchDarkly-Instance-Id"))
-	}
 
 	t.Run("poll requests", func(t *ldtest.T) {
 		dataSystem := NewSDKDataSystem(t, nil)
@@ -170,7 +198,8 @@ func (c CommonInstanceIDTests) RunPHP(t *ldtest.T) {
 			Detail:       false,
 		})
 
-		verifyRequestHeader(t, dataSystem.Synchronizers[0].Endpoint())
+		check := newInstanceIDChecker(t)
+		check(dataSystem.Synchronizers[0].Endpoint())
 	})
 
 	t.Run("event posts", func(t *ldtest.T) {
@@ -183,6 +212,7 @@ func (c CommonInstanceIDTests) RunPHP(t *ldtest.T) {
 		c.sendArbitraryEvent(t, client)
 		client.FlushEvents(t)
 
-		verifyRequestHeader(t, events.Endpoint())
+		check := newInstanceIDChecker(t)
+		check(events.Endpoint())
 	})
 }

--- a/sdktests/common_tests_instance_id.go
+++ b/sdktests/common_tests_instance_id.go
@@ -147,6 +147,11 @@ func (c CommonInstanceIDTests) Run(t *ldtest.T) {
 			check := newInstanceIDChecker(t)
 			check(primaryEndpoint)
 			check(secondaryEndpoint)
+
+			// The Primary was permanently removed on the non-recoverable 401;
+			// assert the SDK is not still retrying it in the background after
+			// falling through to the Secondary.
+			primaryEndpoint.RequireNoMoreConnections(t, time.Millisecond*500)
 		})
 	}
 
@@ -184,6 +189,10 @@ func (c CommonInstanceIDTests) Run(t *ldtest.T) {
 			check := newInstanceIDChecker(t)
 			check(streamEndpoint)
 			check(fdv1Endpoint)
+
+			// Once the directive engaged the FDv1 fallback, the FDv2 stream must
+			// be quiet; assert the SDK is not concurrently retrying it.
+			streamEndpoint.RequireNoMoreConnections(t, time.Millisecond*500)
 		})
 	}
 }

--- a/sdktests/common_tests_instance_id.go
+++ b/sdktests/common_tests_instance_id.go
@@ -1,13 +1,17 @@
 package sdktests
 
 import (
+	"net/http"
 	"time"
 
 	"github.com/launchdarkly/go-sdk-common/v3/ldcontext"
+	"github.com/launchdarkly/go-sdk-common/v3/ldtime"
 	"github.com/launchdarkly/go-sdk-common/v3/ldvalue"
+	"github.com/launchdarkly/go-test-helpers/v2/httphelpers"
 	"github.com/launchdarkly/sdk-test-harness/v2/framework/harness"
 	"github.com/launchdarkly/sdk-test-harness/v2/framework/ldtest"
 	o "github.com/launchdarkly/sdk-test-harness/v2/framework/opt"
+	"github.com/launchdarkly/sdk-test-harness/v2/mockld"
 	"github.com/launchdarkly/sdk-test-harness/v2/servicedef"
 
 	"github.com/stretchr/testify/assert"
@@ -62,6 +66,89 @@ func (c CommonInstanceIDTests) Run(t *ldtest.T) {
 
 		verifyRequestHeader(t, events.Endpoint())
 	})
+
+	// FDv2 introduces request shapes that are not exercised by the streaming
+	// or polling synchronizer subtests above: an Initializer request that
+	// precedes the synchronizer, a Secondary Synchronizer that is only
+	// contacted after the Primary is permanently removed, and an FDv1 Fallback
+	// Synchronizer reached via the server-directed FDv1 Fallback Directive.
+	// These shapes are server-side only today; gate accordingly.
+	if !c.isClientSide {
+		t.Run("polling initializer requests", func(t *ldtest.T) {
+			initializerData := mockld.NewServerSDKDataBuilder().Build()
+			synchronizerData := mockld.NewServerSDKDataBuilder().
+				IntentCode("none").IntentReason("up-to-date").Build()
+			dataSystem := NewSDKDataSystem(t, synchronizerData,
+				DataSystemOptionPollingInitializer(initializerData))
+			_ = NewSDKClient(t, c.baseSDKConfigurationPlus(dataSystem)...)
+			verifyRequestHeader(t, dataSystem.Initializers[0].Endpoint())
+		})
+
+		t.Run("secondary synchronizer requests after permanent fallback", func(t *ldtest.T) {
+			// Primary returns 401, a non-recoverable status that permanently
+			// removes it from the synchronizer chain and causes the SDK to
+			// fall through to the Secondary immediately.
+			primaryEndpoint := requireContext(t).harness.NewMockEndpoint(
+				httphelpers.HandlerWithStatus(401), t.DebugLogger(),
+				harness.MockEndpointDescription("unauthorized primary streaming service"))
+			t.Defer(primaryEndpoint.Close)
+
+			secondaryStream := mockld.NewStreamingService(
+				mockld.NewServerSDKDataBuilder().Build(),
+				requireContext(t).sdkKind, t.DebugLogger())
+			secondaryEndpoint := requireContext(t).harness.NewMockEndpoint(
+				secondaryStream, t.DebugLogger(),
+				harness.MockEndpointDescription("secondary streaming service"))
+			t.Defer(secondaryEndpoint.Close)
+
+			_ = NewSDKClient(t, c.baseSDKConfigurationPlus(
+				WithStreamingSynchronizer(servicedef.SDKConfigStreamingParams{
+					BaseURI: primaryEndpoint.BaseURL(),
+				}),
+				WithStreamingSynchronizer(servicedef.SDKConfigStreamingParams{
+					BaseURI: secondaryEndpoint.BaseURL(),
+				}))...)
+
+			verifyRequestHeader(t, secondaryEndpoint)
+		})
+	}
+
+	if t.Capabilities().Has(servicedef.CapabilityFDv1Fallback) {
+		t.Run("FDv1 fallback directive requests", func(t *ldtest.T) {
+			// FDv2 streaming responds with 403 + directive on every request
+			// so the SDK transitions to the FDv1 Fallback Synchronizer. The
+			// FDv1 endpoint serves an empty payload so initialization can
+			// complete along the fallback path.
+			streamEndpoint := requireContext(t).harness.NewMockEndpoint(
+				httphelpers.HandlerWithResponse(
+					403, http.Header{"X-LD-FD-Fallback": []string{"true"}}, nil),
+				t.DebugLogger(),
+				harness.MockEndpointDescription("FDv2 streaming service (403 + directive)"))
+			t.Defer(streamEndpoint.Close)
+
+			fdv1Endpoint := requireContext(t).harness.NewMockEndpoint(
+				httphelpers.HandlerWithResponse(
+					200,
+					http.Header{"Content-Type": []string{"application/json"}},
+					[]byte(`{"flags":{},"segments":{}}`)),
+				t.DebugLogger(),
+				harness.MockEndpointDescription("FDv1 polling service"))
+			t.Defer(fdv1Endpoint.Close)
+
+			_ = NewSDKClient(t, c.baseSDKConfigurationPlus(
+				WithConfig(servicedef.SDKConfigParams{
+					StartWaitTimeMS: o.Some(ldtime.UnixMillisecondTime(5000)),
+				}),
+				WithStreamingSynchronizer(servicedef.SDKConfigStreamingParams{
+					BaseURI: streamEndpoint.BaseURL(),
+				}),
+				WithFDv1Fallback(servicedef.SDKConfigPollingParams{
+					BaseURI: fdv1Endpoint.BaseURL(),
+				}))...)
+
+			verifyRequestHeader(t, fdv1Endpoint)
+		})
+	}
 }
 
 func (c CommonInstanceIDTests) RunPHP(t *ldtest.T) {

--- a/sdktests/common_tests_instance_id.go
+++ b/sdktests/common_tests_instance_id.go
@@ -183,6 +183,15 @@ func (c CommonInstanceIDTests) Run(t *ldtest.T) {
 
 			_ = NewSDKClient(t, c.baseSDKConfigurationPlus(
 				WithWaitToStart(5*time.Second, false),
+				// Point the top-level service endpoints at the mocks too: some
+				// SDKs resolve the FDv1 fallback polling URL from
+				// ServiceEndpoints.Polling rather than DataSystem.FDv1Fallback,
+				// and without this they would contact the real LaunchDarkly
+				// endpoint. Matches the existing FDv1 fallback tests.
+				WithServiceEndpoints(servicedef.SDKConfigServiceEndpointsParams{
+					Streaming: streamEndpoint.BaseURL(),
+					Polling:   fdv1Endpoint.BaseURL(),
+				}),
 				WithStreamingSynchronizer(servicedef.SDKConfigStreamingParams{
 					BaseURI: streamEndpoint.BaseURL(),
 				}),

--- a/sdktests/common_tests_instance_id.go
+++ b/sdktests/common_tests_instance_id.go
@@ -105,8 +105,11 @@ func (c CommonInstanceIDTests) Run(t *ldtest.T) {
 	// precedes the synchronizer, a Secondary Synchronizer that is only
 	// contacted after the Primary is permanently removed, and an FDv1 Fallback
 	// Synchronizer reached via the server-directed FDv1 Fallback Directive.
-	// These shapes are server-side only today; gate accordingly.
-	if !c.isClientSide {
+	// These shapes are server-side only today, so gate on a positive
+	// identification of the server-side category rather than "not client-side":
+	// a future SDK category should have to opt in explicitly, not inherit these
+	// by default.
+	if c.sdkKind.IsServerSide() {
 		t.Run("polling initializer requests", func(t *ldtest.T) {
 			initializerData := mockld.NewServerSDKDataBuilder().Build()
 			synchronizerData := mockld.NewServerSDKDataBuilder().

--- a/sdktests/common_tests_tags.go
+++ b/sdktests/common_tests_tags.go
@@ -191,7 +191,7 @@ func (c CommonTagsTests) Run(t *ldtest.T) {
 				httphelpers.HandlerWithResponse(
 					200,
 					http.Header{"Content-Type": []string{"application/json"}},
-					[]byte(`{"flags":{},"segments":{}}`)),
+					c.emptyFDv1FallbackBody()),
 				t.DebugLogger(),
 				harness.MockEndpointDescription("FDv1 polling service"))
 			t.Defer(fdv1Endpoint.Close)

--- a/sdktests/common_tests_tags.go
+++ b/sdktests/common_tests_tags.go
@@ -167,6 +167,11 @@ func (c CommonTagsTests) Run(t *ldtest.T) {
 
 			verifyRequestHeader(t, fdv2TagParams, primaryEndpoint)
 			verifyRequestHeader(t, fdv2TagParams, secondaryEndpoint)
+
+			// The Primary was permanently removed on the non-recoverable 401;
+			// assert the SDK is not still retrying it in the background after
+			// falling through to the Secondary.
+			primaryEndpoint.RequireNoMoreConnections(t, time.Millisecond*500)
 		})
 	}
 
@@ -204,6 +209,10 @@ func (c CommonTagsTests) Run(t *ldtest.T) {
 
 			verifyRequestHeader(t, fdv2TagParams, streamEndpoint)
 			verifyRequestHeader(t, fdv2TagParams, fdv1Endpoint)
+
+			// Once the directive engaged the FDv1 fallback, the FDv2 stream must
+			// be quiet; assert the SDK is not concurrently retrying it.
+			streamEndpoint.RequireNoMoreConnections(t, time.Millisecond*500)
 		})
 	}
 

--- a/sdktests/common_tests_tags.go
+++ b/sdktests/common_tests_tags.go
@@ -5,7 +5,6 @@ import (
 	"strings"
 	"time"
 
-	"github.com/launchdarkly/go-sdk-common/v3/ldtime"
 	"github.com/launchdarkly/sdk-test-harness/v2/framework/harness"
 	h "github.com/launchdarkly/sdk-test-harness/v2/framework/helpers"
 	"github.com/launchdarkly/sdk-test-harness/v2/framework/ldtest"
@@ -137,6 +136,7 @@ func (c CommonTagsTests) Run(t *ldtest.T) {
 				withTagsConfig(fdv2TagParams.tags),
 				dataSystem)...)
 			verifyRequestHeader(t, fdv2TagParams, dataSystem.Initializers[0].Endpoint())
+			verifyRequestHeader(t, fdv2TagParams, dataSystem.Synchronizers[0].Endpoint())
 		})
 
 		t.Run("secondary synchronizer requests after permanent fallback", func(t *ldtest.T) {
@@ -165,6 +165,7 @@ func (c CommonTagsTests) Run(t *ldtest.T) {
 					BaseURI: secondaryEndpoint.BaseURL(),
 				}))...)
 
+			verifyRequestHeader(t, fdv2TagParams, primaryEndpoint)
 			verifyRequestHeader(t, fdv2TagParams, secondaryEndpoint)
 		})
 	}
@@ -193,9 +194,7 @@ func (c CommonTagsTests) Run(t *ldtest.T) {
 
 			_ = NewSDKClient(t, c.baseSDKConfigurationPlus(
 				withTagsConfig(fdv2TagParams.tags),
-				WithConfig(servicedef.SDKConfigParams{
-					StartWaitTimeMS: o.Some(ldtime.UnixMillisecondTime(5000)),
-				}),
+				WithWaitToStart(5*time.Second, false),
 				WithStreamingSynchronizer(servicedef.SDKConfigStreamingParams{
 					BaseURI: streamEndpoint.BaseURL(),
 				}),
@@ -203,6 +202,7 @@ func (c CommonTagsTests) Run(t *ldtest.T) {
 					BaseURI: fdv1Endpoint.BaseURL(),
 				}))...)
 
+			verifyRequestHeader(t, fdv2TagParams, streamEndpoint)
 			verifyRequestHeader(t, fdv2TagParams, fdv1Endpoint)
 		})
 	}

--- a/sdktests/common_tests_tags.go
+++ b/sdktests/common_tests_tags.go
@@ -199,6 +199,15 @@ func (c CommonTagsTests) Run(t *ldtest.T) {
 			_ = NewSDKClient(t, c.baseSDKConfigurationPlus(
 				withTagsConfig(fdv2TagParams.tags),
 				WithWaitToStart(5*time.Second, false),
+				// Point the top-level service endpoints at the mocks too: some
+				// SDKs resolve the FDv1 fallback polling URL from
+				// ServiceEndpoints.Polling rather than DataSystem.FDv1Fallback,
+				// and without this they would contact the real LaunchDarkly
+				// endpoint. Matches the existing FDv1 fallback tests.
+				WithServiceEndpoints(servicedef.SDKConfigServiceEndpointsParams{
+					Streaming: streamEndpoint.BaseURL(),
+					Polling:   fdv1Endpoint.BaseURL(),
+				}),
 				WithStreamingSynchronizer(servicedef.SDKConfigStreamingParams{
 					BaseURI: streamEndpoint.BaseURL(),
 				}),

--- a/sdktests/common_tests_tags.go
+++ b/sdktests/common_tests_tags.go
@@ -126,8 +126,8 @@ func (c CommonTagsTests) Run(t *ldtest.T) {
 	if c.sdkKind.IsServerSide() {
 		t.Run("polling initializer requests", func(t *ldtest.T) {
 			initializerData := mockld.NewServerSDKDataBuilder().Build()
-			synchronizerData := mockld.NewServerSDKDataBuilder().
-				IntentCode("none").IntentReason("up-to-date").Build()
+			synchronizerData := mockld.FDv2SDKDataFromServerSDKData(
+				mockld.NewServerSDKDataBuilder().Build(), "none", "up-to-date", "initial")
 			dataSystem := NewSDKDataSystem(t, synchronizerData,
 				DataSystemOptionPollingInitializer(initializerData))
 			_ = NewSDKClient(t, c.baseSDKConfigurationPlus(
@@ -146,9 +146,10 @@ func (c CommonTagsTests) Run(t *ldtest.T) {
 				harness.MockEndpointDescription("unauthorized primary streaming service"))
 			t.Defer(primaryEndpoint.Close)
 
+			secondaryData := mockld.FDv2SDKDataFromServerSDKData(
+				mockld.NewServerSDKDataBuilder().Build(), "xfer-full", "initial", "initial")
 			secondaryStream := mockld.NewStreamingService(
-				mockld.NewServerSDKDataBuilder().Build(),
-				requireContext(t).sdkKind, t.DebugLogger())
+				secondaryData, requireContext(t).sdkKind, t.DebugLogger())
 			secondaryEndpoint := requireContext(t).harness.NewMockEndpoint(
 				secondaryStream, t.DebugLogger(),
 				harness.MockEndpointDescription("secondary streaming service"))

--- a/sdktests/common_tests_tags.go
+++ b/sdktests/common_tests_tags.go
@@ -1,15 +1,19 @@
 package sdktests
 
 import (
+	"net/http"
 	"strings"
 	"time"
 
+	"github.com/launchdarkly/go-sdk-common/v3/ldtime"
 	"github.com/launchdarkly/sdk-test-harness/v2/framework/harness"
 	h "github.com/launchdarkly/sdk-test-harness/v2/framework/helpers"
 	"github.com/launchdarkly/sdk-test-harness/v2/framework/ldtest"
 	o "github.com/launchdarkly/sdk-test-harness/v2/framework/opt"
+	"github.com/launchdarkly/sdk-test-harness/v2/mockld"
 	"github.com/launchdarkly/sdk-test-harness/v2/servicedef"
 
+	"github.com/launchdarkly/go-test-helpers/v2/httphelpers"
 	"github.com/launchdarkly/go-test-helpers/v2/jsonhelpers"
 
 	"github.com/stretchr/testify/assert"
@@ -105,6 +109,103 @@ func (c CommonTagsTests) Run(t *ldtest.T) {
 			})
 		}
 	})
+
+	// FDv2 introduces request shapes the streaming/polling synchronizer cases
+	// above do not cover: a polling Initializer that runs before the
+	// synchronizer, a Secondary Synchronizer reached after the Primary is
+	// permanently removed, and the FDv1 Fallback Synchronizer reached via the
+	// server-directed FDv1 Fallback Directive. The endpoint-coverage property
+	// for these new request shapes is orthogonal to the tag-value variation
+	// the subtests above exercise, so a single representative tags config is
+	// sufficient.
+	fdv2TagParams := tagsTestParams{
+		tags: servicedef.SDKConfigTagsParams{
+			ApplicationID:      o.Some("test-app"),
+			ApplicationVersion: o.Some("1.0.0"),
+		},
+	}
+	fdv2TagParams.expectedHeaderValue = c.makeExpectedTagsHeader(fdv2TagParams.tags)
+
+	if !c.isClientSide {
+		t.Run("polling initializer requests", func(t *ldtest.T) {
+			initializerData := mockld.NewServerSDKDataBuilder().Build()
+			synchronizerData := mockld.NewServerSDKDataBuilder().
+				IntentCode("none").IntentReason("up-to-date").Build()
+			dataSystem := NewSDKDataSystem(t, synchronizerData,
+				DataSystemOptionPollingInitializer(initializerData))
+			_ = NewSDKClient(t, c.baseSDKConfigurationPlus(
+				withTagsConfig(fdv2TagParams.tags),
+				dataSystem)...)
+			verifyRequestHeader(t, fdv2TagParams, dataSystem.Initializers[0].Endpoint())
+		})
+
+		t.Run("secondary synchronizer requests after permanent fallback", func(t *ldtest.T) {
+			// Primary returns 401, a non-recoverable status that permanently
+			// removes it from the synchronizer chain and causes the SDK to
+			// fall through to the Secondary immediately.
+			primaryEndpoint := requireContext(t).harness.NewMockEndpoint(
+				httphelpers.HandlerWithStatus(401), t.DebugLogger(),
+				harness.MockEndpointDescription("unauthorized primary streaming service"))
+			t.Defer(primaryEndpoint.Close)
+
+			secondaryStream := mockld.NewStreamingService(
+				mockld.NewServerSDKDataBuilder().Build(),
+				requireContext(t).sdkKind, t.DebugLogger())
+			secondaryEndpoint := requireContext(t).harness.NewMockEndpoint(
+				secondaryStream, t.DebugLogger(),
+				harness.MockEndpointDescription("secondary streaming service"))
+			t.Defer(secondaryEndpoint.Close)
+
+			_ = NewSDKClient(t, c.baseSDKConfigurationPlus(
+				withTagsConfig(fdv2TagParams.tags),
+				WithStreamingSynchronizer(servicedef.SDKConfigStreamingParams{
+					BaseURI: primaryEndpoint.BaseURL(),
+				}),
+				WithStreamingSynchronizer(servicedef.SDKConfigStreamingParams{
+					BaseURI: secondaryEndpoint.BaseURL(),
+				}))...)
+
+			verifyRequestHeader(t, fdv2TagParams, secondaryEndpoint)
+		})
+	}
+
+	if t.Capabilities().Has(servicedef.CapabilityFDv1Fallback) {
+		t.Run("FDv1 fallback directive requests", func(t *ldtest.T) {
+			// FDv2 streaming responds with 403 + directive on every request
+			// so the SDK transitions to the FDv1 Fallback Synchronizer. The
+			// FDv1 endpoint serves an empty payload so initialization can
+			// complete along the fallback path.
+			streamEndpoint := requireContext(t).harness.NewMockEndpoint(
+				httphelpers.HandlerWithResponse(
+					403, http.Header{"X-LD-FD-Fallback": []string{"true"}}, nil),
+				t.DebugLogger(),
+				harness.MockEndpointDescription("FDv2 streaming service (403 + directive)"))
+			t.Defer(streamEndpoint.Close)
+
+			fdv1Endpoint := requireContext(t).harness.NewMockEndpoint(
+				httphelpers.HandlerWithResponse(
+					200,
+					http.Header{"Content-Type": []string{"application/json"}},
+					[]byte(`{"flags":{},"segments":{}}`)),
+				t.DebugLogger(),
+				harness.MockEndpointDescription("FDv1 polling service"))
+			t.Defer(fdv1Endpoint.Close)
+
+			_ = NewSDKClient(t, c.baseSDKConfigurationPlus(
+				withTagsConfig(fdv2TagParams.tags),
+				WithConfig(servicedef.SDKConfigParams{
+					StartWaitTimeMS: o.Some(ldtime.UnixMillisecondTime(5000)),
+				}),
+				WithStreamingSynchronizer(servicedef.SDKConfigStreamingParams{
+					BaseURI: streamEndpoint.BaseURL(),
+				}),
+				WithFDv1Fallback(servicedef.SDKConfigPollingParams{
+					BaseURI: fdv1Endpoint.BaseURL(),
+				}))...)
+
+			verifyRequestHeader(t, fdv2TagParams, fdv1Endpoint)
+		})
+	}
 
 	runPermutations := func(t *ldtest.T, params []tagsTestParams) {
 		for _, p := range params {

--- a/sdktests/common_tests_tags.go
+++ b/sdktests/common_tests_tags.go
@@ -125,7 +125,11 @@ func (c CommonTagsTests) Run(t *ldtest.T) {
 	}
 	fdv2TagParams.expectedHeaderValue = c.makeExpectedTagsHeader(fdv2TagParams.tags)
 
-	if !c.isClientSide {
+	// These shapes are server-side only today, so gate on a positive
+	// identification of the server-side category rather than "not client-side":
+	// a future SDK category should have to opt in explicitly, not inherit these
+	// by default.
+	if c.sdkKind.IsServerSide() {
 		t.Run("polling initializer requests", func(t *ldtest.T) {
 			initializerData := mockld.NewServerSDKDataBuilder().Build()
 			synchronizerData := mockld.NewServerSDKDataBuilder().


### PR DESCRIPTION
## Summary

`CommonInstanceIDTests` and `CommonTagsTests` previously verified the `X-LaunchDarkly-Instance-Id` and `X-LaunchDarkly-Tags` headers only on a single streaming synchronizer, a single polling synchronizer, and the events endpoint. FDv2 introduced three new request shapes that the suite did not exercise:

- Polling Initializers that run before the synchronizer (`DataSystemOptionPollingInitializer`).
- Secondary Synchronizers reached after the Primary is permanently removed (the FDv2 fallback chain in `CommonStreamingTests.FDv2`).
- The FDv1 Fallback Synchronizer reached via the server-directed FDv1 Fallback Directive (#336).

A regression that dropped either header from any of these new request shapes would not have been caught by the existing tests.

This PR adds three subtests to each of the two files, standing up each request shape and asserting the relevant header is present:

- `polling initializer requests` -- builds a data system with a polling initializer plus a no-op (`xfer-none` / `up-to-date`) synchronizer; asserts on the initializer endpoint.
- `secondary synchronizer requests after permanent fallback` -- primary returns 401 (non-recoverable, immediate permanent removal); secondary serves an empty FDv2 stream; asserts on the secondary endpoint.
- `FDv1 fallback directive requests` -- FDv2 streaming returns `403 + X-LD-FD-Fallback: true`; FDv1 endpoint serves an empty `{"flags":{},"segments":{}}` body so init completes along the fallback path; asserts on the FDv1 endpoint.

The new subtests are server-side only -- the FDv2 features they exercise are server-side today, matching the gating used in `server_side_stream_all.go`. The FDv1 directive subtest is additionally gated on `CapabilityFDv1Fallback` so SDKs that have not yet implemented the directive can opt out.

The tags variant uses one representative tags config for the new subtests rather than iterating over `makeValidTagsTestParams` -- endpoint coverage and tag-value variation are orthogonal properties, and the existing subtests already cover the latter.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only changes to the SDK test harness; no production SDK or service behavior is modified.
> 
> **Overview**
> Expands the SDK test harness so **`X-LaunchDarkly-Instance-Id`** and **`X-LaunchDarkly-Tags`** are verified on FDv2-related request paths that were previously untested (streaming/poll/events only).
> 
> **Instance ID:** Replaces one-off header checks with **`newInstanceIDChecker`**, which requires a non-empty header and the **same** value across every endpoint touched by one client. Adds a subtest that **distinct clients get distinct** instance IDs (skipped when `CapabilitySingleton`). Adds server-side subtests for **polling initializer**, **secondary synchronizer after permanent 401 fallback**, and **FDv1 fallback directive** (gated on `CapabilityFDv1Fallback`), including assertions that abandoned endpoints stop receiving traffic.
> 
> **Tags:** Mirrors the same three FDv2 request-shape subtests using one representative tags config (endpoint coverage vs tag permutations).
> 
> **Shared:** Adds **`emptyFDv1FallbackBody`** on `commonTestsBase` so FDv1 fallback mocks return server- vs client-side-shaped empty JSON for init-only scenarios.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 48e0fd903b1cb3eb6263bdb048ba237e75c7b11b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->