### PR TITLE
docs: Update SECURITY.md to reflect bug bounty program

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,5 +1,8 @@
 # Reporting and Fixing Security Issues
 
-Please report all security issues to the LaunchDarkly security team by submitting a bug bounty report to our [HackerOne program](https://hackerone.com/launchdarkly?type=team). LaunchDarkly will triage and address all valid security issues following the response targets defined in our program policy. Valid security issues may be eligible for a bounty.
+**Do not open Issues or Pull Requests for security issues.**  
+This will make potential issues publicly visible before LaunchDarkly's Security Team can address them, which could lead to a compromise of the platform and negatively impact our customers. 
 
-Please do not open issues or pull requests for security issues. This makes the problem immediately visible to everyone, including potentially malicious actors.
+Security issues must be reported through our [Bug Bounty program](https://bugcrowd.com/engagements/launchdarkly-mbb-og), following the program policy, for triage and remediation by the LaunchDarkly Security Team. Valid security issues may be eligible for a bounty.
+
+Please do not attempt to directly contact members of LaunchDarkly staff.


### PR DESCRIPTION
This ports the SECURITY.md bug bounty update from v2 onto the v3 branch.

The v3 branch will eventually be default, and would have been missing the new notice.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only change with no runtime or security logic impact.
> 
> **Overview**
> Updates **`SECURITY.md`** on the v3 branch to match the bug bounty messaging already on v2.
> 
> The doc now leads with a **bold warning** not to file GitHub Issues or PRs for security problems, with clearer rationale about public disclosure risk. Reporting is pointed at LaunchDarkly’s **[Bugcrowd program](https://bugcrowd.com/engagements/launchdarkly-mbb-og)** instead of the previous HackerOne link, and adds a line asking reporters not to contact staff directly.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4e45ef43b295f74397964d37ed544ccd9c072ab6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->