### PR TITLE
feat: add tests for handling redacting attributes prefixed with `/` correctly

### DIFF
--- a/sdktests/client_side_events_eval.go
+++ b/sdktests/client_side_events_eval.go
@@ -137,6 +137,7 @@ func doClientSideFeatureEventTests(t *ldtest.T) {
 				b.Name("Example name")
 				b.SetString("setup", "Why do programmers always confused Halloween and Christmas?")
 				b.SetString("punchline", "Because OCT 31 = DEC 25")
+				b.SetString("/ssn", "123-45-6789")
 			})
 
 			for _, valueType := range getValueTypesToTest(t) {
@@ -167,9 +168,13 @@ func doClientSideFeatureEventTests(t *ldtest.T) {
 						SetValue("name", ldvalue.Null()).
 						SetValue("setup", ldvalue.Null()).
 						SetValue("punchline", ldvalue.Null()).
+						SetValue("/ssn", ldvalue.Null()).
 						Build()
 
-					matcher := JSONMatchesEventContext(expectedContext, map[string][]string{"user": {"name", "setup", "punchline"}})
+					matcher := JSONMatchesEventContext(
+						expectedContext,
+						map[string][]string{"user": {"name", "setup", "punchline", "/~1ssn"}},
+					)
 
 					payload := events.ExpectAnalyticsEvents(t, defaultEventTimeout)
 					m.In(t).Assert(payload, m.ItemsInAnyOrder(
@@ -187,6 +192,7 @@ func doClientSideFeatureEventTests(t *ldtest.T) {
 				b.Name("User name")
 				b.SetString("setup", "Why do programmers always confused Halloween and Christmas?")
 				b.SetString("punchline", "Because OCT 31 = DEC 25")
+				b.SetString("/ssn", "123-45-6789")
 			})
 			orgContextFactory := data.NewContextFactory("org", func(b *ldcontext.Builder) {
 				b.Name("Org name")
@@ -226,11 +232,15 @@ func doClientSideFeatureEventTests(t *ldtest.T) {
 						SetValue("name", ldvalue.Null()).
 						SetValue("setup", ldvalue.Null()).
 						SetValue("punchline", ldvalue.Null()).
+						SetValue("/ssn", ldvalue.Null()).
 						Build()
 
 					expectedMultiKind := ldcontext.NewMultiBuilder().Add(expectedUser).Add(orgContext).Build()
 
-					matcher := JSONMatchesEventContext(expectedMultiKind, map[string][]string{"user": {"name", "setup", "punchline"}})
+					matcher := JSONMatchesEventContext(
+						expectedMultiKind,
+						map[string][]string{"user": {"name", "setup", "punchline", "/~1ssn"}},
+					)
 
 					payload := events.ExpectAnalyticsEvents(t, defaultEventTimeout)
 					m.In(t).Assert(payload, m.ItemsInAnyOrder(

--- a/sdktests/common_tests_events_contexts.go
+++ b/sdktests/common_tests_events_contexts.go
@@ -74,6 +74,23 @@ func makeEventContextTestParams() []eventContextTestParams {
 			redactedShouldBe: redactedAttrsByKind{"user": {"name", "b"}},
 		},
 		{
+			name: "single-kind, allAttributesPrivate, slash-prefixed attribute name",
+			// proves that a custom attribute whose literal name starts with "/" is redacted
+			// using the escaped attribute-reference form ("/ssn" -> "/~1ssn")
+			eventsConfig: servicedef.SDKConfigEventParams{AllAttributesPrivate: true},
+			contextFactory: func(prefix string) *data.ContextFactory {
+				return data.NewContextFactory(prefix, func(b *ldcontext.Builder) {
+					b.SetString("/ssn", "123-45-6789")
+				})
+			},
+			outputContext: func(c ldcontext.Context) ldcontext.Context {
+				return ldcontext.NewBuilderFromContext(c).
+					SetValue("/ssn", ldvalue.Null()).
+					Build()
+			},
+			redactedShouldBe: redactedAttrsByKind{"user": {"/~1ssn"}},
+		},
+		{
 			name: "single-kind, specific private attributes",
 			// here, "name" is declared private globally, and "b" is private per-context
 			eventsConfig: servicedef.SDKConfigEventParams{

--- a/sdktests/custom_matchers_contexts_test.go
+++ b/sdktests/custom_matchers_contexts_test.go
@@ -153,6 +153,11 @@ func TestJSONMatchesEventContext(t *testing.T) {
 				input:            `{"kind": "user", "key": "a", "_meta": {"redactedAttributes": ["b", "c"]}}`,
 				redactedShouldBe: map[string][]string{"user": {"c", "b"}},
 			},
+			{
+				c:                ldcontext.New("a"),
+				input:            `{"kind": "user", "key": "a", "_meta": {"redactedAttributes": ["/~1ssn"]}}`,
+				redactedShouldBe: map[string][]string{"user": {"/~1ssn"}},
+			},
 		} {
 			t.Run(p.input, func(t *testing.T) {
 				m.In(t).Assert(json.RawMessage(p.input), JSONMatchesEventContext(p.c, p.redactedShouldBe))
@@ -176,6 +181,11 @@ func TestJSONMatchesEventContext(t *testing.T) {
 				c:                ldcontext.NewBuilder("a").Private("b").Build(),
 				input:            `{"kind": "user", "key": "a", "_meta": {"privateAttributes": ["b"]}}`,
 				redactedShouldBe: map[string][]string{"user": {"b"}},
+			},
+			{
+				c:                ldcontext.New("a"),
+				input:            `{"kind": "user", "key": "a", "_meta": {"redactedAttributes": ["/ssn"]}}`,
+				redactedShouldBe: map[string][]string{"user": {"/~1ssn"}},
 			},
 		} {
 			t.Run(p.input, func(t *testing.T) {

--- a/sdktests/php_events_eval.go
+++ b/sdktests/php_events_eval.go
@@ -157,6 +157,7 @@ func doPHPFeatureEventTests(t *ldtest.T) {
 				b.Name("Example name")
 				b.SetString("setup", "Why do programmers always confused Halloween and Christmas?")
 				b.SetString("punchline", "Because OCT 31 = DEC 25")
+				b.SetString("/ssn", "123-45-6789")
 			})
 
 			for _, valueType := range getValueTypesToTest(t) {
@@ -187,9 +188,15 @@ func doPHPFeatureEventTests(t *ldtest.T) {
 						SetValue("name", ldvalue.Null()).
 						SetValue("setup", ldvalue.Null()).
 						SetValue("punchline", ldvalue.Null()).
+						SetValue("/ssn", ldvalue.Null()).
 						Build()
 
-					matcher := JSONMatchesEventContext(expectedContext, map[string][]string{"user": {"name", "setup", "punchline"}})
+					// "/ssn" is a literal attribute name starting with "/", so the redacted
+					// list must use its escaped attribute-reference form: "/~1ssn"
+					matcher := JSONMatchesEventContext(
+						expectedContext,
+						map[string][]string{"user": {"name", "setup", "punchline", "/~1ssn"}},
+					)
 
 					payload := events.ExpectAnalyticsEvents(t, defaultEventTimeout)
 					m.In(t).Assert(payload, m.Items(
@@ -206,6 +213,7 @@ func doPHPFeatureEventTests(t *ldtest.T) {
 				b.Name("User name")
 				b.SetString("setup", "Why do programmers always confused Halloween and Christmas?")
 				b.SetString("punchline", "Because OCT 31 = DEC 25")
+				b.SetString("/ssn", "123-45-6789")
 			})
 			orgContextFactory := data.NewContextFactory("org", func(b *ldcontext.Builder) {
 				b.Name("Org name")
@@ -246,11 +254,16 @@ func doPHPFeatureEventTests(t *ldtest.T) {
 						SetValue("name", ldvalue.Null()).
 						SetValue("setup", ldvalue.Null()).
 						SetValue("punchline", ldvalue.Null()).
+						SetValue("/ssn", ldvalue.Null()).
 						Build()
 
 					expectedMultiKind := ldcontext.NewMultiBuilder().Add(expectedUser).Add(orgContext).Build()
 
-					matcher := JSONMatchesEventContext(expectedMultiKind, map[string][]string{"user": {"name", "setup", "punchline"}})
+					// same escaping as above: "/ssn" -> "/~1ssn"
+					matcher := JSONMatchesEventContext(
+						expectedMultiKind,
+						map[string][]string{"user": {"name", "setup", "punchline", "/~1ssn"}},
+					)
 
 					payload := events.ExpectAnalyticsEvents(t, defaultEventTimeout)
 					m.In(t).Assert(payload, m.Items(

--- a/sdktests/server_side_events_eval.go
+++ b/sdktests/server_side_events_eval.go
@@ -169,6 +169,7 @@ func doServerSideFeatureEventTests(t *ldtest.T) {
 				b.Name("Example name")
 				b.SetString("setup", "Why do programmers always confused Halloween and Christmas?")
 				b.SetString("punchline", "Because OCT 31 = DEC 25")
+				b.SetString("/ssn", "123-45-6789")
 			})
 
 			for _, valueType := range getValueTypesToTest(t) {
@@ -195,9 +196,13 @@ func doServerSideFeatureEventTests(t *ldtest.T) {
 						SetValue("name", ldvalue.Null()).
 						SetValue("setup", ldvalue.Null()).
 						SetValue("punchline", ldvalue.Null()).
+						SetValue("/ssn", ldvalue.Null()).
 						Build()
 
-					matcher := JSONMatchesEventContext(expectedContext, map[string][]string{"user": {"name", "setup", "punchline"}})
+					matcher := JSONMatchesEventContext(
+						expectedContext,
+						map[string][]string{"user": {"name", "setup", "punchline", "/~1ssn"}},
+					)
 
 					payload := events.ExpectAnalyticsEvents(t, defaultEventTimeout)
 					m.In(t).Assert(payload, m.ItemsInAnyOrder(
@@ -216,6 +221,7 @@ func doServerSideFeatureEventTests(t *ldtest.T) {
 				b.Name("User name")
 				b.SetString("setup", "Why do programmers always confused Halloween and Christmas?")
 				b.SetString("punchline", "Because OCT 31 = DEC 25")
+				b.SetString("/ssn", "123-45-6789")
 			})
 			orgContextFactory := data.NewContextFactory("org", func(b *ldcontext.Builder) {
 				b.Name("Org name")
@@ -251,11 +257,15 @@ func doServerSideFeatureEventTests(t *ldtest.T) {
 						SetValue("name", ldvalue.Null()).
 						SetValue("setup", ldvalue.Null()).
 						SetValue("punchline", ldvalue.Null()).
+						SetValue("/ssn", ldvalue.Null()).
 						Build()
 
 					expectedMultiKind := ldcontext.NewMultiBuilder().Add(expectedUser).Add(orgContext).Build()
 
-					matcher := JSONMatchesEventContext(expectedMultiKind, map[string][]string{"user": {"name", "setup", "punchline"}})
+					matcher := JSONMatchesEventContext(
+						expectedMultiKind,
+						map[string][]string{"user": {"name", "setup", "punchline", "/~1ssn"}},
+					)
 
 					payload := events.ExpectAnalyticsEvents(t, defaultEventTimeout)
 					m.In(t).Assert(payload, m.ItemsInAnyOrder(


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Harness-only test and matcher expectations; no runtime SDK or production behavior changes.
> 
> **Overview**
> Extends the SDK test harness so analytics event context redaction is validated when a **custom attribute’s literal name starts with `/`** (e.g. `/ssn`).
> 
> **Shared event-context suite** adds a case under `allAttributesPrivate` that expects `_meta.redactedAttributes` to list **`/~1ssn`**, not the raw name. **Anonymous redaction** feature-event tests (client-side, server-side, PHP) now include `/ssn` on contexts and expect it nulled in the payload with **`/~1ssn`** in the redacted list. **`JSONMatchesEventContext`** unit tests cover match on the escaped form and non-match when the event incorrectly uses `/ssn`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 98715a428fc708cacd36172df33680d2f9251c94. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->