### PR TITLE
test: Verify the in operator keeps booleans and numbers distinct

### DIFF
--- a/data/data-files/server-side-eval/operators-equality-bool-number.yml
+++ b/data/data-files/server-side-eval/operators-equality-bool-number.yml
@@ -1,0 +1,106 @@
+---
+name: operators - equality does not conflate booleans and numbers
+
+# Booleans and numbers are distinct JSON types, so the "in" operator must never
+# treat them as equal. Some languages make this easy to get wrong: in Python a
+# bool is a subclass of int, so a naive equality check makes True == 1 and
+# False == 0. These cases assert that a boolean attribute never matches a numeric
+# clause value (and vice versa), while genuine same-type matches still succeed.
+
+constants:
+  IS_MATCH:
+    value: true
+    variationIndex: 0
+    reason: { kind: "RULE_MATCH", ruleIndex: 0, ruleId: "ruleid" }
+  IS_NOT_MATCH:
+    value: false
+    variationIndex: 1
+    reason: { kind: "FALLTHROUGH" }
+
+parameters:
+  # boolean attribute against numeric clause values - never a match
+  - NAME: boolean true does not match integer clause value 1
+    CONTEXT: { key: "user-key", custom: { attrname: true } }
+    CLAUSE: { attribute: attrname, op: in, values: [ 1 ] }
+    EXPECT: <IS_NOT_MATCH>
+
+  - NAME: boolean true does not match double clause value 1.0
+    CONTEXT: { key: "user-key", custom: { attrname: true } }
+    CLAUSE: { attribute: attrname, op: in, values: [ 1.0 ] }
+    EXPECT: <IS_NOT_MATCH>
+
+  - NAME: boolean false does not match integer clause value 0
+    CONTEXT: { key: "user-key", custom: { attrname: false } }
+    CLAUSE: { attribute: attrname, op: in, values: [ 0 ] }
+    EXPECT: <IS_NOT_MATCH>
+
+  - NAME: boolean false does not match double clause value 0.0
+    CONTEXT: { key: "user-key", custom: { attrname: false } }
+    CLAUSE: { attribute: attrname, op: in, values: [ 0.0 ] }
+    EXPECT: <IS_NOT_MATCH>
+
+  # numeric attribute against boolean clause values - never a match
+  - NAME: integer 1 does not match boolean clause value true
+    CONTEXT: { key: "user-key", custom: { attrname: 1 } }
+    CLAUSE: { attribute: attrname, op: in, values: [ true ] }
+    EXPECT: <IS_NOT_MATCH>
+
+  - NAME: integer 0 does not match boolean clause value false
+    CONTEXT: { key: "user-key", custom: { attrname: 0 } }
+    CLAUSE: { attribute: attrname, op: in, values: [ false ] }
+    EXPECT: <IS_NOT_MATCH>
+
+  - NAME: double 1.0 does not match boolean clause value true
+    CONTEXT: { key: "user-key", custom: { attrname: 1.0 } }
+    CLAUSE: { attribute: attrname, op: in, values: [ true ] }
+    EXPECT: <IS_NOT_MATCH>
+
+  # a boolean must not match a numeric value even when the clause also lists a boolean
+  - NAME: integer 1 does not match clause listing boolean and numeric values
+    CONTEXT: { key: "user-key", custom: { attrname: 1 } }
+    CLAUSE: { attribute: attrname, op: in, values: [ false, true ] }
+    EXPECT: <IS_NOT_MATCH>
+
+  - NAME: boolean true does not match clause listing numeric values
+    CONTEXT: { key: "user-key", custom: { attrname: true } }
+    CLAUSE: { attribute: attrname, op: in, values: [ 0, 1 ] }
+    EXPECT: <IS_NOT_MATCH>
+
+  # same-type comparisons still match, confirming the fix does not over-reject
+  - NAME: boolean true matches boolean clause value true
+    CONTEXT: { key: "user-key", custom: { attrname: true } }
+    CLAUSE: { attribute: attrname, op: in, values: [ true ] }
+    EXPECT: <IS_MATCH>
+
+  - NAME: boolean false matches boolean clause value false
+    CONTEXT: { key: "user-key", custom: { attrname: false } }
+    CLAUSE: { attribute: attrname, op: in, values: [ false ] }
+    EXPECT: <IS_MATCH>
+
+  - NAME: integer 1 matches integer clause value 1
+    CONTEXT: { key: "user-key", custom: { attrname: 1 } }
+    CLAUSE: { attribute: attrname, op: in, values: [ 1 ] }
+    EXPECT: <IS_MATCH>
+
+  - NAME: integer 0 matches integer clause value 0
+    CONTEXT: { key: "user-key", custom: { attrname: 0 } }
+    CLAUSE: { attribute: attrname, op: in, values: [ 0 ] }
+    EXPECT: <IS_MATCH>
+
+sdkData:
+  flags:
+    test-flag:
+      on: true
+      fallthrough: { variation: 1 }
+      variations: [ true, false ]
+      rules:
+        - id: ruleid
+          variation: 0
+          clauses: [ <CLAUSE> ]
+
+evaluations:
+  - name: <NAME>
+    flagKey: test-flag
+    context: <CONTEXT>
+    default: false
+    expect: <EXPECT>


### PR DESCRIPTION
BEGIN_COMMIT_OVERRIDE
feat: Verify the in operator keeps booleans and numbers distinct
END_COMMIT_OVERRIDE

## Summary

Adds server-side evaluation contract tests asserting that the `in` operator keeps booleans and numbers distinct.

Booleans and numbers are distinct JSON types, so the `in` operator must never treat them as equal. This is easy to get wrong in some languages -- in Python a `bool` is a subclass of `int`, so a naive equality check makes `True == 1` and `False == 0`, causing a boolean attribute to match a numeric clause value (and vice versa). This was reported against the Python SDK in launchdarkly/python-server-sdk#432.

The new cases (`operators-equality-bool-number.yml`) cover:

- A boolean attribute never matching an integer or double clause value, in both directions.
- A boolean attribute not matching a numeric clause value even when the clause also lists a boolean (and vice versa).
- Genuine same-type comparisons (`true`/`true`, `false`/`false`, `1`/`1`, `0`/`0`) still matching, so the stricter behavior does not over-reject.

These tests fail against an SDK with the bug and pass against a fixed one, so they will catch the same class of defect in other SDKs going forward.

This is the v3 branch change; an equivalent PR targets v2.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only YAML contract data; no runtime or SDK implementation changes in this PR.
> 
> **Overview**
> Adds a new server-side evaluation contract file **`operators-equality-bool-number.yml`** that locks in JSON-type–strict behavior for the **`in`** operator: boolean context attributes must not match numeric clause values (and the reverse), including when a clause mixes booleans and numbers.
> 
> The suite also asserts that same-type **`in`** checks still match (`true`/`true`, `1`/`1`, etc.), so SDKs cannot “fix” cross-type equality without breaking legitimate rules. This targets bugs like Python’s `True == 1` affecting clause matching (see python-server-sdk#432).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0da476ec1b38f7e6d460fe09a247ae9c13c4ada1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->