### PR TITLE
fix: Authenticate release asset downloads with GITHUB_TOKEN

### DIFF
--- a/downloader/run.sh
+++ b/downloader/run.sh
@@ -7,8 +7,9 @@ set -e
 # or a partial version (v1) in the environment variable VERSION, and any parameters you want to
 # pass to the command in PARAMS.
 #
-# Sometimes you will hit Github API rate limits when running this command. If you have a Github token,
-# pass it in environment variable GITHUB_TOKEN.
+# Sometimes you will hit Github rate limits when running this command. If you have a Github token,
+# pass it in environment variable GITHUB_TOKEN; it is used both to list releases and to download
+# the release asset, which raises the applicable rate limit.
 #
 # This script can be used in either Linux or MacOS; it will download whichever binary is
 # appropriate for the current OS and architecture. It cannot be used in Windows. It requires
@@ -41,33 +42,45 @@ if [ "${ARCH}" = "aarch64" ]; then
 fi
 EXECUTABLE_ARCHIVE_NAME="sdk-test-harness_${OS_TYPE}_${ARCH}.${EXTENSION}"
 
-# Github rate-limits requests to its APIs. The effect is that sometimes the contract test step in CI
-# will fail spuriously when trying to find the list of releases.
-# If we provide an auth token, then we can avoid the rate limiting issues.
-if [ -n "${GITHUB_TOKEN}" ]; then
-  AUTH_HEADER="Authorization: Token ${GITHUB_TOKEN}"
-fi
-
 if [ -z "${VERSION}" -o -z "${PARAMS}" ]; then
   echo 'You must specify a version string in $VERSION and command parameters in $PARAMS' >&2
   exit 1
 fi
 
+# Github rate-limits requests, both to its APIs and to the release asset download endpoints. The
+# effect is that sometimes the contract test step in CI fails spuriously. Authenticated requests get
+# a substantially higher limit, so the token is used for every request that accepts it.
+AUTH_TOKEN="${GITHUB_TOKEN}"
+github_curl() {
+  if [ -n "${AUTH_TOKEN}" ]; then
+    curl -sS -L --retry 5 --retry-delay 2 -H "Authorization: Bearer ${AUTH_TOKEN}" "$@"
+  else
+    curl -sS -L --retry 5 --retry-delay 2 "$@"
+  fi
+}
+
 resolve_version() {
   if echo "$1" | grep -q '^v[^.][^.]*\.[^.][^.]*\..'; then
     # It's already a complete version string
     echo "$1"
-    exit
+    return
   fi
-  cmd="curl"
-  if [ -n "${AUTH_HEADER}" ]; then
-    cmd="${cmd} -H '${AUTH_HEADER}'"
-  fi
-  cmd="${cmd} -s ${RELEASES_API_URL}"
-  eval "$cmd" \
+  github_curl --fail "${RELEASES_API_URL}" \
     | grep "tag_name" \
     | sed -e 's/.*:[^"]*"\([^"]*\).*/\1/' \
     | grep "^$1\." \
+    | head -n 1
+}
+
+# The unauthenticated github.com download URL drops the Authorization header when it redirects to
+# the asset host, so an authenticated download has to go through the releases API instead.
+resolve_asset_url() {
+  github_curl --fail "${RELEASES_API_URL}/tags/$1" \
+    | tr -d ' \n' \
+    | tr '{' '\n' \
+    | grep "\"name\":\"${EXECUTABLE_ARCHIVE_NAME}\"" \
+    | grep -o "\"url\":\"[^\"]*/releases/assets/[0-9]*\"" \
+    | sed -e 's/^"url":"//' -e 's/"$//' \
     | head -n 1
 }
 
@@ -79,13 +92,26 @@ fi
 
 TEMP_DIR="/tmp/sdk-test-harness_${VERSION_TO_DOWNLOAD}"
 EXECUTABLE="${TEMP_DIR}/sdk-test-harness"
-DOWNLOAD_URL="${RELEASES_SITE_URL}/download/${VERSION_TO_DOWNLOAD}/${EXECUTABLE_ARCHIVE_NAME}"
 
 if [ ! -x "${EXECUTABLE}" ]; then
+  DOWNLOAD_URL="${RELEASES_SITE_URL}/download/${VERSION_TO_DOWNLOAD}/${EXECUTABLE_ARCHIVE_NAME}"
+  DOWNLOAD_ACCEPT="*/*"
+  if [ -n "${GITHUB_TOKEN}" ]; then
+    ASSET_URL=$(resolve_asset_url "${VERSION_TO_DOWNLOAD}")
+    if [ -n "${ASSET_URL}" ]; then
+      DOWNLOAD_URL="${ASSET_URL}"
+      DOWNLOAD_ACCEPT="application/octet-stream"
+    else
+      echo "Unable to find asset '${EXECUTABLE_ARCHIVE_NAME}' in release ${VERSION_TO_DOWNLOAD}; falling back to an unauthenticated download" >&2
+      # The public download URL does not need credentials, and a rejected token would fail it.
+      AUTH_TOKEN=""
+    fi
+  fi
+
   rm -rf "${TEMP_DIR}"
   mkdir "${TEMP_DIR}"
   echo "Downloading ${DOWNLOAD_URL}"
-  curl --fail -sS -L --retry 5 --retry-delay 2 \
+  github_curl --fail -H "Accept: ${DOWNLOAD_ACCEPT}" \
     -o "${TEMP_DIR}/archive.${EXTENSION}" "${DOWNLOAD_URL}" \
     || { echo "Download failed" >&2; exit 1; }
   if [ "${EXTENSION}" = "zip" ]; then


### PR DESCRIPTION
**Requirements**

- [ ] I have added test coverage for new or changed functionality
- [x] I have followed the repository's [pull request submission guidelines](../blob/master/CONTRIBUTING.md#submitting-pull-requests)
- [x] I have validated my changes against all supported platform versions

**Related issues**

Port of #415 (merged to `main`) and #416 (`v2`) to `v3`. The contract-tests action fetches `run.sh` from the `v2` branch today, so this port keeps `v3` from regressing when it becomes the branch CI uses.

**Describe the solution you've provided**

Previously `GITHUB_TOKEN` was only used for the releases-listing request in `resolve_version`, so any run that passed a full version string (as CI usually does) made no authenticated requests at all, and the asset download was always anonymous. The `github.com/.../releases/download/...` path is not a REST endpoint: GitHub publishes no rate limit for it and returns no `x-ratelimit-*` headers, and passing a token there is useless because `curl -L` drops `Authorization` on the cross-host redirect to the signed asset host.

This change routes the download through the documented release-assets API when a token is present:

- `github_curl` centralizes auth (`Authorization: Bearer`) plus `-sS --retry 5 --retry-delay 2`, replacing the previous `eval`-built command string that interpolated the token into a shell command.
- `resolve_asset_url` looks up the asset for the current OS/arch via `GET /releases/tags/<version>` and downloads it from `GET /releases/assets/<id>` with `Accept: application/octet-stream`. That lands in the documented authenticated rate limit bucket instead of an undocumented one.
- Without a token — or if the asset lookup fails — the token is cleared and it falls back to the previous anonymous `releases/download` URL, so external consumers are unaffected.

Docs referenced: [rate limits for the REST API](https://docs.github.com/en/rest/using-the-rest-api/rate-limits-for-the-rest-api), [release assets endpoints](https://docs.github.com/en/rest/releases/assets).

**Describe alternatives you've considered**

- Sending the token to the existing `releases/download` URL — verified that this has no effect on the actual byte transfer, since the header is dropped at the redirect.
- Retry-only (#411 on `v2`) — rides out transient failures, but leaves the download in the unauthenticated bucket.

**How to test it**

```sh
export VERSION=v3 PARAMS="-help"
GITHUB_TOKEN=<token> sh downloader/run.sh   # downloads from .../releases/assets/<id>
sh downloader/run.sh                        # falls back to .../releases/download/...
GITHUB_TOKEN=bogus sh downloader/run.sh     # prints the 401, then falls back anonymously
```

Also exercised full and partial version strings, the cached-binary path, and an unmatched version.

**Additional context**

Shell-script-only change used by CI, so no UI screenshots apply. This also brings the retry and error-surfacing behavior of #411 to `v3`, which never received it. The Windows `zip` path is unchanged apart from going through `github_curl`.


Link to Devin session: https://app.devin.ai/sessions/98e5024773d947509ad2575ae80bf31b
Requested by: @kinyoklion

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Overview**
> **CI downloader** (`downloader/run.sh`) now uses `GITHUB_TOKEN` for **release asset downloads**, not only when resolving partial version tags from the releases list.
> 
> A shared **`github_curl`** helper sends **`Authorization: Bearer`** with retries and replaces the old `eval`-built curl that only authenticated the releases list—and did not help downloads when CI passed a full version string.
> 
> When a token is set, **`resolve_asset_url`** fetches the OS/arch archive via the **releases assets REST API** (`Accept: application/octet-stream`), avoiding the public `releases/download` URL where **`curl -L` drops auth on redirect**. If asset lookup fails or no token is provided, behavior falls back to the anonymous download URL (token cleared on fallback so a bad token does not break public downloads).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7a13940aa24208424e46066faf9a60ae39c5685b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->