### PR TITLE
fix: Correct privateAttributes JSON tag in context comparison params

### DIFF
--- a/sdktests/sdk_context_type.go
+++ b/sdktests/sdk_context_type.go
@@ -409,6 +409,37 @@ func doSDKContextComparisonTests(t *ldtest.T) {
 			m.In(t).Assert(resp.Equals, m.Equal(true))
 		})
 
+		t.Run("are different if only one has private attributes", func(t *ldtest.T) {
+			param := servicedef.ContextComparisonPairParams{
+				Context1: servicedef.ContextComparisonParams{
+					Single: &servicedef.ContextComparisonSingleParams{Kind: "user", Key: "user-key",
+						PrivateAttributes: []servicedef.PrivateAttribute{{Value: "name", Literal: false}}},
+				},
+				Context2: servicedef.ContextComparisonParams{
+					Single: &servicedef.ContextComparisonSingleParams{Kind: "user", Key: "user-key"},
+				},
+			}
+
+			resp := client.ContextComparison(t, param)
+			m.In(t).Assert(resp.Equals, m.Equal(false))
+		})
+
+		t.Run("are different if private attributes are not identical", func(t *ldtest.T) {
+			param := servicedef.ContextComparisonPairParams{
+				Context1: servicedef.ContextComparisonParams{
+					Single: &servicedef.ContextComparisonSingleParams{Kind: "user", Key: "user-key",
+						PrivateAttributes: []servicedef.PrivateAttribute{{Value: "name", Literal: false}}},
+				},
+				Context2: servicedef.ContextComparisonParams{
+					Single: &servicedef.ContextComparisonSingleParams{Kind: "user", Key: "user-key",
+						PrivateAttributes: []servicedef.PrivateAttribute{{Value: "/address/street", Literal: false}}},
+				},
+			}
+
+			resp := client.ContextComparison(t, param)
+			m.In(t).Assert(resp.Equals, m.Equal(false))
+		})
+
 		t.Run("are different if kinds are different", func(t *ldtest.T) {
 			param := servicedef.ContextComparisonPairParams{
 				Context1: servicedef.ContextComparisonParams{

--- a/servicedef/command_params.go
+++ b/servicedef/command_params.go
@@ -134,7 +134,7 @@ type ContextComparisonSingleParams struct {
 	Kind              string                `json:"kind"`
 	Key               string                `json:"key"`
 	Attributes        []AttributeDefinition `json:"attributes,omitempty"`
-	PrivateAttributes []PrivateAttribute    `json:"privateAttributes:omitempty"`
+	PrivateAttributes []PrivateAttribute    `json:"privateAttributes,omitempty"`
 }
 
 type AttributeDefinition struct {


### PR DESCRIPTION
## Summary

`ContextComparisonSingleParams.PrivateAttributes` used a colon instead of a comma in its struct tag (`json:"privateAttributes:omitempty"`). Go treats the whole string as the field name, so the field marshaled to the wire key `privateAttributes:omitempty` instead of `privateAttributes`, and `omitempty` was silently ignored. As a result the harness never sent private attributes to SDK test services for the `contextComparison` command, and the context-comparison private-attribute assertions passed vacuously.

This corrects the tag to `json:"privateAttributes,omitempty"` and adds two negative context-comparison tests where private attributes are the sole differentiator (two otherwise-identical contexts expected to be *not* equal). The existing suite only asserted the equal direction, which cannot detect an SDK that drops private attributes.

Verified by running the affected suite (`context type/compare`) against the flutter-client-sdk contract service: 16 tests run, all pass, including the two new negative tests.

Capability exercised: `context-comparison` (declared today by ruby-server-sdk, flutter-client-sdk, ios-client-sdk).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Harness serialization and test coverage only; no production SDK runtime behavior in this repo.
> 
> **Overview**
> Fixes a **JSON struct tag typo** on `ContextComparisonSingleParams.PrivateAttributes`: the tag used a colon instead of a comma (`privateAttributes:omitempty`), so Go treated the whole string as the field name. The harness never serialized private attributes under `privateAttributes` for the `contextComparison` command, so SDK contract tests could pass even when comparison ignored private metadata.
> 
> The tag is corrected to `json:"privateAttributes,omitempty"`. Two **negative** `contextComparison` tests are added: contexts that match on kind/key but differ only by presence or value of private attributes must **not** be equal.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c600ad167930d5d8b96b4c98f955b0abc8644778. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->