### PR TITLE
feat: add client-side streaming retry and error-recovery contract tests

### DIFF
--- a/sdktests/client_side_stream_all.go
+++ b/sdktests/client_side_stream_all.go
@@ -15,6 +15,7 @@ import (
 func doClientSideStreamTests(t *ldtest.T) {
 	t.Run("requests", doClientSideStreamRequestTest)
 	t.Run("updates", doClientSideStreamUpdateTests)
+	t.Run("retry behavior", doClientSideStreamRetryTests)
 }
 
 func doClientSideStreamRequestTest(t *ldtest.T) {

--- a/sdktests/client_side_stream_retry.go
+++ b/sdktests/client_side_stream_retry.go
@@ -35,7 +35,11 @@ func doClientSideStreamRetryTests(t *ldtest.T) {
 	// happen quickly - but, execution speed is always unpredictable, so we'll use a timeout for
 	// these that is much longer than we expect we'll need. That won't make the tests run any slower
 	// than they otherwise would unless the SDK really is hanging and not reconnecting.
-	incomingConnectionTimeout := time.Second * 2
+	//
+	// This timeout is deliberately more generous than the server-side equivalent: not every
+	// client-side SDK supports configuring the stream retry delay, and with a default initial
+	// delay of about a second, exponential backoff can put the third retry several seconds out.
+	incomingConnectionTimeout := time.Second * 10
 
 	// When we're asserting "there are no more connections", we should use a timeout that isn't too
 	// long because that *will* make successful tests run slow, but long enough that we have a
@@ -178,6 +182,10 @@ func doClientSideStreamRetryTests(t *ldtest.T) {
 	})
 
 	t.Run("do not retry after unrecoverable HTTP error on initial connect", func(t *ldtest.T) {
+		// Distinguishing unrecoverable HTTP errors requires the SDK's EventSource to expose
+		// response status codes; browser-native EventSource cannot, so SDKs without this
+		// capability treat every stream error as retryable.
+		t.RequireCapability(servicedef.CapabilityClientEventSourceHTTPErrors)
 		for _, status := range unrecoverableErrors {
 			t.Run(fmt.Sprintf("error %d", status), func(t *ldtest.T) {
 				stream := NewSDKDataSourceWithoutEndpoint(t, dataV1, DataSourceOptionStreaming())
@@ -199,6 +207,7 @@ func doClientSideStreamRetryTests(t *ldtest.T) {
 	})
 
 	t.Run("do not retry after unrecoverable HTTP error on reconnect", func(t *ldtest.T) {
+		t.RequireCapability(servicedef.CapabilityClientEventSourceHTTPErrors)
 		for _, status := range unrecoverableErrors {
 			t.Run(fmt.Sprintf("error %d", status), func(t *ldtest.T) {
 				stream := NewSDKDataSourceWithoutEndpoint(t, dataV1, DataSourceOptionStreaming())

--- a/sdktests/client_side_stream_retry.go
+++ b/sdktests/client_side_stream_retry.go
@@ -1,0 +1,229 @@
+package sdktests
+
+import (
+	"fmt"
+	"net/http"
+	"time"
+
+	"github.com/launchdarkly/sdk-test-harness/v2/framework/harness"
+	"github.com/launchdarkly/sdk-test-harness/v2/framework/ldtest"
+	o "github.com/launchdarkly/sdk-test-harness/v2/framework/opt"
+	"github.com/launchdarkly/sdk-test-harness/v2/mockld"
+	"github.com/launchdarkly/sdk-test-harness/v2/servicedef"
+
+	"github.com/launchdarkly/go-sdk-common/v3/ldcontext"
+	"github.com/launchdarkly/go-sdk-common/v3/ldvalue"
+
+	"github.com/launchdarkly/go-test-helpers/v2/httphelpers"
+	m "github.com/launchdarkly/go-test-helpers/v2/matchers"
+)
+
+func doClientSideStreamRetryTests(t *ldtest.T) {
+	c := NewCommonStreamingTests(t, "doClientSideStreamRetryTests")
+
+	recoverableErrors := []int{400, 408, 429, 500, 503}
+	unrecoverableErrors := []int{401, 403, 405} // really all 4xx errors that aren't 400, 408, or 429
+
+	expectedValueV1 := ldvalue.Int(1)
+	expectedValueV2 := ldvalue.Int(2)
+	flagKey := "flag"
+	dataV1 := c.makeSDKDataWithFlag(flagKey, 1, expectedValueV1)
+	dataV2 := c.makeSDKDataWithFlag(flagKey, 2, expectedValueV2)
+	context := ldcontext.New("user-key")
+
+	// Because we're setting InitialRetryDelayMS to a very short delay, we expect reconnections to
+	// happen quickly - but, execution speed is always unpredictable, so we'll use a timeout for
+	// these that is much longer than we expect we'll need. That won't make the tests run any slower
+	// than they otherwise would unless the SDK really is hanging and not reconnecting.
+	incomingConnectionTimeout := time.Second * 2
+
+	// When we're asserting "there are no more connections", we should use a timeout that isn't too
+	// long because that *will* make successful tests run slow, but long enough that we have a
+	// reasonable chance of detecting an inappropriate retry that happened promptly.
+	noMoreConnectionsTimeout := time.Millisecond * 100
+
+	// Creates a mock streaming endpoint with the given handler, plus whatever secondary data source
+	// configuration each kind of client-side SDK requires (see CommonStreamingTests.setupDataSources):
+	// mobile SDKs need to be told where the polling service is even in streaming mode, and JS-based
+	// client-side SDKs get their initial data by polling before they connect to the stream.
+	makeStreamEndpointAndConfigurers := func(
+		t *ldtest.T,
+		handler http.Handler,
+		initialData mockld.SDKData,
+	) (*harness.MockEndpoint, []SDKConfigurer) {
+		streamEndpoint := requireContext(t).harness.NewMockEndpoint(handler, t.DebugLogger(),
+			harness.MockEndpointDescription("streaming service"))
+		t.Defer(streamEndpoint.Close)
+
+		configurers := []SDKConfigurer{WithStreamingConfig(baseStreamConfig(streamEndpoint))}
+		switch c.sdkKind {
+		case mockld.JSClientSDK:
+			configurers = append(configurers, NewSDKDataSource(t, initialData, DataSourceOptionPolling()))
+		default:
+			configurers = append(configurers, NewSDKDataSource(t, nil, DataSourceOptionPolling()))
+		}
+		return streamEndpoint, configurers
+	}
+
+	t.Run("retry after stream is closed", func(t *ldtest.T) {
+		stream1 := NewSDKDataSourceWithoutEndpoint(t, dataV1, DataSourceOptionStreaming())
+		stream2 := NewSDKDataSourceWithoutEndpoint(t, dataV2, DataSourceOptionStreaming())
+		handler := httphelpers.SequentialHandler(
+			stream1.Handler(), // first request gets the first stream data
+			stream2.Handler(), // second request gets the second stream data
+		)
+		streamEndpoint, configurers := makeStreamEndpointAndConfigurers(t, handler, dataV1)
+
+		client := NewSDKClient(t, c.baseSDKConfigurationPlus(configurers...)...)
+		result := client.EvaluateAllFlags(t, servicedef.EvaluateAllFlagsParams{Context: o.Some(context)})
+		m.In(t).Assert(result, EvalAllFlagsValueForKeyShouldEqual(flagKey, expectedValueV1))
+
+		// Get the request info for the first request
+		request1 := streamEndpoint.RequireConnection(t, incomingConnectionTimeout)
+
+		// Now cause the stream to close; this should trigger a reconnect
+		request1.Cancel()
+
+		// Expect the second request; it succeeds and gets the second stream data
+		_ = streamEndpoint.RequireConnection(t, incomingConnectionTimeout)
+
+		// Check that the client got the new data from the second stream
+		pollUntilFlagValueUpdated(t, client, flagKey, context, expectedValueV1, expectedValueV2, ldvalue.Null())
+	})
+
+	// Client-side SDKs generally resolve their initialization as soon as the first data source
+	// connection attempt completes, even if the failure is one that the data source will retry -
+	// blocking application startup on retries would not be appropriate on a mobile device. So,
+	// unlike the equivalent server-side tests, we create the client with InitCanFail and then
+	// verify that the SDK keeps retrying in the background and eventually gets the flag data.
+	shouldRetryAfterErrorOnInitialConnect := func(t *ldtest.T, errorHandler http.Handler) {
+		stream := NewSDKDataSourceWithoutEndpoint(t, dataV1, DataSourceOptionStreaming())
+		handler := httphelpers.SequentialHandler(
+			errorHandler,     // first request gets the error
+			errorHandler,     // second request also gets the error
+			stream.Handler(), // third request succeeds and gets the stream
+		)
+		streamEndpoint, configurers := makeStreamEndpointAndConfigurers(t, handler, dataV1)
+
+		client := NewSDKClient(t, append(
+			[]SDKConfigurer{WithConfig(servicedef.SDKConfigParams{InitCanFail: true})},
+			c.baseSDKConfigurationPlus(configurers...)...)...)
+
+		for i := 0; i < 3; i++ { // expect three requests
+			_ = streamEndpoint.RequireConnection(t, incomingConnectionTimeout)
+		}
+
+		streamEndpoint.RequireNoMoreConnections(t, noMoreConnectionsTimeout)
+
+		// The third connection got the stream data, so the flag value should show up promptly
+		pollUntilFlagValueUpdated(t, client, flagKey, context, ldvalue.Null(), expectedValueV1, ldvalue.Null())
+	}
+
+	t.Run("retry after IO error on initial connect", func(t *ldtest.T) {
+		shouldRetryAfterErrorOnInitialConnect(t, httphelpers.BrokenConnectionHandler())
+	})
+
+	t.Run("retry after recoverable HTTP error on initial connect", func(t *ldtest.T) {
+		for _, status := range recoverableErrors {
+			t.Run(fmt.Sprintf("error %d", status), func(t *ldtest.T) {
+				shouldRetryAfterErrorOnInitialConnect(t, httphelpers.HandlerWithStatus(status))
+			})
+		}
+	})
+
+	shouldRetryAfterErrorOnReconnect := func(t *ldtest.T, errorHandler http.Handler) {
+		stream1 := NewSDKDataSourceWithoutEndpoint(t, dataV1, DataSourceOptionStreaming())
+		stream2 := NewSDKDataSourceWithoutEndpoint(t, dataV2, DataSourceOptionStreaming())
+		handler := httphelpers.SequentialHandler(
+			stream1.Handler(), // first request gets the first stream data
+			errorHandler,      // second request gets the error
+			errorHandler,      // third request also gets the error
+			stream2.Handler(), // fourth request gets the second stream data
+		)
+		streamEndpoint, configurers := makeStreamEndpointAndConfigurers(t, handler, dataV1)
+
+		client := NewSDKClient(t, c.baseSDKConfigurationPlus(configurers...)...)
+		result := client.EvaluateAllFlags(t, servicedef.EvaluateAllFlagsParams{Context: o.Some(context)})
+		m.In(t).Assert(result, EvalAllFlagsValueForKeyShouldEqual(flagKey, expectedValueV1))
+
+		// Get the request info for the first request
+		request1 := streamEndpoint.RequireConnection(t, incomingConnectionTimeout)
+
+		// Now cause the stream to close; this should trigger a reconnect
+		request1.Cancel()
+
+		// Expect the second request; it will receive an error, causing another attempt
+		_ = streamEndpoint.RequireConnection(t, incomingConnectionTimeout)
+
+		// Expect the third request; it will also receive an error, causing another attempt
+		_ = streamEndpoint.RequireConnection(t, incomingConnectionTimeout)
+
+		// Expect the fourth request; this one succeeds and gets the second stream data
+		_ = streamEndpoint.RequireConnection(t, incomingConnectionTimeout)
+
+		// Check that the client got the new data from the second stream
+		pollUntilFlagValueUpdated(t, client, flagKey, context, expectedValueV1, expectedValueV2, ldvalue.Null())
+	}
+
+	t.Run("retry after IO error on reconnect", func(t *ldtest.T) {
+		shouldRetryAfterErrorOnReconnect(t, httphelpers.BrokenConnectionHandler())
+	})
+
+	t.Run("retry after recoverable HTTP error on reconnect", func(t *ldtest.T) {
+		for _, status := range recoverableErrors {
+			t.Run(fmt.Sprintf("error %d", status), func(t *ldtest.T) {
+				shouldRetryAfterErrorOnReconnect(t, httphelpers.HandlerWithStatus(status))
+			})
+		}
+	})
+
+	t.Run("do not retry after unrecoverable HTTP error on initial connect", func(t *ldtest.T) {
+		for _, status := range unrecoverableErrors {
+			t.Run(fmt.Sprintf("error %d", status), func(t *ldtest.T) {
+				stream := NewSDKDataSourceWithoutEndpoint(t, dataV1, DataSourceOptionStreaming())
+				handler := httphelpers.SequentialHandler(
+					httphelpers.HandlerWithStatus(status), // first request gets the error
+					stream.Handler(),                      // second request would succeed and get the stream, but shouldn't happen
+				)
+				streamEndpoint, configurers := makeStreamEndpointAndConfigurers(t, handler, dataV1)
+
+				_ = NewSDKClient(t, append(
+					[]SDKConfigurer{WithConfig(servicedef.SDKConfigParams{InitCanFail: true})},
+					c.baseSDKConfigurationPlus(configurers...)...)...)
+
+				_ = streamEndpoint.RequireConnection(t, incomingConnectionTimeout)
+
+				streamEndpoint.RequireNoMoreConnections(t, noMoreConnectionsTimeout)
+			})
+		}
+	})
+
+	t.Run("do not retry after unrecoverable HTTP error on reconnect", func(t *ldtest.T) {
+		for _, status := range unrecoverableErrors {
+			t.Run(fmt.Sprintf("error %d", status), func(t *ldtest.T) {
+				stream := NewSDKDataSourceWithoutEndpoint(t, dataV1, DataSourceOptionStreaming())
+				handler := httphelpers.SequentialHandler(
+					stream.Handler(),                      // first request gets the stream data
+					httphelpers.HandlerWithStatus(status), // second request gets the error
+					stream.Handler(),                      // third request would get the stream again, but shouldn't happen
+				)
+				streamEndpoint, configurers := makeStreamEndpointAndConfigurers(t, handler, dataV1)
+
+				client := NewSDKClient(t, c.baseSDKConfigurationPlus(configurers...)...)
+				result := client.EvaluateAllFlags(t, servicedef.EvaluateAllFlagsParams{Context: o.Some(context)})
+				m.In(t).Assert(result, EvalAllFlagsValueForKeyShouldEqual(flagKey, expectedValueV1))
+
+				// Get the request info for the first request
+				request1 := streamEndpoint.RequireConnection(t, incomingConnectionTimeout)
+
+				// Now cause the stream to close; this should trigger a reconnect
+				request1.Cancel()
+
+				// Expect the second request; it will receive an error
+				_ = streamEndpoint.RequireConnection(t, incomingConnectionTimeout)
+
+				streamEndpoint.RequireNoMoreConnections(t, noMoreConnectionsTimeout)
+			})
+		}
+	})
+}

--- a/sdktests/client_side_stream_retry.go
+++ b/sdktests/client_side_stream_retry.go
@@ -6,6 +6,7 @@ import (
 	"time"
 
 	"github.com/launchdarkly/sdk-test-harness/v2/framework/harness"
+	h "github.com/launchdarkly/sdk-test-harness/v2/framework/helpers"
 	"github.com/launchdarkly/sdk-test-harness/v2/framework/ldtest"
 	o "github.com/launchdarkly/sdk-test-harness/v2/framework/opt"
 	"github.com/launchdarkly/sdk-test-harness/v2/mockld"
@@ -100,8 +101,12 @@ func doClientSideStreamRetryTests(t *ldtest.T) {
 	// blocking application startup on retries would not be appropriate on a mobile device. So,
 	// unlike the equivalent server-side tests, we create the client with InitCanFail and then
 	// verify that the SDK keeps retrying in the background and eventually gets the flag data.
+	//
+	// The stream serves dataV2 while the polling service (which JS-based SDKs consult for their
+	// initial data before connecting to the stream) has dataV1, so seeing expectedValueV2 proves
+	// the data came from the successful stream connection rather than from the initial poll.
 	shouldRetryAfterErrorOnInitialConnect := func(t *ldtest.T, errorHandler http.Handler) {
-		stream := NewSDKDataSourceWithoutEndpoint(t, dataV1, DataSourceOptionStreaming())
+		stream := NewSDKDataSourceWithoutEndpoint(t, dataV2, DataSourceOptionStreaming())
 		handler := httphelpers.SequentialHandler(
 			errorHandler,     // first request gets the error
 			errorHandler,     // second request also gets the error
@@ -120,7 +125,9 @@ func doClientSideStreamRetryTests(t *ldtest.T) {
 		streamEndpoint.RequireNoMoreConnections(t, noMoreConnectionsTimeout)
 
 		// The third connection got the stream data, so the flag value should show up promptly
-		pollUntilFlagValueUpdated(t, client, flagKey, context, ldvalue.Null(), expectedValueV1, ldvalue.Null())
+		h.RequireEventually(t, func() bool {
+			return basicEvaluateFlag(t, client, flagKey, context, ldvalue.Null()).Equal(expectedValueV2)
+		}, time.Second*5, time.Millisecond*50, "timed out without seeing flag data from the stream")
 	}
 
 	t.Run("retry after IO error on initial connect", func(t *ldtest.T) {

--- a/servicedef/service_params.go
+++ b/servicedef/service_params.go
@@ -63,6 +63,13 @@ const (
 	// path as the only CA cert in its trust store (rather than adding it to an existing trust store.)
 	CapabilityTLSCustomCA = "tls:custom-ca"
 
+	// CapabilityClientEventSourceHTTPErrors indicates a client-side SDK's EventSource
+	// implementation can detect HTTP error status codes (e.g. 401) and response headers.
+	// Browser-native EventSource does not expose this information, so browser SDKs
+	// typically lack this capability. Only checked for client-side SDKs; server-side
+	// SDKs do not need to declare it.
+	CapabilityClientEventSourceHTTPErrors = "client-event-source-http-errors"
+
 	CapabilityOmitAnonymousContexts = "omit-anonymous-contexts"
 
 	// CapabilityWrapper indicates that the SDK supports setting wrapper name and version and including them in request


### PR DESCRIPTION
The client-side test suite covers stream requests and updates but has no coverage of reconnection behavior: nothing checks that a client-side SDK retries the stream after a recoverable failure (IO error, 400, 408, 429, 5xx) or that it stops after an unrecoverable one (other 4xx). The server-side suite has had these tests for years (`server_side_stream_retry.go`). This gap is not hypothetical: the Android SDK's legacy streaming data source treats **all** 4xx statuses as non-retriable, so a single 429 on the stream connection permanently kills the stream until an app lifecycle event happens to rebuild the data source ([SDK-2824](https://launchdarkly.atlassian.net/browse/SDK-2824)).

This adds `streaming/retry behavior` tests for client-side SDKs, mirroring the server-side ones:

- retry after the stream is closed by the server
- retry after IO errors and recoverable HTTP errors (400, 408, 429, 500, 503), on initial connect and on reconnect
- no retry after unrecoverable HTTP errors (401, 403, 405), on initial connect and on reconnect

Three structural differences from the server-side versions, all found by running against real SDKs:

1. **Init semantics.** Client-side SDKs resolve initialization as soon as the first connection attempt completes rather than blocking through retries, so the initial-connect tests create the client with `initCanFail` and then verify that the SDK keeps retrying in the background and eventually serves the flag data.
2. **Status visibility.** Browser-native EventSource does not expose HTTP status codes, so browser SDKs cannot distinguish unrecoverable errors. The `client-event-source-http-errors` capability is ported from the v3 harness and gates the two do-not-retry groups. SDKs whose event sources do expose status codes should declare it (the Android service already does).
3. **Retry-delay configurability.** Not every client-side SDK supports configuring the stream retry delay (Flutter's FDv1 data source has no such option), so the incoming-connection wait is 10s rather than 2s. This costs nothing for SDKs that honor the configured delay, since the wait returns as soon as the connection arrives.

## Verification against real SDKs

Ran `streaming/retry behavior` locally against seven client-side SDK implementations:

| SDK | Result |
|---|---|
| **Android `main` (bug present)** | Exactly the six recoverable-4xx cases fail: 400/408/429 on initial connect and on reconnect. Everything else passes, so the tests isolate the bug. |
| **Android fix branch** (`rlamb/sdk-2824/fdv1-stream-429-recoverable`) | All 25 pass; full `streaming` category (68 tests) also passes |
| .NET client (`dotnet-core` main) | All pass; do-not-retry groups verified passing before the capability gate was added, skipped after, pending capability declaration in the service |
| Flutter (main) | All 25 pass |
| js-core node-client (main) | All pass (do-not-retry groups verified passing before the capability gate was added; skipped after, pending capability declaration in the service) |
| js-core browser (main, headless Chromium) | All pass; do-not-retry groups skip via the capability gate (native EventSource hides statuses) |
| C++ client (main) | All pass; do-not-retry groups skip pending capability declaration in the service |
| Legacy node-client-sdk (main) | All pass; do-not-retry groups skip pending capability declaration in the service |

iOS and Roku could not be exercised locally (macOS/device requirements).

[SDK-2824]: https://launchdarkly.atlassian.net/browse/SDK-2824?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-harness and capability-definition changes only; no production SDK or runtime behavior in this repo.
> 
> **Overview**
> Adds a **`streaming/retry behavior`** suite for client-side SDKs, aligned with the existing server-side retry tests, so harnesses can verify reconnect after recoverable failures and no further retries after unrecoverable HTTP errors.
> 
> The new **`doClientSideStreamRetryTests`** covers server-initiated stream close, IO and recoverable status codes (400, 408, 429, 5xx) on first connect and on reconnect, and—when the SDK declares **`client-event-source-http-errors`**—401/403/405 cases that must not retry. Client-specific behavior is baked in: **`InitCanFail`** plus background retry assertions on initial connect, JS polling vs stream data to prove updates came from the stream, and a longer connection wait (10s) when retry delay is not configurable.
> 
> Registers the suite under **`doClientSideStreamTests`** and documents **`CapabilityClientEventSourceHTTPErrors`** in **`servicedef`** for SDKs whose EventSource can read HTTP status (browser-native EventSource cannot).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d471022298270fcb943386bd066bf881bb8fed7f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->
