### PR TITLE
feat: Assert hook execution order for evaluation and track stages

### DIFF
--- a/mockld/hook_callback_service.go
+++ b/mockld/hook_callback_service.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"io"
 	"net/http"
+	"sync/atomic"
 
 	"github.com/launchdarkly/sdk-test-harness/v2/framework"
 	"github.com/launchdarkly/sdk-test-harness/v2/framework/harness"
@@ -24,9 +25,14 @@ func (h *HookCallbackService) Close() {
 	h.payloadEndpoint.Close()
 }
 
+// NewHookCallbackService creates an HTTP endpoint that records incoming hook
+// callbacks. If sequence is non-nil it is incremented per received call and
+// stamped onto the payload so tests can establish ordering across hooks that
+// share the same counter.
 func NewHookCallbackService(
 	testHarness *harness.TestHarness,
 	logger framework.Logger,
+	sequence *atomic.Int64,
 ) *HookCallbackService {
 	h := &HookCallbackService{
 		CallChannel: make(chan servicedef.HookExecutionPayload),
@@ -47,6 +53,10 @@ func NewHookCallbackService(
 			logger.Printf("Could not unmarshal hook payload.")
 			w.WriteHeader(http.StatusBadRequest)
 			return
+		}
+
+		if sequence != nil {
+			response.Sequence = sequence.Add(1)
 		}
 
 		go func() {

--- a/sdktests/common_tests_hooks.go
+++ b/sdktests/common_tests_hooks.go
@@ -1,8 +1,8 @@
 package sdktests
 
 import (
+	"cmp"
 	"slices"
-	"sort"
 	"strconv"
 
 	"github.com/launchdarkly/go-sdk-common/v3/ldcontext"
@@ -508,7 +508,7 @@ func observedHookOrder(t *ldtest.T, hooks *Hooks, names []string, stage serviced
 			return true
 		})
 	}
-	sort.Slice(calls, func(i, j int) bool { return calls[i].sequence < calls[j].sequence })
+	slices.SortFunc(calls, func(a, b observedCall) int { return cmp.Compare(a.sequence, b.sequence) })
 	out := make([]string, 0, len(calls))
 	for _, c := range calls {
 		out = append(out, c.name)

--- a/sdktests/common_tests_hooks.go
+++ b/sdktests/common_tests_hooks.go
@@ -30,8 +30,10 @@ func doEvaluationSeriesTests(t *ldtest.T) {
 	t.Run("executes beforeEvaluation stage", executesBeforeEvaluationStage)
 	t.Run("executes afterEvaluation stage", executesAfterEvaluationStage)
 	t.Run("an error in before stage does not affect after stage", errorInBeforeStageDoesNotAffectAfterStage)
-	t.Run("executes beforeEvaluation hooks in registration order", executesBeforeEvaluationHooksInRegistrationOrder)
-	t.Run("executes afterEvaluation hooks in reverse registration order", executesAfterEvaluationHooksInReverseRegistrationOrder)
+	t.Run("executes beforeEvaluation hooks in registration order",
+		executesBeforeEvaluationHooksInRegistrationOrder)
+	t.Run("executes afterEvaluation hooks in reverse registration order",
+		executesAfterEvaluationHooksInReverseRegistrationOrder)
 
 	t.Run("data propagates from before to after", beforeEvaluationDataPropagatesToAfter)
 	t.RequireCapability(servicedef.CapabilityMigrations)

--- a/sdktests/common_tests_hooks.go
+++ b/sdktests/common_tests_hooks.go
@@ -1,6 +1,7 @@
 package sdktests
 
 import (
+	"sort"
 	"strconv"
 
 	"github.com/launchdarkly/go-sdk-common/v3/ldcontext"
@@ -39,6 +40,7 @@ func doTrackSeriesTests(t *ldtest.T) {
 	t.RequireCapability(servicedef.CapabilityTrackHooks)
 	t.Run("executes afterTrack stage", executesAfterTrackStage)
 	t.Run("a hook error prevents afterTrack stage", errorInHookPreventsAfterTrackStage)
+	t.Run("executes afterTrack hooks in registration order", executesAfterTrackHooksInRegistrationOrder)
 }
 
 func executesBeforeEvaluationStage(t *ldtest.T) {
@@ -470,6 +472,57 @@ func errorInHookPreventsAfterTrackStage(t *ldtest.T) {
 	})
 	client.FlushEvents(t)
 	hooks.ExpectNoCall(t, hookName)
+}
+
+// afterTrack must execute in the order of hook registration (forward),
+// unlike afterEvaluation/afterIdentify which run in reverse-registration order.
+func executesAfterTrackHooksInRegistrationOrder(t *ldtest.T) {
+	const numHooks = 3
+	names := make([]string, 0, numHooks)
+	for i := 0; i < numHooks; i++ {
+		names = append(names, "afterTrackOrderHook-"+strconv.Itoa(i))
+	}
+
+	context := ldcontext.New("user-key")
+	eventContext := o.Some(context)
+	configurers := []SDKConfigurer{}
+
+	if t.Capabilities().Has(servicedef.CapabilityClientSide) {
+		configurers = append(configurers, WithClientSideInitialContext(context))
+		eventContext = o.None[ldcontext.Context]()
+	}
+
+	client, hooks := createClientForHooks(t, names, nil, configurers...)
+	defer hooks.Close()
+
+	client.SendCustomEvent(t, servicedef.CustomEventParams{
+		EventKey: "custom-event",
+		Context:  eventContext,
+	})
+
+	type observedCall struct {
+		name     string
+		sequence int64
+	}
+	observed := make([]observedCall, 0, numHooks)
+	for _, name := range names {
+		hooks.ExpectCall(t, name, func(payload servicedef.HookExecutionPayload) bool {
+			if payload.Stage.Value() != servicedef.AfterTrack {
+				return false
+			}
+			observed = append(observed, observedCall{name: name, sequence: payload.Sequence})
+			return true
+		})
+	}
+
+	sort.Slice(observed, func(i, j int) bool { return observed[i].sequence < observed[j].sequence })
+
+	actualOrder := make([]string, 0, len(observed))
+	for _, c := range observed {
+		actualOrder = append(actualOrder, c.name)
+	}
+	assert.Equal(t, names, actualOrder,
+		"afterTrack hooks must execute in the order of hook registration")
 }
 
 func createClientForHooks(t *ldtest.T, instances []string,

--- a/sdktests/common_tests_hooks.go
+++ b/sdktests/common_tests_hooks.go
@@ -30,6 +30,8 @@ func doEvaluationSeriesTests(t *ldtest.T) {
 	t.Run("executes beforeEvaluation stage", executesBeforeEvaluationStage)
 	t.Run("executes afterEvaluation stage", executesAfterEvaluationStage)
 	t.Run("an error in before stage does not affect after stage", errorInBeforeStageDoesNotAffectAfterStage)
+	t.Run("executes beforeEvaluation hooks in registration order", executesBeforeEvaluationHooksInRegistrationOrder)
+	t.Run("executes afterEvaluation hooks in reverse registration order", executesAfterEvaluationHooksInReverseRegistrationOrder)
 
 	t.Run("data propagates from before to after", beforeEvaluationDataPropagatesToAfter)
 	t.RequireCapability(servicedef.CapabilityMigrations)
@@ -474,14 +476,55 @@ func errorInHookPreventsAfterTrackStage(t *ldtest.T) {
 	hooks.ExpectNoCall(t, hookName)
 }
 
+// hookOrderTestNames returns numHooks distinct hook names suitable for
+// ordering tests. The names embed their registration index so the order in
+// which the SDK executed them is decoded from the names alone.
+func hookOrderTestNames(prefix string, numHooks int) []string {
+	names := make([]string, 0, numHooks)
+	for i := 0; i < numHooks; i++ {
+		names = append(names, prefix+"-"+strconv.Itoa(i))
+	}
+	return names
+}
+
+// observedHookOrder collects one call per hook at the given stage and returns
+// the hook names sorted by harness-stamped sequence number, i.e. the order
+// the SDK actually executed them.
+func observedHookOrder(t *ldtest.T, hooks *Hooks, names []string, stage servicedef.HookStage) []string {
+	type observedCall struct {
+		name     string
+		sequence int64
+	}
+	calls := make([]observedCall, 0, len(names))
+	for _, name := range names {
+		hooks.ExpectCall(t, name, func(payload servicedef.HookExecutionPayload) bool {
+			if payload.Stage.Value() != stage {
+				return false
+			}
+			calls = append(calls, observedCall{name: name, sequence: payload.Sequence})
+			return true
+		})
+	}
+	sort.Slice(calls, func(i, j int) bool { return calls[i].sequence < calls[j].sequence })
+	out := make([]string, 0, len(calls))
+	for _, c := range calls {
+		out = append(out, c.name)
+	}
+	return out
+}
+
+func reverseStrings(in []string) []string {
+	out := make([]string, len(in))
+	for i, v := range in {
+		out[len(in)-1-i] = v
+	}
+	return out
+}
+
 // afterTrack must execute in the order of hook registration (forward),
 // unlike afterEvaluation/afterIdentify which run in reverse-registration order.
 func executesAfterTrackHooksInRegistrationOrder(t *ldtest.T) {
-	const numHooks = 3
-	names := make([]string, 0, numHooks)
-	for i := 0; i < numHooks; i++ {
-		names = append(names, "afterTrackOrderHook-"+strconv.Itoa(i))
-	}
+	names := hookOrderTestNames("afterTrackOrderHook", 3)
 
 	context := ldcontext.New("user-key")
 	eventContext := o.Some(context)
@@ -500,29 +543,62 @@ func executesAfterTrackHooksInRegistrationOrder(t *ldtest.T) {
 		Context:  eventContext,
 	})
 
-	type observedCall struct {
-		name     string
-		sequence int64
-	}
-	observed := make([]observedCall, 0, numHooks)
-	for _, name := range names {
-		hooks.ExpectCall(t, name, func(payload servicedef.HookExecutionPayload) bool {
-			if payload.Stage.Value() != servicedef.AfterTrack {
-				return false
-			}
-			observed = append(observed, observedCall{name: name, sequence: payload.Sequence})
-			return true
-		})
-	}
-
-	sort.Slice(observed, func(i, j int) bool { return observed[i].sequence < observed[j].sequence })
-
-	actualOrder := make([]string, 0, len(observed))
-	for _, c := range observed {
-		actualOrder = append(actualOrder, c.name)
-	}
-	assert.Equal(t, names, actualOrder,
+	assert.Equal(t, names, observedHookOrder(t, hooks, names, servicedef.AfterTrack),
 		"afterTrack hooks must execute in the order of hook registration")
+}
+
+// beforeEvaluation must execute in the order of hook registration.
+func executesBeforeEvaluationHooksInRegistrationOrder(t *ldtest.T) {
+	names := hookOrderTestNames("beforeEvalOrderHook", 3)
+
+	context := ldcontext.New("user-key")
+	flagContext := o.Some(context)
+	configurers := []SDKConfigurer{}
+
+	if t.Capabilities().Has(servicedef.CapabilityClientSide) {
+		configurers = append(configurers, WithClientSideInitialContext(context))
+		flagContext = o.None[ldcontext.Context]()
+	}
+
+	client, hooks := createClientForHooks(t, names, nil, configurers...)
+	defer hooks.Close()
+
+	client.EvaluateFlag(t, servicedef.EvaluateFlagParams{
+		FlagKey:      "bool-flag",
+		Context:      flagContext,
+		ValueType:    servicedef.ValueTypeBool,
+		DefaultValue: ldvalue.Bool(false),
+	})
+
+	assert.Equal(t, names, observedHookOrder(t, hooks, names, servicedef.BeforeEvaluation),
+		"beforeEvaluation hooks must execute in the order of hook registration")
+}
+
+// afterEvaluation must execute in the reverse of the order of hook registration.
+func executesAfterEvaluationHooksInReverseRegistrationOrder(t *ldtest.T) {
+	names := hookOrderTestNames("afterEvalOrderHook", 3)
+
+	context := ldcontext.New("user-key")
+	flagContext := o.Some(context)
+	configurers := []SDKConfigurer{}
+
+	if t.Capabilities().Has(servicedef.CapabilityClientSide) {
+		configurers = append(configurers, WithClientSideInitialContext(context))
+		flagContext = o.None[ldcontext.Context]()
+	}
+
+	client, hooks := createClientForHooks(t, names, nil, configurers...)
+	defer hooks.Close()
+
+	client.EvaluateFlag(t, servicedef.EvaluateFlagParams{
+		FlagKey:      "bool-flag",
+		Context:      flagContext,
+		ValueType:    servicedef.ValueTypeBool,
+		DefaultValue: ldvalue.Bool(false),
+	})
+
+	assert.Equal(t, reverseStrings(names), observedHookOrder(t, hooks, names, servicedef.AfterEvaluation),
+		"afterEvaluation hooks must execute in the reverse of the order of hook registration")
 }
 
 func createClientForHooks(t *ldtest.T, instances []string,

--- a/sdktests/common_tests_hooks.go
+++ b/sdktests/common_tests_hooks.go
@@ -1,6 +1,7 @@
 package sdktests
 
 import (
+	"slices"
 	"sort"
 	"strconv"
 
@@ -515,14 +516,6 @@ func observedHookOrder(t *ldtest.T, hooks *Hooks, names []string, stage serviced
 	return out
 }
 
-func reverseStrings(in []string) []string {
-	out := make([]string, len(in))
-	for i, v := range in {
-		out[len(in)-1-i] = v
-	}
-	return out
-}
-
 // afterTrack must execute in the order of hook registration (forward),
 // unlike afterEvaluation/afterIdentify which run in reverse-registration order.
 func executesAfterTrackHooksInRegistrationOrder(t *ldtest.T) {
@@ -599,7 +592,9 @@ func executesAfterEvaluationHooksInReverseRegistrationOrder(t *ldtest.T) {
 		DefaultValue: ldvalue.Bool(false),
 	})
 
-	assert.Equal(t, reverseStrings(names), observedHookOrder(t, hooks, names, servicedef.AfterEvaluation),
+	expected := slices.Clone(names)
+	slices.Reverse(expected)
+	assert.Equal(t, expected, observedHookOrder(t, hooks, names, servicedef.AfterEvaluation),
 		"afterEvaluation hooks must execute in the reverse of the order of hook registration")
 }
 

--- a/sdktests/testapi_hooks.go
+++ b/sdktests/testapi_hooks.go
@@ -1,6 +1,7 @@
 package sdktests
 
 import (
+	"sync/atomic"
 	"time"
 
 	"github.com/stretchr/testify/assert"
@@ -26,6 +27,10 @@ type HookInstance struct {
 
 type Hooks struct {
 	instances map[string]HookInstance
+	// sequence is a per-Hooks counter shared by every HookCallbackService so
+	// that arrival order across hooks (which each have their own callback URL)
+	// can be reconstructed in tests.
+	sequence *atomic.Int64
 }
 
 func NewHooks(
@@ -37,11 +42,12 @@ func NewHooks(
 ) *Hooks {
 	hooks := &Hooks{
 		instances: make(map[string]HookInstance),
+		sequence:  &atomic.Int64{},
 	}
 	for _, instance := range instances {
 		hooks.instances[instance] = HookInstance{
 			name:        instance,
-			hookService: mockld.NewHookCallbackService(testHarness, logger),
+			hookService: mockld.NewHookCallbackService(testHarness, logger, hooks.sequence),
 			data:        data,
 			errors:      errors,
 		}

--- a/sdktests/testapi_hooks.go
+++ b/sdktests/testapi_hooks.go
@@ -27,6 +27,10 @@ type HookInstance struct {
 
 type Hooks struct {
 	instances map[string]HookInstance
+	// order preserves the registration order of hook names so Configure can
+	// send hooks to the SDK deterministically. Map iteration in Go is
+	// randomized, so we cannot derive this from `instances` alone.
+	order []string
 	// sequence is a per-Hooks counter shared by every HookCallbackService so
 	// that arrival order across hooks (which each have their own callback URL)
 	// can be reconstructed in tests.
@@ -42,6 +46,7 @@ func NewHooks(
 ) *Hooks {
 	hooks := &Hooks{
 		instances: make(map[string]HookInstance),
+		order:     make([]string, 0, len(instances)),
 		sequence:  &atomic.Int64{},
 	}
 	for _, instance := range instances {
@@ -51,6 +56,7 @@ func NewHooks(
 			data:        data,
 			errors:      errors,
 		}
+		hooks.order = append(hooks.order, instance)
 	}
 
 	return hooks
@@ -58,7 +64,8 @@ func NewHooks(
 
 func (h *Hooks) Configure(config *servicedef.SDKConfigParams) error {
 	hookConfig := config.Hooks.Value()
-	for _, instance := range h.instances {
+	for _, name := range h.order {
+		instance := h.instances[name]
 		hookConfig.Hooks = append(hookConfig.Hooks, servicedef.SDKConfigHookInstance{
 			Name:        instance.name,
 			CallbackURI: instance.hookService.GetURL(),

--- a/servicedef/command_params.go
+++ b/servicedef/command_params.go
@@ -218,4 +218,9 @@ type HookExecutionPayload struct {
 	EvaluationDetail        o.Maybe[EvaluateFlagResponse]     `json:"evaluationDetail"`
 	TrackSeriesContext      o.Maybe[TrackSeriesContext]       `json:"trackSeriesContext"`
 	Stage                   o.Maybe[HookStage]                `json:"stage"`
+
+	// Sequence is stamped by the test harness in the order callbacks arrive.
+	// Shared across all hook instances of a single Hooks group so tests can
+	// assert cross-hook ordering. Not part of the SDK contract.
+	Sequence int64 `json:"-"`
 }


### PR DESCRIPTION
## Summary

- Adds cross-hook ordering assertions for the three hook stages the harness currently knows about:
  - `beforeEvaluation` -- registration order.
  - `afterEvaluation` -- reverse of registration order.
  - `afterTrack` -- registration order.
- The harness previously had no ordering coverage for any hook stage, so a regression to the wrong order (e.g. the pre-fix Go SDK behavior corrected in [go-server-sdk#379](https://github.com/launchdarkly/go-server-sdk/pull/379)) would not have been caught.
- Mechanism: each `Hooks` group owns one `*atomic.Int64`, threaded into every `HookCallbackService` it creates. The endpoint handler stamps the counter onto each received payload before pushing it onto the channel, so tests can reconstruct cross-hook execution order from the otherwise-independent callback URLs.
- The new `Sequence` field on `HookExecutionPayload` is harness-internal (`json:"-"`) and is not part of the SDK contract; no contract-test changes are required in SDK repos.
- `beforeIdentify` / `afterIdentify` are still uncovered because the harness has no `HookStage` constants or contract surface for the identify series. That is left for a follow-up.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes are confined to the test harness and test suite; the new `Sequence` field is harness-internal (`json:"-"`) and should not affect SDK contracts or wire formats.
> 
> **Overview**
> Adds new hook-ordering coverage to the common hooks test suite, asserting `beforeEvaluation` runs in registration order, `afterEvaluation` runs in reverse registration order, and `afterTrack` runs in registration order.
> 
> To support cross-hook ordering assertions, hook callbacks are now stamped with a harness-managed monotonic `Sequence` counter shared across a `Hooks` group, and hook configuration is emitted in deterministic registration order rather than Go map iteration order.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1a8d35914f2bb3065c5cfca856255bc58aaf3b29. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->