### PR TITLE
fix: Retry the test harness download and surface curl errors

### DIFF
--- a/downloader/run.sh
+++ b/downloader/run.sh
@@ -85,7 +85,9 @@ if [ ! -x "${EXECUTABLE}" ]; then
   rm -rf "${TEMP_DIR}"
   mkdir "${TEMP_DIR}"
   echo "Downloading ${DOWNLOAD_URL}"
-  curl --fail -s -L -o "${TEMP_DIR}/archive.${EXTENSION}" "${DOWNLOAD_URL}" || (echo "Download failed" >&2; exit 1)
+  curl --fail -sS -L --retry 5 --retry-delay 2 \
+    -o "${TEMP_DIR}/archive.${EXTENSION}" "${DOWNLOAD_URL}" \
+    || { echo "Download failed" >&2; exit 1; }
   if [ "${EXTENSION}" = "zip" ]; then
     unzip "${TEMP_DIR}/archive.${EXTENSION}" -d "${TEMP_DIR}"
   else


### PR DESCRIPTION
**Requirements**

- [ ] I have added test coverage for new or changed functionality
- [x] I have followed the repository's pull request submission guidelines
- [x] I have validated my changes against all supported platform versions

**Related issues**

Intermittent `Download failed` failures in SDK contract-test jobs, e.g. https://github.com/launchdarkly/python-server-sdk/pull/484 where 4 of 5 matrix jobs died at the same second while the rest passed on identical code.

**Describe the solution you've provided**

`downloader/run.sh` resolves the release version through the GitHub API (authenticated when `GITHUB_TOKEN` is set), but then downloads the release asset with a single un-retried `curl --fail -s`, and `-s` hides the reason for a failure:

```diff
-curl --fail -s -L -o "${TEMP_DIR}/archive.${EXTENSION}" "${DOWNLOAD_URL}" || (echo "Download failed" >&2; exit 1)
+curl --fail -sS -L --retry 5 --retry-delay 2 \
+  -o "${TEMP_DIR}/archive.${EXTENSION}" "${DOWNLOAD_URL}" \
+  || { echo "Download failed" >&2; exit 1; }
```

`--retry` covers transient 5xx/408/429 responses (consistent with several matrix jobs failing at once while others succeed), and `-sS` means the next failure reports the actual curl error instead of a bare `Download failed`.

**Describe alternatives you've considered**

- `--retry-all-errors`: rejected, it requires curl 7.71+ and this script also runs on older macOS runners.
- Sending the token on the asset download: the asset URL redirects to an unauthenticated object store, so an `Authorization` header there is at best useless and can break the redirect.

**Additional context**

The `contract-tests` GitHub action reads this script from the `v2` branch by default, so this also covers repos running the v3 harness through that action. `main` has the same line and should get the same change.


Link to Devin session: https://app.devin.ai/sessions/bfe54128e2804a96bb100e6120e9a3ef
Requested by: @kinyoklion

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Overview**
> Contract-test jobs intermittently failed with a bare **Download failed** when fetching the `sdk-test-harness` release asset from GitHub.
> 
> The download `curl` in `downloader/run.sh` now uses **`--retry 5 --retry-delay 2`** for transient HTTP failures (aligned with matrix jobs failing together while others pass) and **`-sS`** instead of `-s` so failures include the actual curl error message.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2c2302048392c5f12b2ceddf8d44640ffb83f436. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->