### PR TITLE
fix: Only expect custom-event anonymous redaction for server SDKs

### DIFF
--- a/sdktests/common_tests_events_custom.go
+++ b/sdktests/common_tests_events_custom.go
@@ -73,8 +73,13 @@ func (c CommonEventTests) CustomEvents(t *ldtest.T) {
 		}
 	})
 
+	// Server-side SDKs inline the full context in custom events and redact anonymous context
+	// attributes. Client-side SDKs use the current (identified) context for custom events and do
+	// NOT redact anonymous contexts in custom events -- only in feature events. The client-side
+	// behavior is covered separately below.
 	if t.Capabilities().Has(servicedef.CapabilityAnonymousRedaction) &&
-		t.Capabilities().Has(servicedef.CapabilityInlineContextAll) {
+		t.Capabilities().Has(servicedef.CapabilityInlineContextAll) &&
+		!c.isClientSide {
 		t.Run("single-kind anonymous context redacts all attributes", func(t *ldtest.T) {
 			anonymousFactory := data.NewContextFactory("anonymous", func(b *ldcontext.Builder) {
 				b.Anonymous(true)
@@ -166,6 +171,86 @@ func (c CommonEventTests) CustomEvents(t *ldtest.T) {
 
 			payload := events.ExpectAnalyticsEvents(t, defaultEventTimeout)
 			m.In(t).Assert(payload, m.ItemsInAnyOrder(expectedEvents...))
+		})
+	}
+
+	// Client-side SDKs use the current (identified) context for custom events and do NOT redact
+	// anonymous context attributes in custom events -- only feature events redact anonymous
+	// contexts on the client. Establish the context via identify (discarding that identify event),
+	// then verify the custom event carries the full, unredacted context.
+	if t.Capabilities().Has(servicedef.CapabilityAnonymousRedaction) &&
+		t.Capabilities().Has(servicedef.CapabilityInlineContextAll) &&
+		c.isClientSide {
+		t.Run("single-kind anonymous context is not redacted", func(t *ldtest.T) {
+			anonymousFactory := data.NewContextFactory("anonymous", func(b *ldcontext.Builder) {
+				b.Anonymous(true)
+				b.Name("Example name")
+				b.SetString("setup", "Why do programmers always confused Halloween and Christmas?")
+				b.SetString("punchline", "Because OCT 31 = DEC 25")
+			})
+			anonymousContext := anonymousFactory.NextUniqueContext()
+
+			dataSource := NewSDKDataSource(t, nil)
+			events := NewSDKEventSinkWithGzip(t, t.Capabilities().Has(servicedef.CapabilityEventGzip))
+			client := NewSDKClient(t, c.baseSDKConfigurationPlus(dataSource, events)...)
+
+			client.SendIdentifyEvent(t, anonymousContext)
+			client.FlushEvents(t)
+			_ = events.ExpectAnalyticsEvents(t, defaultEventTimeout) // discard the identify event
+
+			client.SendCustomEvent(t, servicedef.CustomEventParams{
+				EventKey: "event-key",
+				Context:  o.Some(anonymousContext),
+			})
+			client.FlushEvents(t)
+
+			// No redaction: the full anonymous context (including its attributes) is expected.
+			expectedContextMatcher := JSONMatchesEventContext(anonymousContext, nil)
+			payload := events.ExpectAnalyticsEvents(t, defaultEventTimeout)
+			m.In(t).Assert(payload, m.ItemsInAnyOrder(
+				m.AllOf(IsCustomEvent(), m.JSONProperty("context").Should(expectedContextMatcher)),
+			))
+		})
+
+		t.Run("multi-kind with anonymous context is not redacted", func(t *ldtest.T) {
+			userContextFactory := data.NewContextFactory("user", func(b *ldcontext.Builder) {
+				b.Anonymous(true)
+				b.Kind("user")
+				b.Name("User name")
+				b.SetString("setup", "Why do programmers always confused Halloween and Christmas?")
+				b.SetString("punchline", "Because OCT 31 = DEC 25")
+			})
+			orgContextFactory := data.NewContextFactory("org", func(b *ldcontext.Builder) {
+				b.Name("Org name")
+				b.Kind("org")
+				b.SetString("setup", "Why did the edge server go bankrupt?")
+				b.SetString("punchline", "Because it ran out of cache")
+			})
+
+			userContext := userContextFactory.NextUniqueContext()
+			orgContext := orgContextFactory.NextUniqueContext()
+			multiContext := ldcontext.NewMultiBuilder().Add(userContext).Add(orgContext).Build()
+
+			dataSource := NewSDKDataSource(t, nil)
+			events := NewSDKEventSinkWithGzip(t, t.Capabilities().Has(servicedef.CapabilityEventGzip))
+			client := NewSDKClient(t, c.baseSDKConfigurationPlus(dataSource, events)...)
+
+			client.SendIdentifyEvent(t, multiContext)
+			client.FlushEvents(t)
+			_ = events.ExpectAnalyticsEvents(t, defaultEventTimeout) // discard the identify event
+
+			client.SendCustomEvent(t, servicedef.CustomEventParams{
+				EventKey: "event-key",
+				Context:  o.Some(multiContext),
+			})
+			client.FlushEvents(t)
+
+			// No redaction: the full multi-kind context (including all attributes) is expected.
+			expectedContextMatcher := JSONMatchesEventContext(multiContext, nil)
+			payload := events.ExpectAnalyticsEvents(t, defaultEventTimeout)
+			m.In(t).Assert(payload, m.ItemsInAnyOrder(
+				m.AllOf(IsCustomEvent(), m.JSONProperty("context").Should(expectedContextMatcher)),
+			))
 		})
 	}
 }


### PR DESCRIPTION
## Summary

The custom-event anonymous-redaction test began running for client SDKs after the capability-guard fix (#386), but it was written for server semantics: it attaches the anonymous context to the custom event via the per-event context param. Client SDKs use the current (identified) context for custom events and do NOT redact anonymous contexts there -- only in feature events, matching the other LaunchDarkly client/mobile SDKs.

This gates the redaction assertion to server-side SDKs (`!c.isClientSide`), and adds client-side tests ('single-/multi-kind anonymous context is not redacted') that establish the anonymous context via identify and verify the custom event carries the full, unredacted context.

Verified: node-client passes (client tests, no redaction), server-node passes (server tests, redaction).

Relates to SDK-2716.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-harness-only changes to expectations and coverage; no production SDK or runtime behavior is modified.
> 
> **Overview**
> Aligns the SDK test harness with **server vs client** semantics for anonymous context on **custom events**.
> 
> The existing anonymous-redaction cases (per-event context, attributes nulled) now run only when **`!c.isClientSide`**, so client SDKs are no longer held to server redaction expectations after the capability-guard fix.
> 
> For **client-side** SDKs, new cases **`identify` first** (discarding that event), then assert custom events carry the **full, unredacted** context for single- and multi-kind anonymous contexts. Comments document that clients use the current identified context and only redact anonymous data on **feature** events, not custom events.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit dc9d371558a89edf956b199838ffd32279071973. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->