### PR TITLE
fix: Correct privateAttributes JSON tag in context comparison params

### DIFF
--- a/sdktests/sdk_context_type.go
+++ b/sdktests/sdk_context_type.go
@@ -409,6 +409,37 @@ func doSDKContextComparisonTests(t *ldtest.T) {
 			m.In(t).Assert(resp.Equals, m.Equal(true))
 		})
 
+		t.Run("are different if only one has private attributes", func(t *ldtest.T) {
+			param := servicedef.ContextComparisonPairParams{
+				Context1: servicedef.ContextComparisonParams{
+					Single: &servicedef.ContextComparisonSingleParams{Kind: "user", Key: "user-key",
+						PrivateAttributes: []servicedef.PrivateAttribute{{Value: "name", Literal: false}}},
+				},
+				Context2: servicedef.ContextComparisonParams{
+					Single: &servicedef.ContextComparisonSingleParams{Kind: "user", Key: "user-key"},
+				},
+			}
+
+			resp := client.ContextComparison(t, param)
+			m.In(t).Assert(resp.Equals, m.Equal(false))
+		})
+
+		t.Run("are different if private attributes are not identical", func(t *ldtest.T) {
+			param := servicedef.ContextComparisonPairParams{
+				Context1: servicedef.ContextComparisonParams{
+					Single: &servicedef.ContextComparisonSingleParams{Kind: "user", Key: "user-key",
+						PrivateAttributes: []servicedef.PrivateAttribute{{Value: "name", Literal: false}}},
+				},
+				Context2: servicedef.ContextComparisonParams{
+					Single: &servicedef.ContextComparisonSingleParams{Kind: "user", Key: "user-key",
+						PrivateAttributes: []servicedef.PrivateAttribute{{Value: "/address/street", Literal: false}}},
+				},
+			}
+
+			resp := client.ContextComparison(t, param)
+			m.In(t).Assert(resp.Equals, m.Equal(false))
+		})
+
 		t.Run("are different if kinds are different", func(t *ldtest.T) {
 			param := servicedef.ContextComparisonPairParams{
 				Context1: servicedef.ContextComparisonParams{

--- a/servicedef/command_params.go
+++ b/servicedef/command_params.go
@@ -140,7 +140,7 @@ type ContextComparisonSingleParams struct {
 	Kind              string                `json:"kind"`
 	Key               string                `json:"key"`
 	Attributes        []AttributeDefinition `json:"attributes,omitempty"`
-	PrivateAttributes []PrivateAttribute    `json:"privateAttributes:omitempty"`
+	PrivateAttributes []PrivateAttribute    `json:"privateAttributes,omitempty"`
 }
 
 type AttributeDefinition struct {


### PR DESCRIPTION
## Summary

`ContextComparisonSingleParams.PrivateAttributes` used a colon instead of a comma in its struct tag (`json:"privateAttributes:omitempty"`). Go treats the whole string as the field name, so the field marshaled to the wire key `privateAttributes:omitempty` instead of `privateAttributes`, and `omitempty` was silently ignored. As a result the harness never sent private attributes to SDK test services for the `contextComparison` command, and the context-comparison private-attribute assertions passed vacuously.

This corrects the tag to `json:"privateAttributes,omitempty"` and adds two negative context-comparison tests where private attributes are the sole differentiator (two otherwise-identical contexts expected to be *not* equal). The existing suite only asserted the equal direction, which cannot detect an SDK that drops private attributes.

Verified on the v2 line by running the affected suite (`context type/compare`) against the flutter-client-sdk contract service: 16 tests run, all pass, including the two new negative tests. This is the v3 backport of that fix.

Capability exercised: `context-comparison` (declared today by ruby-server-sdk, flutter-client-sdk, ios-client-sdk).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small harness serialization fix and contract tests only; no production SDK runtime behavior in this repo.
> 
> **Overview**
> Fixes a typo in `ContextComparisonSingleParams.PrivateAttributes` so the harness marshals **`privateAttributes`** on `contextComparison` commands instead of the invalid key `privateAttributes:omitempty`, which had prevented private attributes from reaching SDK test services.
> 
> Adds two **context compare** tests that expect contexts **not** equal when private attributes are missing on one side or differ, so SDKs that ignore private attributes can no longer pass the suite vacuously.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7220f5d076a5f76eedf697c09ced7be7b3e6c79a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->