### PR TITLE
feat: RETRY-conformance contract tests for FDv1 streaming and polling

### DIFF
--- a/sdktests/server_side_poll_all.go
+++ b/sdktests/server_side_poll_all.go
@@ -16,6 +16,7 @@ func doServerSidePollTests(t *ldtest.T) {
 	t.Run("interval", func(t *ldtest.T) {
 		doPollIntervalTests(t, WithCredential("my-sdk-key"))
 	})
+	t.Run("retry behavior", doServerSidePollRetryTests)
 }
 
 func doServerSidePollRequestTests(t *ldtest.T) {

--- a/sdktests/server_side_poll_retry.go
+++ b/sdktests/server_side_poll_retry.go
@@ -1,0 +1,92 @@
+package sdktests
+
+import (
+	"fmt"
+	"net/http"
+	"time"
+
+	"github.com/launchdarkly/sdk-test-harness/v2/framework/harness"
+	"github.com/launchdarkly/sdk-test-harness/v2/framework/ldtest"
+	o "github.com/launchdarkly/sdk-test-harness/v2/framework/opt"
+	"github.com/launchdarkly/sdk-test-harness/v2/mockld"
+	"github.com/launchdarkly/sdk-test-harness/v2/servicedef"
+
+	"github.com/launchdarkly/go-sdk-common/v3/ldcontext"
+	"github.com/launchdarkly/go-sdk-common/v3/ldvalue"
+
+	"github.com/launchdarkly/go-test-helpers/v2/httphelpers"
+	m "github.com/launchdarkly/go-test-helpers/v2/matchers"
+)
+
+// doServerSidePollRetryTests exercises the RETRY specification's non-permanent-stop guarantee
+// for the FDv1 server-side polling data source. Server-side polling enforces a PollInterval
+// minimum of 30 seconds, so tests here inherently take tens of seconds per iteration and are
+// marked LongRunning.
+//
+// This first pass covers the core guarantee (no permanent stop after an unexpected HTTP error);
+// additional polling scenarios (extended-regime shape, reset after 2 consecutive successful
+// polls) are deferred to follow-up work.
+func doServerSidePollRetryTests(t *ldtest.T) {
+	t.RequireCapability(servicedef.CapabilityServerSidePolling)
+	t.RequireCapability(servicedef.CapabilityRetryConformanceFDv1Polling)
+	t.LongRunning() // polling waits are >= 30 seconds per iteration
+
+	unexpectedErrors := []int{401, 403, 405}
+
+	expectedValue := ldvalue.Int(1)
+	flagKey := "flag"
+	flagV1, _ := makeFlagVersionsWithValues(flagKey, 1, 2, expectedValue, ldvalue.Int(2))
+	dataV1 := mockld.NewServerSDKDataBuilder().Flag(flagV1).Build()
+	context := ldcontext.New("user-key")
+
+	// pollingRecoveryTimeout is a generous ceiling for observing the second poll request after
+	// an unexpected error. It must exceed the SDK's extended-regime initial delay for polling,
+	// which is max(ExtendedInitialDelayMS, PollInterval). With PollInterval at the server-side
+	// minimum of 30 s, the effective delay is 30 s; the SDK's actual retry has jitter and
+	// platform variance on top. 90 s covers this with generous headroom.
+	pollingRecoveryTimeout := 90 * time.Second
+
+	// initialPollTimeout bounds the SDK's initial poll (no backoff involved; happens on client
+	// construction).
+	initialPollTimeout := 15 * time.Second
+
+	makePollEndpoint := func(t *ldtest.T, handler http.Handler) *harness.MockEndpoint {
+		return requireContext(t).harness.NewMockEndpoint(handler, t.DebugLogger(),
+			harness.MockEndpointDescription("polling service"))
+	}
+
+	basePollConfig := func(endpoint *harness.MockEndpoint) servicedef.SDKConfigPollingParams {
+		return servicedef.SDKConfigPollingParams{
+			BaseURI:                endpoint.BaseURL(),
+			ExtendedInitialDelayMS: o.Some(compressedExtendedInitialDelay),
+		}
+	}
+
+	t.Run("retry after unexpected HTTP error on initial poll", func(t *ldtest.T) {
+		for _, status := range unexpectedErrors {
+			t.Run(fmt.Sprintf("error %d", status), func(t *ldtest.T) {
+				dataSystem := NewSDKDataSystemWithoutEndpoints(t, dataV1, DataSystemOptionPolling())
+				handler := httphelpers.SequentialHandler(
+					httphelpers.HandlerWithStatus(status), // 1st: error
+					dataSystem.Synchronizers[0].polling,   // 2nd: success (only reached if SDK retries)
+				)
+				pollEndpoint := makePollEndpoint(t, handler)
+				t.Defer(pollEndpoint.Close)
+
+				client := NewSDKClient(t, WithConfig(servicedef.SDKConfigParams{InitCanFail: true}),
+					WithPollingSynchronizer(basePollConfig(pollEndpoint)))
+
+				// First poll -> error
+				_ = pollEndpoint.RequireConnection(t, initialPollTimeout)
+
+				// Second poll should arrive within the extended-regime window, proving the SDK
+				// did not permanently stop after the unexpected error.
+				_ = pollEndpoint.RequireConnection(t, pollingRecoveryTimeout)
+
+				// SDK reaches ready and evaluates against the second poll's data.
+				result := client.EvaluateAllFlags(t, servicedef.EvaluateAllFlagsParams{Context: o.Some(context)})
+				m.In(t).Assert(result, EvalAllFlagsValueForKeyShouldEqual(flagKey, expectedValue))
+			})
+		}
+	})
+}

--- a/sdktests/server_side_stream_retry.go
+++ b/sdktests/server_side_stream_retry.go
@@ -28,6 +28,24 @@ func baseStreamConfig(endpoint *harness.MockEndpoint) servicedef.SDKConfigStream
 	}
 }
 
+// compressedExtendedInitialDelay is the value used for ExtendedInitialDelayMS in
+// retry-conformance tests. Compressed from the SDK's production default of 5 minutes
+// so tests can observe extended-regime engagement in a few seconds. Chosen at 500 ms
+// to be well above the paired-bound "no more connections" window (100 ms) and low enough
+// to keep tests fast.
+const compressedExtendedInitialDelay ldtime.UnixMillisecondTime = 500
+
+// retryConformanceStreamConfig returns a streaming config that compresses both the normal-regime
+// initial delay and the extended-regime initial delay to observable values. Used by tests guarded
+// by CapabilityRetryConformanceFDv1Streaming.
+func retryConformanceStreamConfig(endpoint *harness.MockEndpoint) servicedef.SDKConfigStreamingParams {
+	return servicedef.SDKConfigStreamingParams{
+		BaseURI:                endpoint.BaseURL(),
+		InitialRetryDelayMS:    o.Some(briefDelay),
+		ExtendedInitialDelayMS: o.Some(compressedExtendedInitialDelay),
+	}
+}
+
 func doServerSideStreamRetryTests(t *ldtest.T) {
 	recoverableErrors := []int{400, 408, 429, 500, 503}
 	unexpectedErrors := []int{401, 403, 405} // really all 4xx errors that aren't 400, 408, or 429
@@ -198,6 +216,119 @@ func doServerSideStreamRetryTests(t *ldtest.T) {
 			t.Run(fmt.Sprintf("error %d", status), func(t *ldtest.T) {
 				shouldRetryAfterErrorOnReconnect(t, httphelpers.HandlerWithStatus(status))
 			})
+		}
+	})
+
+	// extendedRegimeConnectionTimeout is used when waiting for a reconnect during extended-regime
+	// backoff. Set generously above the compressed ExtendedInitialDelayMS (500 ms) plus any
+	// doubling to tolerate CI variance.
+	extendedRegimeConnectionTimeout := time.Second * 3
+
+	// The following retry-conformance tests are guarded by CapabilityRetryConformanceFDv1Streaming
+	// being PRESENT. They assert RETRY-conformant behavior: unexpected HTTP errors trigger an
+	// extended-regime backoff (retry with a longer delay) rather than a permanent stop.
+	t.Run("retry after unexpected HTTP error on initial connect", func(t *ldtest.T) {
+		t.RequireCapability(servicedef.CapabilityRetryConformanceFDv1Streaming)
+		for _, status := range unexpectedErrors {
+			t.Run(fmt.Sprintf("error %d", status), func(t *ldtest.T) {
+				dataSystem := NewSDKDataSystemWithoutEndpoints(t, dataV1)
+				handler := httphelpers.SequentialHandler(
+					httphelpers.HandlerWithStatus(status), // 1st: error
+					httphelpers.HandlerWithStatus(status), // 2nd: error
+					dataSystem.Synchronizers[0].streaming, // 3rd: success
+				)
+				streamEndpoint := makeStreamEndpoint(t, handler)
+				t.Defer(streamEndpoint.Close)
+
+				client := NewSDKClient(t, WithStreamingSynchronizer(retryConformanceStreamConfig(streamEndpoint)))
+				result := client.EvaluateAllFlags(t, servicedef.EvaluateAllFlagsParams{Context: o.Some(context)})
+				m.In(t).Assert(result, EvalAllFlagsValueForKeyShouldEqual(flagKey, expectedValueV1))
+
+				for i := 0; i < 3; i++ { // expect three requests
+					_ = streamEndpoint.RequireConnection(t, extendedRegimeConnectionTimeout)
+				}
+			})
+		}
+	})
+
+	t.Run("retry after unexpected HTTP error on reconnect", func(t *ldtest.T) {
+		t.RequireCapability(servicedef.CapabilityRetryConformanceFDv1Streaming)
+		for _, status := range unexpectedErrors {
+			t.Run(fmt.Sprintf("error %d", status), func(t *ldtest.T) {
+				dataSystem1 := NewSDKDataSystemWithoutEndpoints(t, dataV1)
+				dataSystem2 := NewSDKDataSystemWithoutEndpoints(t, dataV2)
+				handler := httphelpers.SequentialHandler(
+					dataSystem1.Synchronizers[0].streaming, // 1st: first stream data
+					httphelpers.HandlerWithStatus(status),  // 2nd: error
+					httphelpers.HandlerWithStatus(status),  // 3rd: error
+					dataSystem2.Synchronizers[0].streaming, // 4th: second stream data
+				)
+				streamEndpoint := makeStreamEndpoint(t, handler)
+				t.Defer(streamEndpoint.Close)
+
+				client := NewSDKClient(t, WithStreamingSynchronizer(retryConformanceStreamConfig(streamEndpoint)))
+				result := client.EvaluateAllFlags(t, servicedef.EvaluateAllFlagsParams{Context: o.Some(context)})
+				m.In(t).Assert(result, EvalAllFlagsValueForKeyShouldEqual(flagKey, expectedValueV1))
+
+				// Cause the initial stream to close; triggers reconnect
+				request1 := streamEndpoint.RequireConnection(t, incomingConnectionTimeout)
+				request1.Cancel()
+
+				// Two error responses, then a successful reconnect at extended-regime timing
+				_ = streamEndpoint.RequireConnection(t, extendedRegimeConnectionTimeout) // 2nd (error)
+				_ = streamEndpoint.RequireConnection(t, extendedRegimeConnectionTimeout) // 3rd (error)
+				_ = streamEndpoint.RequireConnection(t, extendedRegimeConnectionTimeout) // 4th (success)
+
+				pollUntilFlagValueUpdated(t, client, flagKey, context, expectedValueV1, expectedValueV2, ldvalue.Null())
+			})
+		}
+	})
+
+	t.Run("enters extended-regime backoff after unexpected HTTP error", func(t *ldtest.T) {
+		// Paired-bound assertion: after an unexpected error, the SDK MUST NOT retry at
+		// normal-regime timing (which would be ~briefDelay = 1 ms), AND MUST eventually retry
+		// (proving it hasn't permanently stopped). The 100 ms "no more connections" window is
+		// well above briefDelay (100x) and well below compressedExtendedInitialDelay (20% of
+		// 500 ms) -- a clean discriminating window.
+		t.RequireCapability(servicedef.CapabilityRetryConformanceFDv1Streaming)
+		dataSystem := NewSDKDataSystemWithoutEndpoints(t, dataV1)
+		handler := httphelpers.SequentialHandler(
+			httphelpers.HandlerWithStatus(401), // 1st: unexpected error
+			dataSystem.Synchronizers[0].streaming, // 2nd: success (only reached if SDK retries)
+		)
+		streamEndpoint := makeStreamEndpoint(t, handler)
+		t.Defer(streamEndpoint.Close)
+
+		_ = NewSDKClient(t, WithConfig(servicedef.SDKConfigParams{InitCanFail: true}),
+			WithStreamingSynchronizer(retryConformanceStreamConfig(streamEndpoint)))
+
+		// 1st connection produces the 401
+		_ = streamEndpoint.RequireConnection(t, incomingConnectionTimeout)
+
+		// Assertion A: SDK does NOT reconnect within the normal-regime window (100 ms).
+		// If the SDK were retrying at normal-regime timing (1 ms) it would already have reconnected.
+		streamEndpoint.RequireNoMoreConnections(t, noMoreConnectionsTimeout)
+
+		// Assertion B: SDK DOES reconnect within the extended-regime window (3 s).
+		// If the SDK had permanently stopped, this would fail.
+		_ = streamEndpoint.RequireConnection(t, extendedRegimeConnectionTimeout)
+	})
+
+	t.Run("does not permanently stop under sustained unexpected HTTP errors", func(t *ldtest.T) {
+		// Endpoint returns 401 to every request. SDK should keep retrying at extended-regime
+		// cadence. Assert multiple connections observed within a bounded window (proves
+		// repeated retry) and one more still arrives at the end (proves not permanently stopped).
+		t.RequireCapability(servicedef.CapabilityRetryConformanceFDv1Streaming)
+		streamEndpoint := makeStreamEndpoint(t, httphelpers.HandlerWithStatus(401))
+		t.Defer(streamEndpoint.Close)
+
+		_ = NewSDKClient(t, WithConfig(servicedef.SDKConfigParams{InitCanFail: true}),
+			WithStreamingSynchronizer(retryConformanceStreamConfig(streamEndpoint)))
+
+		// Observe at least 3 connections at extended-regime timing. Each takes ~500 ms; with
+		// doubling, total ~3.5 s in the worst case. Generous per-connection timeout.
+		for i := 0; i < 3; i++ {
+			_ = streamEndpoint.RequireConnection(t, extendedRegimeConnectionTimeout)
 		}
 	})
 

--- a/sdktests/server_side_stream_retry.go
+++ b/sdktests/server_side_stream_retry.go
@@ -30,7 +30,7 @@ func baseStreamConfig(endpoint *harness.MockEndpoint) servicedef.SDKConfigStream
 
 func doServerSideStreamRetryTests(t *ldtest.T) {
 	recoverableErrors := []int{400, 408, 429, 500, 503}
-	unrecoverableErrors := []int{401, 403, 405} // really all 4xx errors that aren't 400, 408, or 429
+	unexpectedErrors := []int{401, 403, 405} // really all 4xx errors that aren't 400, 408, or 429
 
 	expectedValueV1 := ldvalue.Int(1)
 	expectedValueV2 := ldvalue.Int(2)
@@ -201,8 +201,8 @@ func doServerSideStreamRetryTests(t *ldtest.T) {
 		}
 	})
 
-	t.Run("do not retry after unrecoverable HTTP error on initial connect", func(t *ldtest.T) {
-		for _, status := range unrecoverableErrors {
+	t.Run("do not retry after unexpected HTTP error on initial connect", func(t *ldtest.T) {
+		for _, status := range unexpectedErrors {
 			t.Run(fmt.Sprintf("error %d", status), func(t *ldtest.T) {
 				dataSystem := NewSDKDataSystemWithoutEndpoints(t, dataV1)
 				handler := httphelpers.SequentialHandler(
@@ -224,8 +224,8 @@ func doServerSideStreamRetryTests(t *ldtest.T) {
 		}
 	})
 
-	t.Run("do not retry after unrecoverable HTTP error on reconnect", func(t *ldtest.T) {
-		for _, status := range unrecoverableErrors {
+	t.Run("do not retry after unexpected HTTP error on reconnect", func(t *ldtest.T) {
+		for _, status := range unexpectedErrors {
 			t.Run(fmt.Sprintf("error %d", status), func(t *ldtest.T) {
 				dataSystem := NewSDKDataSystemWithoutEndpoints(t, dataV1)
 				handler := httphelpers.SequentialHandler(

--- a/sdktests/server_side_stream_retry.go
+++ b/sdktests/server_side_stream_retry.go
@@ -201,7 +201,19 @@ func doServerSideStreamRetryTests(t *ldtest.T) {
 		}
 	})
 
+	// The following two "do not retry" tests describe legacy behavior for SDKs that have not yet
+	// adopted the RETRY specification. Under RETRY, `401` / `403` / other `4xx` responses are
+	// classified as `unexpected` errors and trigger an extended-regime backoff rather than a
+	// permanent stop. These legacy tests are gated behind the ABSENCE of the
+	// `retry-conformance-fdv1-streaming` capability; SDKs that declare that capability run the
+	// new "retry after unexpected HTTP error" tests instead. Once every SDK reports the
+	// capability, these legacy tests can be removed.
 	t.Run("do not retry after unexpected HTTP error on initial connect", func(t *ldtest.T) {
+		if t.Capabilities().Has(servicedef.CapabilityRetryConformanceFDv1Streaming) {
+			t.SkipWithReason("SDK reports " + servicedef.CapabilityRetryConformanceFDv1Streaming +
+				"; legacy permanent-stop behavior does not apply")
+			return
+		}
 		for _, status := range unexpectedErrors {
 			t.Run(fmt.Sprintf("error %d", status), func(t *ldtest.T) {
 				dataSystem := NewSDKDataSystemWithoutEndpoints(t, dataV1)
@@ -225,6 +237,11 @@ func doServerSideStreamRetryTests(t *ldtest.T) {
 	})
 
 	t.Run("do not retry after unexpected HTTP error on reconnect", func(t *ldtest.T) {
+		if t.Capabilities().Has(servicedef.CapabilityRetryConformanceFDv1Streaming) {
+			t.SkipWithReason("SDK reports " + servicedef.CapabilityRetryConformanceFDv1Streaming +
+				"; legacy permanent-stop behavior does not apply")
+			return
+		}
 		for _, status := range unexpectedErrors {
 			t.Run(fmt.Sprintf("error %d", status), func(t *ldtest.T) {
 				dataSystem := NewSDKDataSystemWithoutEndpoints(t, dataV1)

--- a/servicedef/sdk_config.go
+++ b/servicedef/sdk_config.go
@@ -101,11 +101,33 @@ type SDKConfigServiceEndpointsParams struct {
 type SDKConfigStreamingParams struct {
 	BaseURI             string                              `json:"baseUri,omitempty"`
 	InitialRetryDelayMS o.Maybe[ldtime.UnixMillisecondTime] `json:"initialRetryDelayMs,omitempty"`
+
+	// ExtendedInitialDelayMS overrides the initial delay of the RETRY specification's extended
+	// regime (default 5 minutes in the SDK). Used by retry-conformance tests to compress the
+	// extended regime into an observable window. Only meaningful when the SDK declares
+	// CapabilityRetryConformanceFDv1Streaming.
+	ExtendedInitialDelayMS o.Maybe[ldtime.UnixMillisecondTime] `json:"extendedInitialDelayMs,omitempty"`
+
+	// ResetThresholdMS overrides the reset threshold that returns the streaming data source from
+	// the extended regime back to the normal regime (default 60 seconds in the SDK, measured as
+	// continuous healthy operation). Used by retry-conformance tests to compress the reset window
+	// into an observable duration. Only meaningful when the SDK declares
+	// CapabilityRetryConformanceFDv1Streaming.
+	ResetThresholdMS o.Maybe[ldtime.UnixMillisecondTime] `json:"resetThresholdMs,omitempty"`
 }
 
 type SDKConfigPollingParams struct {
 	BaseURI        string                              `json:"baseUri,omitempty"`
 	PollIntervalMS o.Maybe[ldtime.UnixMillisecondTime] `json:"pollIntervalMs,omitempty"`
+
+	// ExtendedInitialDelayMS overrides the initial delay of the RETRY specification's extended
+	// regime (default 5 minutes in the SDK, floored at PollInterval). Used by retry-conformance
+	// tests to compress the extended regime into an observable window. Only meaningful when the
+	// SDK declares CapabilityRetryConformanceFDv1Polling.
+	//
+	// Polling's reset condition is count-based (two consecutive successful poll responses) rather
+	// than time-based, so no ResetThresholdMS is needed on the polling params.
+	ExtendedInitialDelayMS o.Maybe[ldtime.UnixMillisecondTime] `json:"extendedInitialDelayMs,omitempty"`
 }
 
 type SDKConfigEventParams struct {

--- a/servicedef/service_params.go
+++ b/servicedef/service_params.go
@@ -98,6 +98,31 @@ const (
 	// implement the behavior can opt out, and so the tests can be decommissioned by dropping the
 	// capability from all SDK test services once it is ubiquitous.
 	CapabilityFDv1Fallback = "fdv1-fallback"
+
+	// CapabilityRetryConformanceFDv1Streaming indicates that the SDK's FDv1 streaming data source
+	// conforms to the RETRY specification: no HTTP response and no transport-level failure causes
+	// the data source to permanently cease operation. In particular, `401` / `403` / other `4xx`
+	// statuses and TLS/certificate validation failures now trigger an extended-regime backoff
+	// instead of a permanent stop.
+	//
+	// SDKs declaring this capability MUST also honor the extended-regime timing knobs exposed on
+	// SDKConfigStreamingParams (see ExtendedInitialDelayMS, ResetThresholdMS). The capability gates
+	// the new "retry-conformance" subtests. Legacy "do not retry after unexpected HTTP error"
+	// subtests are only run when this capability is absent; both sets of tests can be decommissioned
+	// once every SDK reports the capability.
+	CapabilityRetryConformanceFDv1Streaming = "retry-conformance-fdv1-streaming"
+
+	// CapabilityRetryConformanceFDv1Polling indicates that the SDK's FDv1 polling data source
+	// conforms to the RETRY specification: no HTTP response and no transport-level failure causes
+	// the data source to permanently cease operation. `401` / `403` / other `4xx` statuses and
+	// TLS/certificate validation failures trigger an extended-regime backoff floored at the
+	// customer-configured `PollInterval`.
+	//
+	// SDKs declaring this capability MUST also honor the extended-regime timing knob exposed on
+	// SDKConfigPollingParams (see ExtendedInitialDelayMS). The capability gates the new
+	// "retry-conformance" subtests and is scoped to the polling data source independently of the
+	// streaming capability so an SDK can partially adopt.
+	CapabilityRetryConformanceFDv1Polling = "retry-conformance-fdv1-polling"
 )
 
 type StatusRep struct {


### PR DESCRIPTION
## Summary

Adds contract test coverage for the RETRY specification's non-permanent-stop guarantee, applied to FDv1 streaming and polling data sources. Every SDK that adopts RETRY-conforming behavior will opt into these tests via the new capabilities; SDKs that have not yet adopted keep passing the existing legacy tests, unmodified in behavior.

Draft status: this PR can land test scaffolding, capabilities, and the tests themselves — but no SDK reports the new capabilities yet, so the new tests all skip today. The Go server SDK (reference implementation per the parent epic) will be the first SDK to opt in; that work happens separately.

## Design document

The implementation follows the plan at [`individual/tanderson/tickets/SDK-2808/implementation/plan.md`](https://github.com/launchdarkly/sdk-scratchpad/blob/main/individual/tanderson/tickets/SDK-2808/implementation/plan.md) in `sdk-scratchpad`.

## Structure — 6 commits

1. **`refactor: rename unrecoverableErrors to unexpectedErrors`** — terminology alignment with the RETRY specification. No behavior change.
2. **`feat: add retry-conformance-fdv1-{streaming,polling} capabilities`** — two new capabilities in `servicedef/service_params.go`, following the `CapabilityFDv1Fallback` pattern.
3. **`refactor: guard legacy "do not retry" tests behind capability absence`** — old permanent-stop tests now skip on SDKs that declare the RETRY-conformance capability. No SDK declares it today, so no test coverage changes.
4. **`feat: add ExtendedInitialDelayMS and ResetThresholdMS servicedef fields`** — test-mode timing knobs analogous to the existing `InitialRetryDelayMS`. Streaming gets both; polling gets only `ExtendedInitialDelayMS` (polling's reset is count-based).
5. **`test: server-side streaming retry-conformance scenarios`** — 4 new subtests: retry after 401/403/405 on initial connect, retry on reconnect, extended-regime engagement (paired-bound assertion), and sustained-failure no-permanent-stop.
6. **`test: server-side polling retry-conformance scenarios`** — 1 new subtest (functional recovery after 401/403/405), marked `LongRunning` because polling's PollInterval minimum forces 30 s+ per iteration.

## What's NOT in this PR

- **v2 port** — will follow as a separate PR after this one merges (paired-PR pattern used elsewhere in this repo for FDv1-relevant test additions). Sequential to avoid the v2 port becoming a moving target during this PR's review.
- **Client-side polling** (mobile foreground / background cadence, browser JS / PHP single-shot) — separate ticket, different test shape.
- **TLS / certificate validation failure scenarios** — separate ticket, requires TLS-specific mock infrastructure.
- **Additional polling scenarios** — extended-regime shape verification, wait-floor verification, reset after 2 consecutive successful polls. All feasible but each requires careful attention to LongRunning timing budgets. Deferred to follow-up.

## Capability gating

Each new test skips unless the SDK declares the corresponding capability:

- `retry-conformance-fdv1-streaming` — SDK's FDv1 streaming data source is RETRY-conformant AND honors `ExtendedInitialDelayMS` / `ResetThresholdMS` on `SDKConfigStreamingParams`.
- `retry-conformance-fdv1-polling` — SDK's FDv1 polling data source is RETRY-conformant AND honors `ExtendedInitialDelayMS` on `SDKConfigPollingParams`.

Legacy \"do not retry after unexpected HTTP error\" tests skip when the corresponding capability IS present (mirror gating). Once every SDK reports the capability, both the gate and the legacy tests can be decommissioned.

## Validation

- `go build ./...` — clean.
- `go vet ./...` — clean.
- `go test -c ./sdktests -o /dev/null` — clean.
- Runtime validation happens when the first SDK opts into the capability. That's not in this PR.

## Test plan

- [ ] Reviewer sanity-checks the capability naming and gating pattern.
- [ ] Reviewer confirms the timing pattern for the streaming paired-bound assertion is safe against CI variance.
- [ ] Reviewer confirms the `LongRunning` tagging on the polling test is the right pattern (or suggests an alternative).
- [ ] Once a RETRY-conformant SDK exists, run the new tests against it to validate the assertions exercise real behavior.