### PR TITLE
fix: Fix capability guarding custom event redaction

### DIFF
--- a/sdktests/common_tests_events_custom.go
+++ b/sdktests/common_tests_events_custom.go
@@ -73,7 +73,7 @@ func (c CommonEventTests) CustomEvents(t *ldtest.T) {
 		}
 	})
 
-	if t.Capabilities().Has(servicedef.CapabilityOmitAnonymousContexts) &&
+	if t.Capabilities().Has(servicedef.CapabilityAnonymousRedaction) &&
 		t.Capabilities().Has(servicedef.CapabilityInlineContextAll) {
 		t.Run("single-kind anonymous context redacts all attributes", func(t *ldtest.T) {
 			anonymousFactory := data.NewContextFactory("anonymous", func(b *ldcontext.Builder) {


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Test-only change to a capability guard; no production SDK behavior is modified.
> 
> **Overview**
> The custom-event anonymous redaction harness tests were gated on **`CapabilityOmitAnonymousContexts`**, which describes omitting anonymous contexts from identify events—not redacting attributes in inlined context on custom events.
> 
> The guard now uses **`CapabilityAnonymousRedaction`** (still combined with **`CapabilityInlineContextAll`**), matching how feature-event redaction tests are gated elsewhere in the harness.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1af87dce6b4559b65f83f6cf94585367803a30ae. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->