### PR TITLE
Add contract tests for client-side secure mode hash (h query param)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ bin/
 dist/
 .idea
 sdk-test-harness
+.claude/sdk-one-shot/

--- a/docs/service_spec.md
+++ b/docs/service_spec.md
@@ -124,6 +124,7 @@ A `POST` request indicates that the test harness wants to start an instance of t
   * `clientSide` (object): This is omitted for server-side SDKs, and required for client-side SDKs. Properties are:
     * `initialUser` (object, required): The user properties to initialize the SDK with. The test service for a client-side SDK can assume that the test harness will _always_ set this: if the test logic does not explicitly provide a value, the test harness will add a default one.
     * `autoAliasingOptOut`, `evaluationReasons`, `useReport` (boolean, optional): These correspond to the SDK configuration properties of the same names.
+    * `hash` (string, optional): If present, a secure mode hash value that the SDK should use when connecting to the streaming and polling services. When set, the SDK must include this value as the `h` query parameter on streaming and polling requests. This field is only used by test services that declare the `"secure-mode-hash"` capability.
 
 The response to a valid request is any HTTP `2xx` status, with a `Location` header whose value is the URL of the test service resource representing this SDK client instance (that is, the one that would be used for "Close client" or "Send command" as described below).
 

--- a/downloader/run.sh
+++ b/downloader/run.sh
@@ -7,6 +7,9 @@ set -e
 # or a partial version (v1) in the environment variable VERSION, and any parameters you want to
 # pass to the command in PARAMS.
 #
+# Sometimes you will hit Github API rate limits when running this command. If you have a Github token,
+# pass it in environment variable GITHUB_TOKEN.
+#
 # This script can be used in either Linux or MacOS; it will download whichever binary is
 # appropriate for the current OS and architecture. It cannot be used in Windows. It requires
 # /bin/sh and the commands, "grep", "sed", "curl", and "tar".
@@ -14,6 +17,13 @@ set -e
 RELEASES_API_URL=https://api.github.com/repos/launchdarkly/sdk-test-harness/releases
 RELEASES_SITE_URL=https://github.com/launchdarkly/sdk-test-harness/releases
 EXECUTABLE_ARCHIVE_NAME=sdk-test-harness_$(uname -s)_$(uname -m).tar.gz
+
+# Github rate-limits requests to its APIs. The effect is that sometimes the contract test step in CI
+# will fail spuriously when trying to find the list of releases.
+# If we provide an auth token, then we can avoid the rate limiting issues.
+if [ -n "${GITHUB_TOKEN}" ]; then
+  AUTH_HEADER="Authorization: Token ${GITHUB_TOKEN}"
+fi
 
 if [ -z "${VERSION}" -o -z "${PARAMS}" ]; then
   echo 'You must specify a version string in $VERSION and command parameters in $PARAMS' >&2
@@ -26,7 +36,12 @@ resolve_version() {
     echo "$1"
     exit
   fi
-  curl -s "${RELEASES_API_URL}" \
+  cmd="curl"
+  if [ -n "${AUTH_HEADER}" ]; then
+    cmd="${cmd} -H '${AUTH_HEADER}'"
+  fi
+  cmd="${cmd} -s ${RELEASES_API_URL}"
+  eval "$cmd" \
     | grep "tag_name" \
     | sed -e 's/.*:[^"]*"\([^"]*\).*/\1/' \
     | grep "^$1\." \

--- a/sdktests/client_side_secure_mode_hash.go
+++ b/sdktests/client_side_secure_mode_hash.go
@@ -1,0 +1,108 @@
+package sdktests
+
+import (
+	"time"
+
+	m "github.com/launchdarkly/go-test-helpers/v2/matchers"
+	"github.com/launchdarkly/sdk-test-harness/framework/ldtest"
+	o "github.com/launchdarkly/sdk-test-harness/framework/opt"
+	"github.com/launchdarkly/sdk-test-harness/mockld"
+	"github.com/launchdarkly/sdk-test-harness/servicedef"
+)
+
+func doClientSideSecureModeHashTests(t *ldtest.T) {
+	t.RequireCapability(servicedef.CapabilitySecureModeHash)
+
+	const testHash = "test-secure-mode-hash"
+
+	t.Run("streaming", func(t *ldtest.T) {
+		t.Run("sends h query parameter when hash is configured", func(t *ldtest.T) {
+			c := NewCommonStreamingTests(t, "doClientSideSecureModeHashTests")
+			dataSource, configurers := c.setupDataSources(t, nil)
+
+			_ = NewSDKClient(t, append(
+				configurers,
+				WithClientSideConfig(servicedef.SDKConfigClientSideParams{
+					InitialUser: c.userFactory.NextUniqueUser(),
+					Hash:        o.Some(testHash),
+				}),
+			)...)
+
+			request := dataSource.Endpoint().RequireConnection(t, time.Second)
+			m.In(t).For("h query parameter").Assert(request.URL.RawQuery,
+				UniqueQueryParameters().Should(m.MapIncluding(m.KV("h", m.Equal(testHash)))))
+
+			// JS client SDKs connect to the polling service first in streaming mode. Assert h is
+			// present on that bootstrap request too; configurers[0] is the polling data source.
+			if c.sdkKind == mockld.JSClientSDK {
+				bootstrapDS := configurers[0].(*SDKDataSource)
+				bootstrapRequest := bootstrapDS.Endpoint().RequireConnection(t, time.Second)
+				m.In(t).For("h query parameter on bootstrap poll").Assert(bootstrapRequest.URL.RawQuery,
+					UniqueQueryParameters().Should(m.MapIncluding(m.KV("h", m.Equal(testHash)))))
+			}
+		})
+
+		t.Run("omits h query parameter when hash is not configured", func(t *ldtest.T) {
+			c := NewCommonStreamingTests(t, "doClientSideSecureModeHashTests")
+			dataSource, configurers := c.setupDataSources(t, nil)
+
+			_ = NewSDKClient(t, append(
+				configurers,
+				WithClientSideConfig(servicedef.SDKConfigClientSideParams{
+					InitialUser: c.userFactory.NextUniqueUser(),
+				}),
+			)...)
+
+			request := dataSource.Endpoint().RequireConnection(t, time.Second)
+			// m.AllOf() is used as "match any value" since this matchers library has no Anything() function.
+			m.In(t).For("h query parameter").Assert(request.URL.RawQuery,
+				UniqueQueryParameters().Should(m.Not(m.MapIncluding(m.KV("h", m.AllOf())))))
+
+			// JS client SDKs connect to the polling service first in streaming mode. Assert h is
+			// absent on that bootstrap request too.
+			if c.sdkKind == mockld.JSClientSDK {
+				bootstrapDS := configurers[0].(*SDKDataSource)
+				bootstrapRequest := bootstrapDS.Endpoint().RequireConnection(t, time.Second)
+				m.In(t).For("h query parameter on bootstrap poll").Assert(bootstrapRequest.URL.RawQuery,
+					UniqueQueryParameters().Should(m.Not(m.MapIncluding(m.KV("h", m.AllOf())))))
+			}
+		})
+	})
+
+	t.Run("polling", func(t *ldtest.T) {
+		t.Run("sends h query parameter when hash is configured", func(t *ldtest.T) {
+			dataSource := NewSDKDataSource(t, nil, DataSourceOptionPolling())
+			userFactory := NewUserFactory("doClientSideSecureModeHashTests")
+
+			_ = NewSDKClient(t,
+				WithClientSideConfig(servicedef.SDKConfigClientSideParams{
+					InitialUser: userFactory.NextUniqueUser(),
+					Hash:        o.Some(testHash),
+				}),
+				dataSource,
+			)
+
+			request := dataSource.Endpoint().RequireConnection(t, time.Second)
+			m.In(t).For("h query parameter").Assert(request.URL.RawQuery,
+				UniqueQueryParameters().Should(m.MapIncluding(m.KV("h", m.Equal(testHash)))))
+		})
+
+		t.Run("omits h query parameter when hash is not configured", func(t *ldtest.T) {
+			dataSource := NewSDKDataSource(t, nil, DataSourceOptionPolling())
+			userFactory := NewUserFactory("doClientSideSecureModeHashTests")
+
+			_ = NewSDKClient(t,
+				WithClientSideConfig(servicedef.SDKConfigClientSideParams{
+					InitialUser: userFactory.NextUniqueUser(),
+				}),
+				dataSource,
+			)
+
+			request := dataSource.Endpoint().RequireConnection(t, time.Second)
+			// m.AllOf() with no args is vacuously true; used as "match any value" since this
+			// matchers library has no Anything() function.
+			m.In(t).For("h query parameter").Assert(request.URL.RawQuery,
+				UniqueQueryParameters().Should(m.Not(m.MapIncluding(m.KV("h", m.AllOf())))))
+		})
+	})
+}

--- a/sdktests/testsuite_entry_point.go
+++ b/sdktests/testsuite_entry_point.go
@@ -96,6 +96,7 @@ func doAllClientSideTests(t *ldtest.T) {
 	t.Run("streaming", doClientSideStreamTests)
 	t.Run("polling", doClientSidePollTests)
 	t.Run("tags", doClientSideTagsTests)
+	t.Run("secure mode hash", doClientSideSecureModeHashTests)
 }
 
 func doAllPHPTests(t *ldtest.T) {

--- a/servicedef/sdk_config.go
+++ b/servicedef/sdk_config.go
@@ -67,8 +67,9 @@ type SDKConfigTagsParams struct {
 }
 
 type SDKConfigClientSideParams struct {
-	InitialUser        lduser.User   `json:"initialUser"`
-	AutoAliasingOptOut o.Maybe[bool] `json:"autoAliasingOptOut,omitempty"`
-	EvaluationReasons  o.Maybe[bool] `json:"evaluationReasons,omitempty"`
-	UseReport          o.Maybe[bool] `json:"useReport,omitempty"`
+	InitialUser        lduser.User     `json:"initialUser"`
+	AutoAliasingOptOut o.Maybe[bool]   `json:"autoAliasingOptOut,omitempty"`
+	EvaluationReasons  o.Maybe[bool]   `json:"evaluationReasons,omitempty"`
+	UseReport          o.Maybe[bool]   `json:"useReport,omitempty"`
+	Hash               o.Maybe[string] `json:"hash,omitempty"`
 }


### PR DESCRIPTION
## Summary

- Adds `Hash o.Maybe[string]` to `SDKConfigClientSideParams` so the test protocol can pass a secure mode hash to client-side SDK test services
- Adds `doClientSideSecureModeHashTests` with streaming and polling subtests verifying the SDK includes `h=<hash>` in request URLs when configured, and omits it when not configured
- Tests gate on the existing `"secure-mode-hash"` capability — no new capability introduced
- For JS client SDKs in streaming mode, also asserts the bootstrap polling request carries the `h` parameter (JS SDK polls first before connecting to the stream)
- Documents the new `hash` field in `docs/service_spec.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)