### PR TITLE
Add contract tests for client-side secure mode hash (h query param)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ dist/
 .idea/
 
 sdk-test-harness
+.claude/sdk-one-shot/

--- a/docs/service_spec.md
+++ b/docs/service_spec.md
@@ -310,6 +310,7 @@ A `POST` request indicates that the test harness wants to start an instance of t
     * `initialContext` (object, optional): The context properties to initialize the SDK with (unless `initialUser` is specified instead). The test service for a client-side SDK can assume that the test harness will _always_ set this: if the test logic does not explicitly provide a value, the test harness will add a default one.
     * `initialUser` (object, optional): Can be specified instead of `initialContext` to use an old-style user JSON representation.
     * `evaluationReasons`, `useReport` (boolean, optional): These correspond to the SDK configuration properties of the same names.
+    * `hash` (string, optional): If present, a secure mode hash value that the SDK should use when connecting to the streaming and polling services. When set, the SDK must include this value as the `h` query parameter on streaming and polling requests. This field is only used by test services that declare the `"secure-mode-hash"` capability.
   * `hooks` (object, optional): If specified this has the configuration for hooks.
     * `hooks` (array, required): Contains configuration of one or more hooks, each item is an object with the following parameters.
       * `name` (string, required): A name to associate with the hook.

--- a/downloader/run.sh
+++ b/downloader/run.sh
@@ -48,6 +48,13 @@ if [ -n "${GITHUB_TOKEN}" ]; then
   AUTH_HEADER="Authorization: Token ${GITHUB_TOKEN}"
 fi
 
+# Github rate-limits requests to its APIs. The effect is that sometimes the contract test step in CI
+# will fail spuriously when trying to find the list of releases.
+# If we provide an auth token, then we can avoid the rate limiting issues.
+if [ -n "${GITHUB_TOKEN}" ]; then
+  AUTH_HEADER="Authorization: Token ${GITHUB_TOKEN}"
+fi
+
 if [ -z "${VERSION}" -o -z "${PARAMS}" ]; then
   echo 'You must specify a version string in $VERSION and command parameters in $PARAMS' >&2
   exit 1

--- a/sdktests/client_side_secure_mode_hash.go
+++ b/sdktests/client_side_secure_mode_hash.go
@@ -1,0 +1,109 @@
+package sdktests
+
+import (
+	"time"
+
+	m "github.com/launchdarkly/go-test-helpers/v2/matchers"
+	"github.com/launchdarkly/sdk-test-harness/v2/data"
+	"github.com/launchdarkly/sdk-test-harness/v2/framework/ldtest"
+	o "github.com/launchdarkly/sdk-test-harness/v2/framework/opt"
+	"github.com/launchdarkly/sdk-test-harness/v2/mockld"
+	"github.com/launchdarkly/sdk-test-harness/v2/servicedef"
+)
+
+func doClientSideSecureModeHashTests(t *ldtest.T) {
+	t.RequireCapability(servicedef.CapabilitySecureModeHash)
+
+	const testHash = "test-secure-mode-hash"
+
+	t.Run("streaming", func(t *ldtest.T) {
+		t.Run("sends h query parameter when hash is configured", func(t *ldtest.T) {
+			c := NewCommonStreamingTests(t, "doClientSideSecureModeHashTests")
+			dataSource, configurers := c.setupDataSources(t, nil)
+
+			_ = NewSDKClient(t, append(
+				configurers,
+				WithClientSideConfig(servicedef.SDKConfigClientSideParams{
+					InitialContext: o.Some(c.contextFactory.NextUniqueContext()),
+					Hash:           o.Some(testHash),
+				}),
+			)...)
+
+			request := dataSource.Endpoint().RequireConnection(t, time.Second)
+			m.In(t).For("h query parameter").Assert(request.URL.RawQuery,
+				UniqueQueryParameters().Should(m.MapIncluding(m.KV("h", m.Equal(testHash)))))
+
+			// JS client SDKs connect to the polling service first in streaming mode. Assert h is
+			// present on that bootstrap request too; configurers[0] is the polling data source.
+			if c.sdkKind == mockld.JSClientSDK {
+				bootstrapDS := configurers[0].(*SDKDataSource)
+				bootstrapRequest := bootstrapDS.Endpoint().RequireConnection(t, time.Second)
+				m.In(t).For("h query parameter on bootstrap poll").Assert(bootstrapRequest.URL.RawQuery,
+					UniqueQueryParameters().Should(m.MapIncluding(m.KV("h", m.Equal(testHash)))))
+			}
+		})
+
+		t.Run("omits h query parameter when hash is not configured", func(t *ldtest.T) {
+			c := NewCommonStreamingTests(t, "doClientSideSecureModeHashTests")
+			dataSource, configurers := c.setupDataSources(t, nil)
+
+			_ = NewSDKClient(t, append(
+				configurers,
+				WithClientSideConfig(servicedef.SDKConfigClientSideParams{
+					InitialContext: o.Some(c.contextFactory.NextUniqueContext()),
+				}),
+			)...)
+
+			request := dataSource.Endpoint().RequireConnection(t, time.Second)
+			// m.AllOf() is used as "match any value" since this matchers library has no Anything() function.
+			m.In(t).For("h query parameter").Assert(request.URL.RawQuery,
+				UniqueQueryParameters().Should(m.Not(m.MapIncluding(m.KV("h", m.AllOf())))))
+
+			// JS client SDKs connect to the polling service first in streaming mode. Assert h is
+			// absent on that bootstrap request too.
+			if c.sdkKind == mockld.JSClientSDK {
+				bootstrapDS := configurers[0].(*SDKDataSource)
+				bootstrapRequest := bootstrapDS.Endpoint().RequireConnection(t, time.Second)
+				m.In(t).For("h query parameter on bootstrap poll").Assert(bootstrapRequest.URL.RawQuery,
+					UniqueQueryParameters().Should(m.Not(m.MapIncluding(m.KV("h", m.AllOf())))))
+			}
+		})
+	})
+
+	t.Run("polling", func(t *ldtest.T) {
+		t.Run("sends h query parameter when hash is configured", func(t *ldtest.T) {
+			dataSource := NewSDKDataSource(t, nil, DataSourceOptionPolling())
+			contextFactory := data.NewContextFactory("doClientSideSecureModeHashTests")
+
+			_ = NewSDKClient(t,
+				WithClientSideConfig(servicedef.SDKConfigClientSideParams{
+					InitialContext: o.Some(contextFactory.NextUniqueContext()),
+					Hash:           o.Some(testHash),
+				}),
+				dataSource,
+			)
+
+			request := dataSource.Endpoint().RequireConnection(t, time.Second)
+			m.In(t).For("h query parameter").Assert(request.URL.RawQuery,
+				UniqueQueryParameters().Should(m.MapIncluding(m.KV("h", m.Equal(testHash)))))
+		})
+
+		t.Run("omits h query parameter when hash is not configured", func(t *ldtest.T) {
+			dataSource := NewSDKDataSource(t, nil, DataSourceOptionPolling())
+			contextFactory := data.NewContextFactory("doClientSideSecureModeHashTests")
+
+			_ = NewSDKClient(t,
+				WithClientSideConfig(servicedef.SDKConfigClientSideParams{
+					InitialContext: o.Some(contextFactory.NextUniqueContext()),
+				}),
+				dataSource,
+			)
+
+			request := dataSource.Endpoint().RequireConnection(t, time.Second)
+			// m.AllOf() with no args is vacuously true; used as "match any value" since this
+			// matchers library has no Anything() function.
+			m.In(t).For("h query parameter").Assert(request.URL.RawQuery,
+				UniqueQueryParameters().Should(m.Not(m.MapIncluding(m.KV("h", m.AllOf())))))
+		})
+	})
+}

--- a/sdktests/testsuite_entry_point.go
+++ b/sdktests/testsuite_entry_point.go
@@ -112,6 +112,7 @@ func doAllClientSideTests(t *ldtest.T) {
 	t.Run("client independence", doClientSideClientIndependenceTests)
 	t.Run("hooks", doCommonHooksTests)
 	t.Run("wrapper", doClientSideWrapperTests)
+	t.Run("secure mode hash", doClientSideSecureModeHashTests)
 }
 
 func doAllPHPTests(t *ldtest.T) {

--- a/servicedef/sdk_config.go
+++ b/servicedef/sdk_config.go
@@ -86,6 +86,7 @@ type SDKConfigClientSideParams struct {
 	EvaluationReasons            o.Maybe[bool]              `json:"evaluationReasons,omitempty"`
 	UseReport                    o.Maybe[bool]              `json:"useReport,omitempty"`
 	IncludeEnvironmentAttributes o.Maybe[bool]              `json:"includeEnvironmentAttributes,omitempty"`
+	Hash                         o.Maybe[string]            `json:"hash,omitempty"`
 }
 
 type SDKConfigEvaluationHookData map[string]ldvalue.Value


### PR DESCRIPTION
## Summary

- Adds `Hash o.Maybe[string]` to `SDKConfigClientSideParams` so the test protocol can pass a secure mode hash to client-side SDK test services
- Adds `doClientSideSecureModeHashTests` with streaming and polling subtests verifying the SDK includes `h=<hash>` in request URLs when configured, and omits it when not configured
- Tests gate on the existing `"secure-mode-hash"` capability — no new capability introduced
- For JS client SDKs in streaming mode, also asserts the bootstrap polling request carries the `h` parameter (JS SDK polls first before connecting to the stream)
- Documents the new `hash` field in `docs/service_spec.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)