### PR TITLE
feat: Add contract tests for client-side secure mode hash (h query param)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ dist/
 .idea/
 
 sdk-test-harness
+.claude/sdk-one-shot/

--- a/.gitignore
+++ b/.gitignore
@@ -4,4 +4,3 @@ dist/
 .idea/
 
 sdk-test-harness
-.claude/sdk-one-shot/

--- a/docs/service_spec.md
+++ b/docs/service_spec.md
@@ -329,6 +329,7 @@ A `POST` request indicates that the test harness wants to start an instance of t
     * `initialContext` (object, optional): The context properties to initialize the SDK with (unless `initialUser` is specified instead). The test service for a client-side SDK can assume that the test harness will _always_ set this: if the test logic does not explicitly provide a value, the test harness will add a default one.
     * `initialUser` (object, optional): Can be specified instead of `initialContext` to use an old-style user JSON representation.
     * `evaluationReasons`, `useReport` (boolean, optional): These correspond to the SDK configuration properties of the same names.
+    * `hash` (string, optional): If present, a secure mode hash value that the SDK should use when connecting to the streaming and polling services. When set, the SDK must include this value as the `h` query parameter on streaming and polling requests. This field is only used by test services that declare the `"secure-mode-hash"` capability.
   * `hooks` (object, optional): If specified this has the configuration for hooks.
     * `hooks` (array, required): Contains configuration of one or more hooks, each item is an object with the following parameters.
       * `name` (string, required): A name to associate with the hook.

--- a/sdktests/client_side_secure_mode_hash.go
+++ b/sdktests/client_side_secure_mode_hash.go
@@ -4,7 +4,6 @@ import (
 	"time"
 
 	m "github.com/launchdarkly/go-test-helpers/v2/matchers"
-	"github.com/launchdarkly/sdk-test-harness/v2/data"
 	"github.com/launchdarkly/sdk-test-harness/v2/framework/ldtest"
 	o "github.com/launchdarkly/sdk-test-harness/v2/framework/opt"
 	"github.com/launchdarkly/sdk-test-harness/v2/servicedef"
@@ -18,7 +17,7 @@ func doClientSideSecureModeHashTests(t *ldtest.T) {
 	t.Run("streaming", func(t *ldtest.T) {
 		t.Run("sends h query parameter when hash is configured", func(t *ldtest.T) {
 			c := NewCommonStreamingTests(t, "doClientSideSecureModeHashTests")
-			dataSource, configurers := c.setupDataSources(t, nil)
+			dataSystem, configurers := c.setupDataSystems(t, nil)
 
 			_ = NewSDKClient(t, append(
 				configurers,
@@ -28,14 +27,14 @@ func doClientSideSecureModeHashTests(t *ldtest.T) {
 				}),
 			)...)
 
-			request := dataSource.Endpoint().RequireConnection(t, time.Second)
+			request := dataSystem.Synchronizers[0].Endpoint().RequireConnection(t, time.Second)
 			m.In(t).For("h query parameter").Assert(request.URL.RawQuery,
 				UniqueQueryParameters().Should(m.MapIncluding(m.KV("h", m.Equal(testHash)))))
 		})
 
 		t.Run("omits h query parameter when hash is not configured", func(t *ldtest.T) {
 			c := NewCommonStreamingTests(t, "doClientSideSecureModeHashTests")
-			dataSource, configurers := c.setupDataSources(t, nil)
+			dataSystem, configurers := c.setupDataSystems(t, nil)
 
 			_ = NewSDKClient(t, append(
 				configurers,
@@ -44,47 +43,44 @@ func doClientSideSecureModeHashTests(t *ldtest.T) {
 				}),
 			)...)
 
-			request := dataSource.Endpoint().RequireConnection(t, time.Second)
-			// m.AllOf() is used as "match any value" since this matchers library has no Anything() function.
+			request := dataSystem.Synchronizers[0].Endpoint().RequireConnection(t, time.Second)
 			m.In(t).For("h query parameter").Assert(request.URL.RawQuery,
-				UniqueQueryParameters().Should(m.Not(m.MapIncluding(m.KV("h", m.AllOf())))))
+				UniqueQueryParameters().Should(m.Not(MapHasKey("h"))))
 		})
 	})
 
 	t.Run("polling", func(t *ldtest.T) {
 		t.Run("sends h query parameter when hash is configured", func(t *ldtest.T) {
-			dataSource := NewSDKDataSource(t, nil, DataSourceOptionPolling())
-			contextFactory := data.NewContextFactory("doClientSideSecureModeHashTests")
+			p := NewCommonPollingTests(t, "doClientSideSecureModeHashTests")
+			dataSystem := NewSDKDataSystem(t, nil, p.pollingDataSystemOptions()...)
 
 			_ = NewSDKClient(t,
 				WithClientSideConfig(servicedef.SDKConfigClientSideParams{
-					InitialContext: o.Some(contextFactory.NextUniqueContext()),
+					InitialContext: o.Some(p.contextFactory.NextUniqueContext()),
 					Hash:           o.Some(testHash),
 				}),
-				dataSource,
+				dataSystem,
 			)
 
-			request := dataSource.Endpoint().RequireConnection(t, time.Second)
+			request := dataSystem.Synchronizers[0].Endpoint().RequireConnection(t, time.Second)
 			m.In(t).For("h query parameter").Assert(request.URL.RawQuery,
 				UniqueQueryParameters().Should(m.MapIncluding(m.KV("h", m.Equal(testHash)))))
 		})
 
 		t.Run("omits h query parameter when hash is not configured", func(t *ldtest.T) {
-			dataSource := NewSDKDataSource(t, nil, DataSourceOptionPolling())
-			contextFactory := data.NewContextFactory("doClientSideSecureModeHashTests")
+			p := NewCommonPollingTests(t, "doClientSideSecureModeHashTests")
+			dataSystem := NewSDKDataSystem(t, nil, p.pollingDataSystemOptions()...)
 
 			_ = NewSDKClient(t,
 				WithClientSideConfig(servicedef.SDKConfigClientSideParams{
-					InitialContext: o.Some(contextFactory.NextUniqueContext()),
+					InitialContext: o.Some(p.contextFactory.NextUniqueContext()),
 				}),
-				dataSource,
+				dataSystem,
 			)
 
-			request := dataSource.Endpoint().RequireConnection(t, time.Second)
-			// m.AllOf() with no args is vacuously true; used as "match any value" since this
-			// matchers library has no Anything() function.
+			request := dataSystem.Synchronizers[0].Endpoint().RequireConnection(t, time.Second)
 			m.In(t).For("h query parameter").Assert(request.URL.RawQuery,
-				UniqueQueryParameters().Should(m.Not(m.MapIncluding(m.KV("h", m.AllOf())))))
+				UniqueQueryParameters().Should(m.Not(MapHasKey("h"))))
 		})
 	})
 }

--- a/sdktests/client_side_secure_mode_hash.go
+++ b/sdktests/client_side_secure_mode_hash.go
@@ -1,0 +1,90 @@
+package sdktests
+
+import (
+	"time"
+
+	m "github.com/launchdarkly/go-test-helpers/v2/matchers"
+	"github.com/launchdarkly/sdk-test-harness/v2/data"
+	"github.com/launchdarkly/sdk-test-harness/v2/framework/ldtest"
+	o "github.com/launchdarkly/sdk-test-harness/v2/framework/opt"
+	"github.com/launchdarkly/sdk-test-harness/v2/servicedef"
+)
+
+func doClientSideSecureModeHashTests(t *ldtest.T) {
+	t.RequireCapability(servicedef.CapabilitySecureModeHash)
+
+	const testHash = "test-secure-mode-hash"
+
+	t.Run("streaming", func(t *ldtest.T) {
+		t.Run("sends h query parameter when hash is configured", func(t *ldtest.T) {
+			c := NewCommonStreamingTests(t, "doClientSideSecureModeHashTests")
+			dataSource, configurers := c.setupDataSources(t, nil)
+
+			_ = NewSDKClient(t, append(
+				configurers,
+				WithClientSideConfig(servicedef.SDKConfigClientSideParams{
+					InitialContext: o.Some(c.contextFactory.NextUniqueContext()),
+					Hash:           o.Some(testHash),
+				}),
+			)...)
+
+			request := dataSource.Endpoint().RequireConnection(t, time.Second)
+			m.In(t).For("h query parameter").Assert(request.URL.RawQuery,
+				UniqueQueryParameters().Should(m.MapIncluding(m.KV("h", m.Equal(testHash)))))
+		})
+
+		t.Run("omits h query parameter when hash is not configured", func(t *ldtest.T) {
+			c := NewCommonStreamingTests(t, "doClientSideSecureModeHashTests")
+			dataSource, configurers := c.setupDataSources(t, nil)
+
+			_ = NewSDKClient(t, append(
+				configurers,
+				WithClientSideConfig(servicedef.SDKConfigClientSideParams{
+					InitialContext: o.Some(c.contextFactory.NextUniqueContext()),
+				}),
+			)...)
+
+			request := dataSource.Endpoint().RequireConnection(t, time.Second)
+			// m.AllOf() is used as "match any value" since this matchers library has no Anything() function.
+			m.In(t).For("h query parameter").Assert(request.URL.RawQuery,
+				UniqueQueryParameters().Should(m.Not(m.MapIncluding(m.KV("h", m.AllOf())))))
+		})
+	})
+
+	t.Run("polling", func(t *ldtest.T) {
+		t.Run("sends h query parameter when hash is configured", func(t *ldtest.T) {
+			dataSource := NewSDKDataSource(t, nil, DataSourceOptionPolling())
+			contextFactory := data.NewContextFactory("doClientSideSecureModeHashTests")
+
+			_ = NewSDKClient(t,
+				WithClientSideConfig(servicedef.SDKConfigClientSideParams{
+					InitialContext: o.Some(contextFactory.NextUniqueContext()),
+					Hash:           o.Some(testHash),
+				}),
+				dataSource,
+			)
+
+			request := dataSource.Endpoint().RequireConnection(t, time.Second)
+			m.In(t).For("h query parameter").Assert(request.URL.RawQuery,
+				UniqueQueryParameters().Should(m.MapIncluding(m.KV("h", m.Equal(testHash)))))
+		})
+
+		t.Run("omits h query parameter when hash is not configured", func(t *ldtest.T) {
+			dataSource := NewSDKDataSource(t, nil, DataSourceOptionPolling())
+			contextFactory := data.NewContextFactory("doClientSideSecureModeHashTests")
+
+			_ = NewSDKClient(t,
+				WithClientSideConfig(servicedef.SDKConfigClientSideParams{
+					InitialContext: o.Some(contextFactory.NextUniqueContext()),
+				}),
+				dataSource,
+			)
+
+			request := dataSource.Endpoint().RequireConnection(t, time.Second)
+			// m.AllOf() with no args is vacuously true; used as "match any value" since this
+			// matchers library has no Anything() function.
+			m.In(t).For("h query parameter").Assert(request.URL.RawQuery,
+				UniqueQueryParameters().Should(m.Not(m.MapIncluding(m.KV("h", m.AllOf())))))
+		})
+	})
+}

--- a/sdktests/custom_matchers_general.go
+++ b/sdktests/custom_matchers_general.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"net/http"
 	"net/url"
+	"reflect"
 	"sort"
 	"strings"
 
@@ -200,6 +201,21 @@ func SortedStrings() m.MatcherTransform {
 			sort.Strings(ret)
 			return ret, nil
 		})
+}
+
+// MapHasKey matches a map that contains the given key, regardless of its value.
+func MapHasKey(key string) m.Matcher {
+	return m.New(
+		func(value interface{}) bool {
+			rv := reflect.ValueOf(value)
+			if rv.Kind() != reflect.Map {
+				return false
+			}
+			return rv.MapIndex(reflect.ValueOf(key)).IsValid()
+		},
+		func() string { return fmt.Sprintf("map has key %q", key) },
+		func(value interface{}) string { return fmt.Sprintf("key %q not found in map", key) },
+	)
 }
 
 func ValueIsPositiveNonZeroInteger() m.Matcher {

--- a/sdktests/testsuite_entry_point.go
+++ b/sdktests/testsuite_entry_point.go
@@ -115,6 +115,7 @@ func doAllClientSideTests(t *ldtest.T) {
 	t.Run("client independence", doClientSideClientIndependenceTests)
 	t.Run("hooks", doCommonHooksTests)
 	t.Run("wrapper", doClientSideWrapperTests)
+	t.Run("secure mode hash", doClientSideSecureModeHashTests)
 }
 
 func doAllPHPTests(t *ldtest.T) {

--- a/servicedef/sdk_config.go
+++ b/servicedef/sdk_config.go
@@ -138,6 +138,7 @@ type SDKConfigClientSideParams struct {
 	EvaluationReasons            o.Maybe[bool]              `json:"evaluationReasons,omitempty"`
 	UseReport                    o.Maybe[bool]              `json:"useReport,omitempty"`
 	IncludeEnvironmentAttributes o.Maybe[bool]              `json:"includeEnvironmentAttributes,omitempty"`
+	Hash                         o.Maybe[string]            `json:"hash,omitempty"`
 }
 
 type SDKConfigEvaluationHookData map[string]ldvalue.Value


### PR DESCRIPTION
## Summary

- Cherry-picks the client-side secure mode hash contract tests from the v2 branch
- Adds `Hash` field to `SDKConfigClientSideParams` so test services can receive the secure mode hash at client initialization
- Registers `doClientSideSecureModeHashTests` in the client-side test suite
- Adds `MapHasKey` helper to `custom_matchers_general.go` for cleaner key-existence assertions
- Polling tests adapted to v3 data system API (`NewCommonPollingTests` / `SDKDataSystem` / `Synchronizers[0].Endpoint()`)
- Streaming tests adapted to use `setupDataSystems` instead of `setupDataSources`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test harness and documentation changes only; no production SDK runtime behavior in this repo.
> 
> **Overview**
> Adds **client-side contract coverage** for secure mode: when `clientSide.hash` is set, client SDKs must send it as the **`h` query parameter** on streaming and polling connections, and omit `h` when hash is unset.
> 
> The harness now exposes **`hash`** on `SDKConfigClientSideParams`, documents it in **`service_spec.md`**, wires **`doClientSideSecureModeHashTests`** into the client-side suite (gated on **`secure-mode-hash`**), and introduces a **`MapHasKey`** matcher for asserting absence of `h` in parsed query strings.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4018c8088a41fbe4838dbf2cbb87788dc308f667. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->