### PR TITLE
fix: Only expect custom-event anonymous redaction for server SDKs

### DIFF
--- a/sdktests/common_tests_events_custom.go
+++ b/sdktests/common_tests_events_custom.go
@@ -73,8 +73,13 @@ func (c CommonEventTests) CustomEvents(t *ldtest.T) {
 		}
 	})
 
+	// Server-side SDKs inline the full context in custom events and redact anonymous context
+	// attributes. Client-side SDKs use the current (identified) context for custom events and do
+	// NOT redact anonymous contexts in custom events -- only in feature events. The client-side
+	// behavior is covered separately below.
 	if t.Capabilities().Has(servicedef.CapabilityAnonymousRedaction) &&
-		t.Capabilities().Has(servicedef.CapabilityInlineContextAll) {
+		t.Capabilities().Has(servicedef.CapabilityInlineContextAll) &&
+		!c.isClientSide {
 		t.Run("single-kind anonymous context redacts all attributes", func(t *ldtest.T) {
 			anonymousFactory := data.NewContextFactory("anonymous", func(b *ldcontext.Builder) {
 				b.Anonymous(true)
@@ -166,6 +171,86 @@ func (c CommonEventTests) CustomEvents(t *ldtest.T) {
 
 			payload := events.ExpectAnalyticsEvents(t, defaultEventTimeout)
 			m.In(t).Assert(payload, m.ItemsInAnyOrder(expectedEvents...))
+		})
+	}
+
+	// Client-side SDKs use the current (identified) context for custom events and do NOT redact
+	// anonymous context attributes in custom events -- only feature events redact anonymous
+	// contexts on the client. Establish the context via identify (discarding that identify event),
+	// then verify the custom event carries the full, unredacted context.
+	if t.Capabilities().Has(servicedef.CapabilityAnonymousRedaction) &&
+		t.Capabilities().Has(servicedef.CapabilityInlineContextAll) &&
+		c.isClientSide {
+		t.Run("single-kind anonymous context is not redacted", func(t *ldtest.T) {
+			anonymousFactory := data.NewContextFactory("anonymous", func(b *ldcontext.Builder) {
+				b.Anonymous(true)
+				b.Name("Example name")
+				b.SetString("setup", "Why do programmers always confused Halloween and Christmas?")
+				b.SetString("punchline", "Because OCT 31 = DEC 25")
+			})
+			anonymousContext := anonymousFactory.NextUniqueContext()
+
+			dataSystem := NewSDKDataSystem(t, nil)
+			events := NewSDKEventSinkWithGzip(t, t.Capabilities().Has(servicedef.CapabilityEventGzip))
+			client := NewSDKClient(t, c.baseSDKConfigurationPlus(dataSystem, events)...)
+
+			client.SendIdentifyEvent(t, anonymousContext)
+			client.FlushEvents(t)
+			_ = events.ExpectAnalyticsEvents(t, defaultEventTimeout) // discard the identify event
+
+			client.SendCustomEvent(t, servicedef.CustomEventParams{
+				EventKey: "event-key",
+				Context:  o.Some(anonymousContext),
+			})
+			client.FlushEvents(t)
+
+			// No redaction: the full anonymous context (including its attributes) is expected.
+			expectedContextMatcher := JSONMatchesEventContext(anonymousContext, nil)
+			payload := events.ExpectAnalyticsEvents(t, defaultEventTimeout)
+			m.In(t).Assert(payload, m.ItemsInAnyOrder(
+				m.AllOf(IsCustomEvent(), m.JSONProperty("context").Should(expectedContextMatcher)),
+			))
+		})
+
+		t.Run("multi-kind with anonymous context is not redacted", func(t *ldtest.T) {
+			userContextFactory := data.NewContextFactory("user", func(b *ldcontext.Builder) {
+				b.Anonymous(true)
+				b.Kind("user")
+				b.Name("User name")
+				b.SetString("setup", "Why do programmers always confused Halloween and Christmas?")
+				b.SetString("punchline", "Because OCT 31 = DEC 25")
+			})
+			orgContextFactory := data.NewContextFactory("org", func(b *ldcontext.Builder) {
+				b.Name("Org name")
+				b.Kind("org")
+				b.SetString("setup", "Why did the edge server go bankrupt?")
+				b.SetString("punchline", "Because it ran out of cache")
+			})
+
+			userContext := userContextFactory.NextUniqueContext()
+			orgContext := orgContextFactory.NextUniqueContext()
+			multiContext := ldcontext.NewMultiBuilder().Add(userContext).Add(orgContext).Build()
+
+			dataSystem := NewSDKDataSystem(t, nil)
+			events := NewSDKEventSinkWithGzip(t, t.Capabilities().Has(servicedef.CapabilityEventGzip))
+			client := NewSDKClient(t, c.baseSDKConfigurationPlus(dataSystem, events)...)
+
+			client.SendIdentifyEvent(t, multiContext)
+			client.FlushEvents(t)
+			_ = events.ExpectAnalyticsEvents(t, defaultEventTimeout) // discard the identify event
+
+			client.SendCustomEvent(t, servicedef.CustomEventParams{
+				EventKey: "event-key",
+				Context:  o.Some(multiContext),
+			})
+			client.FlushEvents(t)
+
+			// No redaction: the full multi-kind context (including all attributes) is expected.
+			expectedContextMatcher := JSONMatchesEventContext(multiContext, nil)
+			payload := events.ExpectAnalyticsEvents(t, defaultEventTimeout)
+			m.In(t).Assert(payload, m.ItemsInAnyOrder(
+				m.AllOf(IsCustomEvent(), m.JSONProperty("context").Should(expectedContextMatcher)),
+			))
 		})
 	}
 }


### PR DESCRIPTION
## Summary

v3 port of launchdarkly/sdk-test-harness#388.

The custom-event anonymous-redaction test began running for client SDKs after the capability-guard fix (#387), but it was written for server semantics (attaching the anonymous context to the custom event via the per-event context param). Client SDKs use the current (identified) context for custom events and do NOT redact anonymous contexts there -- only in feature events, matching the other LaunchDarkly client/mobile SDKs.

Gates the redaction assertion to server-side SDKs (`!c.isClientSide`), and adds client-side tests ('single-/multi-kind anonymous context is not redacted') that establish the context via identify and verify the custom event carries the full, unredacted context. Only difference from v2 is the `NewSDKDataSource` -> `NewSDKDataSystem` naming.

Relates to SDK-2716.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only changes in the SDK harness; no production SDK or runtime behavior is modified.
> 
> **Overview**
> Aligns the SDK test harness with **server vs client** semantics for anonymous context on **custom events**.
> 
> **Server SDKs** still must inline context and **redact** anonymous attributes on custom events; those assertions now run only when `!c.isClientSide`.
> 
> **Client SDKs** are expected to use the **current identified context** for custom events and **not** redact anonymous attributes there (redaction remains for feature events). New tests identify first (discarding the identify payload), send a custom event, and assert the payload carries the **full, unredacted** context for single- and multi-kind anonymous contexts.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 78d79e6dca68fe865a8c3f6ee6b92669f612a5d5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->