### PR TITLE
fix: Do not record intermediate poll misses in FDv2 validatePayloadReceived

### DIFF
--- a/sdktests/common_tests_stream_fdv2.go
+++ b/sdktests/common_tests_stream_fdv2.go
@@ -1297,16 +1297,22 @@ func validatePayloadReceived(t *ldtest.T,
 
 	m.In(t).Assert(request.URL.Query().Get("basis"), m.Equal(state))
 
+	// Use a non-recording matcher Test() inside the poll: m.In(t).Assert would
+	// call t.Errorf on the first miss and permanently fail the test, defeating
+	// RequireEventually. Some SDKs deliver the first streamed payload slightly
+	// after the connection is established (e.g. RN's XHR EventSource), so the
+	// expected value may not be present on the first poll even though the SDK
+	// behaves correctly. RequireEventually reports a real failure on timeout.
 	h.RequireEventually(t, func() bool {
 		for flagKey, expectedValue := range evaluations {
 			actualValue := basicEvaluateFlag(t, client, flagKey, evalContext, defaultValue)
-			if !m.In(t).Assert(actualValue, m.JSONEqual(expectedValue)) {
+			if pass, _ := m.JSONEqual(expectedValue).Test(actualValue); !pass {
 				return false
 			}
 		}
 
 		return true
-	}, time.Second, time.Millisecond*20, "failed to evaluate flag")
+	}, time.Second, time.Millisecond*20, "failed to evaluate flags to the expected values")
 
 	return request
 }


### PR DESCRIPTION
BEGIN_COMMIT_OVERRIDE
fix: Do not record intermediate poll misses in FDv2 validatePayloadReceived
END_COMMIT_OVERRIDE

## Summary

`validatePayloadReceived` (used by the FDv2 `streaming/fdv2/reconnection state management` tests) calls `m.In(t).Assert(...)` inside its `RequireEventually` poll closure:

```go
h.RequireEventually(t, func() bool {
    for flagKey, expectedValue := range evaluations {
        actualValue := basicEvaluateFlag(t, client, flagKey, evalContext, defaultValue)
        if !m.In(t).Assert(actualValue, m.JSONEqual(expectedValue)) { // records t.Errorf on first miss
            return false
        }
    }
    return true
}, time.Second, time.Millisecond*20, "failed to evaluate flag")
```

`AssertionScope.Assert` calls `t.Errorf` on a failed match, which **permanently** fails the test on the very first poll tick (20ms) -- even though the closure returns `false`, the loop retries, and a later tick succeeds within the 1s window. This defeats the purpose of `RequireEventually`.

The bug is latent for SDKs whose EventSource delivers the first streamed payload synchronously (they win the first-tick race). It surfaces for SDKs that deliver the first payload a few tens of milliseconds after the stream connection is established -- e.g. the React Native SDK, whose XHR-based EventSource surfaces the response body shortly after the response headers. In that case the SDK behaves correctly (the value and `basis` are correct, and the value is present well within 1s), but the test records a failure from the first poll tick.

## Change

Use a non-recording `matcher.Test()` inside the poll closure. `RequireEventually` still fails the test (with its message) if the values never converge within the timeout. The one-time `basis` query-parameter assertion is unchanged.

## Validation

Run locally against an Android emulator (React Native SDK) and a headless-Chromium browser SDK entity, harness built from this branch:
- React Native: the four `streaming/fdv2/reconnection state management` tests now pass; full FDv2 client-side suite green (788 ran, 0 critical failures). Previously 4 failed.
- Browser: all critical FDv2 tests still pass; no regression.

The corresponding RN SDK reconnect fix (replaying the `basis` selector on reconnect) is a separate change in js-core.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-harness-only change with no production SDK or runtime behavior impact.
> 
> **Overview**
> Fixes a **false failure** in FDv2 harness helper `validatePayloadReceived` (used by **reconnection state management** and related streaming tests).
> 
> Inside the `RequireEventually` poll loop, flag checks now use **`m.JSONEqual(...).Test(actualValue)`** instead of **`m.In(t).Assert`**. Recording assertions call `t.Errorf` on the first mismatch, which **permanently fails** the test even when a later poll would succeed within the timeout—problematic for SDKs whose first streamed payload arrives shortly after the connection (e.g. React Native XHR EventSource).
> 
> The one-shot `basis` query assertion is unchanged; only the eventual flag-evaluation polling behavior is fixed. The timeout message is slightly clarified.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit eb44f104ebf64640c533a96341c917a51c9bd626. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->