### PR TITLE
fix: Retry the test harness download and surface curl errors

### DIFF
--- a/downloader/run.sh
+++ b/downloader/run.sh
@@ -85,7 +85,9 @@ if [ ! -x "${EXECUTABLE}" ]; then
   rm -rf "${TEMP_DIR}"
   mkdir "${TEMP_DIR}"
   echo "Downloading ${DOWNLOAD_URL}"
-  curl --fail -s -L -o "${TEMP_DIR}/archive.${EXTENSION}" "${DOWNLOAD_URL}" || (echo "Download failed" >&2; exit 1)
+  curl --fail -sS -L --retry 5 --retry-delay 2 \
+    -o "${TEMP_DIR}/archive.${EXTENSION}" "${DOWNLOAD_URL}" \
+    || { echo "Download failed" >&2; exit 1; }
   if [ "${EXTENSION}" = "zip" ]; then
     unzip "${TEMP_DIR}/archive.${EXTENSION}" -d "${TEMP_DIR}"
   else


### PR DESCRIPTION
**Requirements**

- [ ] I have added test coverage for new or changed functionality
- [x] I have followed the repository's pull request submission guidelines
- [x] I have validated my changes against all supported platform versions

**Related issues**

Same change as #411, on the v3 branch.

**Describe the solution you've provided**

The release-asset download is a single un-retried `curl --fail -s`, and `-s` hides the reason for a failure:

```diff
-curl --fail -s -L -o "${TEMP_DIR}/archive.${EXTENSION}" "${DOWNLOAD_URL}" || (echo "Download failed" >&2; exit 1)
+curl --fail -sS -L --retry 5 --retry-delay 2 \
+  -o "${TEMP_DIR}/archive.${EXTENSION}" "${DOWNLOAD_URL}" \
+  || { echo "Download failed" >&2; exit 1; }
```

**Describe alternatives you've considered**

- `--retry-all-errors`: rejected, it requires curl 7.71+ and this script also runs on older macOS runners.
- Sending the token on the asset download: the asset URL redirects to an unauthenticated object store, so an `Authorization` header there is at best useless and can break the redirect.

**Additional context**

Fresh evidence: six SDK PRs were pushed within a few seconds to validate v2.39.0 / v3.2.0-alpha.6 end-to-end, and nearly every contract-test job died on `Download failed` between 21:55 and 21:58 UTC (python-server-sdk, go-server-sdk, js-core, php-server-sdk, cpp-sdks), for both the `v2.39.0` and `v3.0.0-alpha.6` assets. Downloading the same URLs afterwards succeeds with HTTP 200, so the asset endpoint was throttling concurrent downloads.


Link to Devin session: https://app.devin.ai/sessions/bfe54128e2804a96bb100e6120e9a3ef
Requested by: @kinyoklion

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Overview**
> Makes CI contract-test jobs more resilient when pulling **sdk-test-harness** release archives via `downloader/run.sh`.
> 
> The release download `curl` now uses **`-sS`** so failures still print curl diagnostics, and **`--retry 5 --retry-delay 2`** to ride out brief GitHub/asset throttling (the motivation described in the PR). The failure path is unchanged in behavior: still exits with **Download failed**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c7e7f093507451137368bac42a49f7d3e5684956. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->