### PR TITLE
ci: enable release-please for v3 prereleases

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -4,6 +4,8 @@ on:
   push:
     branches:
       - v2
+      - feat/fdv2
+  workflow_dispatch:
 
 jobs:
   release-please:

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -4,7 +4,7 @@ on:
   push:
     branches:
       - v2
-      - feat/fdv2
+      - v3
   workflow_dispatch:
 
 jobs:

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -6,6 +6,8 @@
       "bump-minor-pre-major": true,
       "versioning": "default",
       "include-component-in-tag": false,
+      "prerelease": true,
+      "prerelease-type": "alpha",
       "extra-files": [
         "main.go"
       ]


### PR DESCRIPTION
**Requirements**

- [x] I have followed the repository's [pull request submission guidelines](../blob/master/CONTRIBUTING.md#submitting-pull-requests)

**Related issues**

N/A — this replaces the recurring manual version-bump pattern most recently seen in #337 ("chore: Prepare for next v3 release").

**Describe the solution you've provided**

Enables release-please automation for the `v3` branch (formerly `feat/fdv2`, renamed as part of promoting it to a long-lived release branch) so v3 prereleases (`3.0.0-alpha.x`) are produced on the same automated flow that already runs for `v2`. Two files change:

- `.github/workflows/release-please.yml`
  - Adds `v3` to the `push.branches` filter so the workflow runs on commits to this branch.
  - Adds `workflow_dispatch` so the workflow can be triggered manually from the Actions UI as a catch-up / retry mechanism.

- `release-please-config.json`
  - Adds `"prerelease": true` so commits since the last manifest bump roll into a prerelease rather than promoting to stable or jumping to the next minor.
  - Adds `"prerelease-type": "alpha"` to explicitly lock the prerelease label to `alpha` (matching the current `3.0.0-alpha.x` series).

The workflow body is already branch-agnostic — it uses `target-branch: ${{ github.ref_name }}`, and release-please tracks per-branch state via `.release-please-manifest.json` — so no other changes are needed.

**Effect on `v2`**

None. GitHub Actions evaluates the workflow file at the pushed commit's ref, so v2's copy of the file is unaffected by these changes. `release-please-config.json` is also branch-scoped.

**Expected first run after merge**

When this PR merges, the merge commit's push to `v3` should trigger release-please. It should scan conventional commits since the last manifest bump (`3.0.0-alpha.6` set by #337) and open a release PR proposing `3.0.0-alpha.7`. If the auto-trigger doesn't fire for any reason, the workflow can be manually dispatched from **Actions → Run Release Please → Run workflow → v3**.

**Note for future `v2` → `v3` forward merges**

The merge-conflict checklist on `v3` (previously: manifest version, `main.go` version constant) now includes two additional files where v2's content must not overwrite v3's:

- `.github/workflows/release-please.yml` — keep the superset filter (`v2` + `v3`) and the `workflow_dispatch` trigger.
- `release-please-config.json` — keep the `prerelease` and `prerelease-type` entries.

**Describe alternatives you've considered**

- **Pre-syncing `v3` into v2's workflow filter as a separate PR.** Considered but dropped to keep this to a single PR. The trade-off is one extra item on the v2-forward merge conflict checklist (see above) — small and consistent enough to be acceptable.
- **Adding a `concurrency:` block to guard against simultaneous push + manual-dispatch runs.** Skipped — v2 doesn't have one today, and release-please-action is mostly idempotent. Easy to add later if contention is ever observed.

**Test plan**

- [ ] On merge, verify release-please runs on `v3` and opens a release PR for `3.0.0-alpha.7`.
- [ ] Verify the auto-generated release PR's diff is limited to `.release-please-manifest.json`, `main.go` (version constant), and `CHANGELOG.md`.
- [ ] If the auto-trigger doesn't fire, manually dispatch from the Actions UI and confirm the release PR is created.
- [ ] Merge the release PR and confirm the existing tag/publish flow produces a non-draft `v3.0.0-alpha.7` release with artifacts.