### PR TITLE
feat: Contract tests for client-side prerequisite cycle detection

### DIFF
--- a/sdktests/client_side_events_all.go
+++ b/sdktests/client_side_events_all.go
@@ -24,6 +24,10 @@ func doClientSideEventTests(t *ldtest.T) {
 
 	t.RequireCapability(servicedef.CapabilityClientPrereqEvents)
 	t.Run("prerequisite events emit in order", doClientSideInOrderPrereqEventTests)
+	t.Run("prerequisite events handle cycles", func(t *ldtest.T) {
+		t.RequireCapability(servicedef.CapabilityClientPrereqCycleDetection)
+		doClientSidePrereqCycleTests(t)
+	})
 }
 
 func doClientSideEventRequestTests(t *ldtest.T) {

--- a/sdktests/client_side_events_eval.go
+++ b/sdktests/client_side_events_eval.go
@@ -468,7 +468,8 @@ func doClientSidePrereqCycleTests(t *ldtest.T) {
 		client.FlushEvents(t)
 		payload := events.ExpectAnalyticsEvents(t, defaultEventTimeout)
 
-		expected := []m.Matcher{IsIdentifyEventForContext(context)}
+		expected := make([]m.Matcher, 0, 1+len(expectedFeatureEventKeys)+1)
+		expected = append(expected, IsIdentifyEventForContext(context))
 		for _, key := range expectedFeatureEventKeys {
 			key := key
 			expected = append(expected, IsValidFeatureEventWithConditions(

--- a/sdktests/client_side_events_eval.go
+++ b/sdktests/client_side_events_eval.go
@@ -1,6 +1,7 @@
 package sdktests
 
 import (
+	"fmt"
 	"time"
 
 	"github.com/launchdarkly/sdk-test-harness/v2/data"
@@ -422,4 +423,163 @@ func doClientSideDebugEventTests(t *ldtest.T) {
 	}
 
 	doDebugEventTestCases(t, doDebugTest)
+}
+
+// doClientSidePrereqCycleTests exercises CSPE 1.2.5, 1.2.5.1, and 1.2.5.2: the SDK must
+// not enter unbounded recursion when the prerequisites graph reachable from the evaluated
+// flag contains a cycle. On cycle detection the SDK skips the offending edge, continues
+// processing remaining prerequisites at the current level, and returns the requested
+// flag's cached value and reason unchanged.
+//
+// These cases cover feature-event emission. Companion summary-counter cases live in
+// client_side_events_summary.go as doClientSideSummaryPrereqCycleTests.
+func doClientSidePrereqCycleTests(t *ldtest.T) {
+	context := ldcontext.New("user")
+
+	// runCase evaluates evalKey against the given flag data and asserts:
+	//   - the HTTP round-trip to the test service completes (implicit: no SDK crash),
+	//   - Requirement 1.2.5.1: the returned value equals expectedValue (the cached
+	//     evaluation result of the requested flag, unchanged),
+	//   - feature events are emitted for the flags in expectedFeatureEventKeys, plus
+	//     the usual identify and summary events. The expected list is finite, so a
+	//     failed cycle guard that emits an unbounded event stream would fail the match.
+	runCase := func(
+		t *ldtest.T,
+		dataBuilder *mockld.ClientSDKDataBuilder,
+		evalKey string,
+		expectedValue ldvalue.Value,
+		expectedFeatureEventKeys []string,
+	) {
+		dataSource := NewSDKDataSource(t, dataBuilder.Build())
+		events := NewSDKEventSink(t)
+		client := NewSDKClient(t,
+			WithClientSideInitialContext(context),
+			dataSource, events)
+
+		result := client.EvaluateFlag(t, servicedef.EvaluateFlagParams{
+			FlagKey:      evalKey,
+			DefaultValue: ldvalue.Null(),
+			ValueType:    servicedef.ValueTypeAny,
+		})
+
+		// Requirement 1.2.5.1: value MUST equal the flag's cached evaluation result.
+		m.In(t).Assert(result.Value, m.JSONEqual(expectedValue))
+
+		client.FlushEvents(t)
+		payload := events.ExpectAnalyticsEvents(t, defaultEventTimeout)
+
+		expected := []m.Matcher{IsIdentifyEventForContext(context)}
+		for _, key := range expectedFeatureEventKeys {
+			key := key
+			expected = append(expected, IsValidFeatureEventWithConditions(
+				t, false, context,
+				m.JSONProperty("key").Should(m.Equal(key)),
+			))
+		}
+		expected = append(expected, IsSummaryEvent())
+		m.In(t).Assert(payload, m.ItemsInAnyOrder(expected...))
+	}
+
+	valTrue := ldvalue.Bool(true)
+
+	makeFlag := func(prereqs ...string) mockld.ClientSDKFlag {
+		return mockld.ClientSDKFlag{
+			Value:         valTrue,
+			Variation:     o.Some(0),
+			TrackEvents:   true,
+			Prerequisites: prereqs,
+		}
+	}
+
+	t.Run("self-loop", func(t *ldtest.T) {
+		dataBuilder := mockld.NewClientSDKDataBuilder().
+			Flag("A", makeFlag("A"))
+		// A's only prerequisite is itself; the cycle guard skips it. Only A emits a
+		// feature event (as the top-level evaluation).
+		runCase(t, dataBuilder, "A", valTrue, []string{"A"})
+	})
+
+	t.Run("self-loop with sibling prerequisite", func(t *ldtest.T) {
+		dataBuilder := mockld.NewClientSDKDataBuilder().
+			Flag("A", makeFlag("A", "B")).
+			Flag("B", makeFlag())
+		// The self-prereq on A is skipped; B is still evaluated as a sibling.
+		runCase(t, dataBuilder, "A", valTrue, []string{"B", "A"})
+	})
+
+	t.Run("two-cycle, evaluating A", func(t *ldtest.T) {
+		dataBuilder := mockld.NewClientSDKDataBuilder().
+			Flag("A", makeFlag("B")).
+			Flag("B", makeFlag("A"))
+		// A -> B -> [A skipped by cycle guard]. Events: B (as prereq of A), A.
+		runCase(t, dataBuilder, "A", valTrue, []string{"B", "A"})
+	})
+
+	t.Run("two-cycle, evaluating B", func(t *ldtest.T) {
+		dataBuilder := mockld.NewClientSDKDataBuilder().
+			Flag("A", makeFlag("B")).
+			Flag("B", makeFlag("A"))
+		// Symmetric: same graph, but B is the entry point.
+		runCase(t, dataBuilder, "B", valTrue, []string{"A", "B"})
+	})
+
+	t.Run("three-cycle", func(t *ldtest.T) {
+		dataBuilder := mockld.NewClientSDKDataBuilder().
+			Flag("A", makeFlag("B")).
+			Flag("B", makeFlag("C")).
+			Flag("C", makeFlag("A"))
+		// A -> B -> C -> [A skipped]. Events (deepest first): C, B, A.
+		runCase(t, dataBuilder, "A", valTrue, []string{"C", "B", "A"})
+	})
+
+	t.Run("cycle within a subgraph", func(t *ldtest.T) {
+		// A has one acyclic branch (X) and one branch that contains a cycle (B <-> C).
+		// The cycle must not affect processing of the sibling branch.
+		dataBuilder := mockld.NewClientSDKDataBuilder().
+			Flag("A", makeFlag("X", "B")).
+			Flag("X", makeFlag()).
+			Flag("B", makeFlag("C")).
+			Flag("C", makeFlag("B"))
+		// A -> [X (leaf), B -> C -> [B skipped]]. Events: X, C, B, A.
+		runCase(t, dataBuilder, "A", valTrue, []string{"X", "C", "B", "A"})
+	})
+
+	t.Run("diamond (non-cyclic control)", func(t *ldtest.T) {
+		// Ancestor-set (Requirement 1.2.5.2) semantics: D is reached twice via
+		// independent paths and MUST emit a prerequisite event on each. A naive
+		// "visited across the whole walk" implementation would silently drop the
+		// second D event; this case catches that regression.
+		dataBuilder := mockld.NewClientSDKDataBuilder().
+			Flag("A", makeFlag("B", "C")).
+			Flag("B", makeFlag("D")).
+			Flag("C", makeFlag("D")).
+			Flag("D", makeFlag())
+		// Events: D (via B), B, D (via C), C, A. D appears twice.
+		runCase(t, dataBuilder, "A", valTrue, []string{"D", "B", "D", "C", "A"})
+	})
+
+	t.Run("deep chain (non-cyclic control)", func(t *ldtest.T) {
+		// Verifies that the cycle-detection implementation does not accidentally
+		// impose a shallow depth limit that would break legitimate deep prereq trees.
+		const depth = 20
+		dataBuilder := mockld.NewClientSDKDataBuilder()
+		for i := 0; i < depth; i++ {
+			key := fmt.Sprintf("f%d", i)
+			flag := mockld.ClientSDKFlag{
+				Value:       valTrue,
+				Variation:   o.Some(0),
+				TrackEvents: true,
+			}
+			if i < depth-1 {
+				flag.Prerequisites = []string{fmt.Sprintf("f%d", i+1)}
+			}
+			dataBuilder.Flag(key, flag)
+		}
+		// Deepest first: f19, f18, ..., f0.
+		expected := make([]string, depth)
+		for i := 0; i < depth; i++ {
+			expected[i] = fmt.Sprintf("f%d", depth-1-i)
+		}
+		runCase(t, dataBuilder, "f0", valTrue, expected)
+	})
 }

--- a/sdktests/client_side_events_summary.go
+++ b/sdktests/client_side_events_summary.go
@@ -31,6 +31,10 @@ func doClientSideSummaryEventTests(t *ldtest.T) {
 		t.RequireCapability(servicedef.CapabilityClientPrereqEvents)
 		t.Run("basic behavior", doClientSideSummaryBasicPrereqTest)
 		t.Run("emits unknown event", doClientSideSummaryPrereqUnknownFlagTest)
+		t.Run("handles cycles", func(t *ldtest.T) {
+			t.RequireCapability(servicedef.CapabilityClientPrereqCycleDetection)
+			doClientSideSummaryPrereqCycleTests(t)
+		})
 	})
 }
 
@@ -606,4 +610,136 @@ func doClientSideSummaryPrereqUnknownFlagTest(t *ldtest.T) {
 			)),
 		)),
 	)
+}
+
+// doClientSideSummaryPrereqCycleTests is the summary-counter mirror of the feature-event
+// cases in doClientSidePrereqCycleTests (client_side_events_eval.go). Requirement 1.2.2
+// says the SDK must update summary counters equivalently to a direct evaluation of each
+// prerequisite; Requirement 1.2.5 says the SDK must skip descent on cycle detection. The
+// combined effect is that each cycle-safe descent increments the counter exactly once,
+// and cyclic edges do not increment the counter at all. The diamond case verifies the
+// ancestor-set semantics of Requirement 1.2.5.2: the same flag reached via two independent
+// paths increments its counter twice.
+func doClientSideSummaryPrereqCycleTests(t *ldtest.T) {
+	context := ldcontext.New("user")
+	valTrue := ldvalue.Bool(true)
+	defaultVal := ldvalue.String("default")
+
+	makeFlag := func(prereqs ...string) mockld.ClientSDKFlag {
+		return mockld.ClientSDKFlag{
+			Value:         valTrue,
+			Variation:     o.Some(0),
+			FlagVersion:   o.Some(1),
+			Version:       1,
+			Prerequisites: prereqs,
+		}
+	}
+
+	// runCase evaluates evalKey and asserts each flag's summary counter matches
+	// expectedCounts. The top-level flag entry also carries the default value we
+	// passed to EvaluateFlag; prereq-only flags do not.
+	runCase := func(
+		t *ldtest.T,
+		dataBuilder *mockld.ClientSDKDataBuilder,
+		evalKey string,
+		expectedCounts map[string]int,
+	) {
+		dataSource := NewSDKDataSource(t, dataBuilder.Build())
+		events := NewSDKEventSinkWithGzip(t, t.Capabilities().Has(servicedef.CapabilityEventGzip))
+		client := NewSDKClient(t,
+			WithClientSideInitialContext(context),
+			dataSource, events)
+
+		_ = client.EvaluateFlag(t, servicedef.EvaluateFlagParams{
+			FlagKey:      evalKey,
+			DefaultValue: defaultVal,
+		})
+
+		client.FlushEvents(t)
+		payload := events.ExpectAnalyticsEvents(t, defaultEventTimeout)
+
+		flagEntries := make([]m.KeyValueMatcher, 0, len(expectedCounts))
+		for key, count := range expectedCounts {
+			key, count := key, count
+			counter := flagCounter(valTrue, 0, 1, count)
+			if key == evalKey {
+				flagEntries = append(flagEntries, m.KV(key, m.MapOf(
+					m.KV("default", m.JSONEqual(defaultVal)),
+					m.KV("counters", m.ItemsInAnyOrder(counter)),
+					m.KV("contextKinds", anyContextKindsList()),
+				)))
+			} else {
+				flagEntries = append(flagEntries, m.KV(key, m.AllOf(
+					JSONPropertyNullOrAbsent("default"),
+					m.JSONProperty("counters").Should(m.ItemsInAnyOrder(counter)),
+					m.JSONProperty("contextKinds").Should(anyContextKindsList()),
+				)))
+			}
+		}
+
+		m.In(t).Assert(payload, m.ItemsInAnyOrder(
+			IsIdentifyEventForContext(context),
+			IsValidSummaryEventWithFlags(
+				t.Capabilities().Has(servicedef.CapabilityClientPerContextSummaries),
+				flagEntries...,
+			),
+		))
+	}
+
+	t.Run("self-loop", func(t *ldtest.T) {
+		dataBuilder := mockld.NewClientSDKDataBuilder().
+			Flag("A", makeFlag("A"))
+		// A is counted once at the top level; the self-prereq is cycle-skipped.
+		runCase(t, dataBuilder, "A", map[string]int{"A": 1})
+	})
+
+	t.Run("self-loop with sibling prerequisite", func(t *ldtest.T) {
+		dataBuilder := mockld.NewClientSDKDataBuilder().
+			Flag("A", makeFlag("A", "B")).
+			Flag("B", makeFlag())
+		runCase(t, dataBuilder, "A", map[string]int{"A": 1, "B": 1})
+	})
+
+	t.Run("two-cycle, evaluating A", func(t *ldtest.T) {
+		dataBuilder := mockld.NewClientSDKDataBuilder().
+			Flag("A", makeFlag("B")).
+			Flag("B", makeFlag("A"))
+		runCase(t, dataBuilder, "A", map[string]int{"A": 1, "B": 1})
+	})
+
+	t.Run("two-cycle, evaluating B", func(t *ldtest.T) {
+		dataBuilder := mockld.NewClientSDKDataBuilder().
+			Flag("A", makeFlag("B")).
+			Flag("B", makeFlag("A"))
+		runCase(t, dataBuilder, "B", map[string]int{"A": 1, "B": 1})
+	})
+
+	t.Run("three-cycle", func(t *ldtest.T) {
+		dataBuilder := mockld.NewClientSDKDataBuilder().
+			Flag("A", makeFlag("B")).
+			Flag("B", makeFlag("C")).
+			Flag("C", makeFlag("A"))
+		runCase(t, dataBuilder, "A", map[string]int{"A": 1, "B": 1, "C": 1})
+	})
+
+	t.Run("cycle within a subgraph", func(t *ldtest.T) {
+		dataBuilder := mockld.NewClientSDKDataBuilder().
+			Flag("A", makeFlag("X", "B")).
+			Flag("X", makeFlag()).
+			Flag("B", makeFlag("C")).
+			Flag("C", makeFlag("B"))
+		runCase(t, dataBuilder, "A", map[string]int{"A": 1, "X": 1, "B": 1, "C": 1})
+	})
+
+	t.Run("diamond (non-cyclic control)", func(t *ldtest.T) {
+		// D is reached via two independent paths (through B and through C), so its
+		// counter increments twice. A naive "visited across the whole walk"
+		// implementation would count D only once.
+		dataBuilder := mockld.NewClientSDKDataBuilder().
+			Flag("A", makeFlag("B", "C")).
+			Flag("B", makeFlag("D")).
+			Flag("C", makeFlag("D")).
+			Flag("D", makeFlag())
+		runCase(t, dataBuilder, "A", map[string]int{"A": 1, "B": 1, "C": 1, "D": 2})
+	})
 }

--- a/servicedef/service_params.go
+++ b/servicedef/service_params.go
@@ -42,6 +42,7 @@ const (
 	CapabilityEvaluationHooks             = "evaluation-hooks"
 	CapabilityTrackHooks                  = "track-hooks"
 	CapabilityClientPrereqEvents          = "client-prereq-events"
+	CapabilityClientPrereqCycleDetection  = "client-prereq-cycle-detection"
 	CapabilityPersistentDataStoreRedis    = "persistent-data-store-redis"
 	CapabilityPersistentDataStoreConsul   = "persistent-data-store-consul"
 	CapabilityPersistentDataStoreDynamoDB = "persistent-data-store-dynamodb"


### PR DESCRIPTION
## Summary

Adds the `client-prereq-cycle-detection` capability plus a set of contract tests that exercise **CSPE 1.2.5, 1.2.5.1, and 1.2.5.2** (see [sdk-specs PR #246](https://github.com/launchdarkly/sdk-specs/pull/246), currently in review):

- **1.2.5**: on a cyclic prerequisite graph reachable from the evaluated flag, the SDK must not enter unbounded recursion, exhaust its stack, or terminate abnormally. It must skip descent into the cyclic edge and continue processing any remaining prerequisites at the current level.
- **1.2.5.1**: the returned value and reason must equal the requested flag's cached evaluation result unchanged. A client-side cycle must not surface as `MALFORMED_FLAG` and must not fall back to the caller-provided default.
- **1.2.5.2**: cycle detection must use ancestor-set (current-path) semantics so that a prerequisite reachable via multiple non-cyclic paths (a diamond) is still processed on each path.

Draft while [sdk-specs PR #246](https://github.com/launchdarkly/sdk-specs/pull/246) is in review; tests may be adjusted to match final requirement wording. Zero SDKs declare `client-prereq-cycle-detection` at merge time, so this PR is a no-op for existing CI runs. Each per-SDK fix will declare the capability and activate the test for that SDK.

## What's in

**`servicedef/service_params.go`** — new capability constant `CapabilityClientPrereqCycleDetection = "client-prereq-cycle-detection"`.

**`sdktests/client_side_events_eval.go`** — new `doClientSidePrereqCycleTests` covering feature-event emission across cycle shapes. Cases: self-loop, self-loop-with-sibling, two-cycle (evaluated from each end), three-cycle, cycle-in-subgraph, diamond (non-cyclic control), 20-flag deep chain (non-cyclic control). Each case asserts that the returned value equals the flag's cached value and that the emitted feature events match the expected set (bounded — a failed cycle guard would emit unbounded events and fail the match).

**`sdktests/client_side_events_summary.go`** — new `doClientSideSummaryPrereqCycleTests`. Summary-counter mirror of the feature-event cases: each cycle-safe descent increments the counter exactly once; cyclic edges do not increment; the diamond's shared descendant increments twice (ancestor-set proof).

**`sdktests/client_side_events_all.go`** and the "prerequisites" subtree in the summary file — wires the new tests behind `t.RequireCapability(CapabilityClientPrereqCycleDetection)`, nested under the existing `CapabilityClientPrereqEvents` gate.

## What's deliberately not in

- **Persisted-cyclic-cache-across-restart scenario**: platform-specific storage — belongs in each SDK's own unit tests. The runtime cycle guard fixes the in-memory case and the persisted case equally.
- **Patch-introduces-cycle-mid-stream scenario**: exercises the same walker code path as an initial `put` containing a cycle. Redundant.
- **Hooks-not-triggered-on-prereq-recursion**: SDK-specific (some SDKs have hooks, some don't). Belongs per-SDK.

## Rollout

Parent story: [SDK-2695](https://launchdarkly.atlassian.net/browse/SDK-2695). This is [SDK-2703](https://launchdarkly.atlassian.net/browse/SDK-2703). Per-SDK subtasks are SDK-2704 through SDK-2715. Suggested order: Android → shipping iOS → JS shared sdk-client → wrappers (React, RN, Electron, node-client, Vue) → Flutter → .NET → C++ → Roku.

## Test plan

- [ ] `go build ./...` passes (verified locally).
- [ ] `go vet ./sdktests/... ./servicedef/...` passes (verified locally).
- [ ] With zero SDKs declaring the capability, this PR is a no-op for existing CI runs.
- [ ] Once a fixed SDK declares `client-prereq-cycle-detection`, this test suite runs against it and passes.

[SDK-2695]: https://launchdarkly.atlassian.net/browse/SDK-2695?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Harness-only additions behind a new opt-in capability; no production SDK or runtime behavior changes in this repo.
> 
> **Overview**
> Introduces the **`client-prereq-cycle-detection`** harness capability and contract tests for **CSPE 1.2.5** (safe handling of cyclic prerequisite graphs on client-side evaluation).
> 
> **Feature-event tests** (`doClientSidePrereqCycleTests`) assert the evaluated flag still returns its cached value, the SDK does not crash or emit unbounded events, and prerequisite feature events match expected finite sets for self-loops, multi-flag cycles, cycles beside acyclic siblings, diamond graphs (shared node counted per path), and a deep acyclic chain control.
> 
> **Summary-counter tests** (`doClientSideSummaryPrereqCycleTests`) mirror those graphs: each non-cyclic descent increments counters once, cyclic edges do not, and the diamond case expects the shared flag counted twice.
> 
> Both suites are gated behind **`CapabilityClientPrereqCycleDetection`** (nested under existing **`client-prereq-events`**), so CI stays unchanged until an SDK opts in.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e819cc65129f502f67e807eb76852f221b9cc576. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->