### PR TITLE
fix: Fix capability guarding custom event redaction

### DIFF
--- a/sdktests/common_tests_events_custom.go
+++ b/sdktests/common_tests_events_custom.go
@@ -73,7 +73,7 @@ func (c CommonEventTests) CustomEvents(t *ldtest.T) {
 		}
 	})
 
-	if t.Capabilities().Has(servicedef.CapabilityOmitAnonymousContexts) &&
+	if t.Capabilities().Has(servicedef.CapabilityAnonymousRedaction) &&
 		t.Capabilities().Has(servicedef.CapabilityInlineContextAll) {
 		t.Run("single-kind anonymous context redacts all attributes", func(t *ldtest.T) {
 			anonymousFactory := data.NewContextFactory("anonymous", func(b *ldcontext.Builder) {


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Test harness guard only; no production SDK or runtime behavior changes.
> 
> **Overview**
> Fixes incorrect capability gating for the custom-event anonymous context redaction harness tests.
> 
> The **single-kind** and **multi-kind** anonymous redaction subtests under `CustomEvents` now require `CapabilityAnonymousRedaction` (with `CapabilityInlineContextAll`) instead of `CapabilityOmitAnonymousContexts`, matching how similar redaction tests are guarded elsewhere in the suite.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ca3aa624a56d49850ad76063a60eace8c88d464c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->