### PR TITLE
feat: Add contract test for undecodable data-source payload

### DIFF
--- a/sdktests/server_side_poll_all.go
+++ b/sdktests/server_side_poll_all.go
@@ -13,6 +13,7 @@ func doServerSidePollTests(t *ldtest.T) {
 
 	t.Run("requests", doServerSidePollRequestTests)
 	t.Run("payload", doServerSidePollPayloadTests)
+	t.Run("undecodable payload", doServerSidePollUndecodablePayloadTests)
 }
 
 func doServerSidePollRequestTests(t *ldtest.T) {

--- a/sdktests/server_side_poll_decoding.go
+++ b/sdktests/server_side_poll_decoding.go
@@ -1,0 +1,88 @@
+package sdktests
+
+import (
+	"bytes"
+	"net/http"
+
+	"github.com/launchdarkly/sdk-test-harness/v2/framework/harness"
+	"github.com/launchdarkly/sdk-test-harness/v2/framework/ldtest"
+	o "github.com/launchdarkly/sdk-test-harness/v2/framework/opt"
+	"github.com/launchdarkly/sdk-test-harness/v2/mockld"
+	"github.com/launchdarkly/sdk-test-harness/v2/servicedef"
+
+	"github.com/launchdarkly/go-sdk-common/v3/ldcontext"
+	"github.com/launchdarkly/go-sdk-common/v3/ldtime"
+	"github.com/launchdarkly/go-sdk-common/v3/ldvalue"
+	"github.com/launchdarkly/go-server-sdk-evaluation/v3/ldbuilders"
+
+	"github.com/stretchr/testify/require"
+)
+
+// doServerSidePollUndecodablePayloadTests checks that an SDK does not silently corrupt flag data
+// when a polling response body cannot be decoded as valid UTF-8.
+//
+// The mock polling service serves a body that is valid JSON except for a single invalid UTF-8 byte
+// inside a flag's string value. An SDK that decodes strictly must reject the whole payload and keep
+// no flag data. An SDK that decodes with byte replacement turns the invalid byte into U+FFFD, parses
+// the now-valid JSON, and applies a corrupted flag value -- the bug this test detects.
+//
+// The observable signal is the evaluated flag value. The flag is off with an off-variation whose
+// value is the corrupted string, so:
+//   - a strict SDK never initializes from this payload and returns the evaluation default;
+//   - a lenient SDK initializes and returns the U+FFFD-corrupted string.
+//
+// The test asserts the SDK returns the default, i.e. it did not apply data from an undecodable payload.
+// It runs for every polling-capable server-side SDK; the enclosing polling group already requires the
+// server-side-polling capability.
+func doServerSidePollUndecodablePayloadTests(t *ldtest.T) {
+	const flagKey = "flag"
+	const sentinel = "SENTINELVALUE"
+	defaultValue := ldvalue.String("default-fallback")
+	context := ldcontext.New("user-key")
+
+	// Build a valid server-side polling payload with a single flag whose off-variation value is the
+	// sentinel string, then splice one invalid UTF-8 byte (0xFF) into the middle of that string. The
+	// result is still structurally valid JSON: 0xFF sits inside a JSON string, so a lenient decoder
+	// that replaces it with U+FFFD produces parseable JSON, while a strict decoder raises.
+	flag := ldbuilders.NewFlagBuilder(flagKey).Version(1).
+		On(false).OffVariation(0).Variations(ldvalue.String(sentinel)).Build()
+	validBody := mockld.NewServerSDKDataBuilder().Flag(flag).Build().Serialize()
+	badBody := bytes.Replace(validBody, []byte(sentinel), []byte("AB\xffCD"), 1)
+	require.NotEqual(t, validBody, badBody, "test setup failed to inject the invalid byte")
+
+	// The value a lenient (errors='replace') SDK would apply after substituting U+FFFD for 0xFF.
+	corruptedValue := ldvalue.String("AB�CD")
+
+	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write(badBody)
+	})
+	endpoint := requireContext(t).harness.NewMockEndpoint(handler, t.DebugLogger(),
+		harness.MockEndpointDescription("polling service with undecodable payload"))
+	t.Defer(endpoint.Close)
+
+	// InitCanFail lets the client be created even when the data source never initializes, so that a
+	// correct (strict) SDK can still answer evaluations with the default. A short start-wait keeps the
+	// strict SDK from blocking for a long time while its first poll fails.
+	client := NewSDKClient(t, WithConfig(servicedef.SDKConfigParams{
+		Credential:      "my-sdk-key",
+		InitCanFail:     true,
+		StartWaitTimeMS: o.Some(ldtime.UnixMillisecondTime(2000)),
+		Polling: o.Some(servicedef.SDKConfigPollingParams{
+			BaseURI: endpoint.BaseURL(),
+		}),
+	}))
+
+	result := evaluateFlagDetail(t, client, flagKey, context, defaultValue)
+
+	if result.Value.Equal(corruptedValue) {
+		require.Fail(t, "SDK applied data from an undecodable payload",
+			"the SDK returned the U+FFFD-corrupted value %s from a body that failed to decode;"+
+				" it should have rejected the payload and returned the default %s (reason: %+v)",
+			result.Value, defaultValue, result.Reason.Value())
+	}
+	require.True(t, result.Value.Equal(defaultValue),
+		"expected the default value %s (payload rejected), but got %s (reason: %+v)",
+		defaultValue, result.Value, result.Reason.Value())
+}

--- a/sdktests/server_side_poll_decoding.go
+++ b/sdktests/server_side_poll_decoding.go
@@ -65,8 +65,9 @@ func doServerSidePollUndecodablePayloadTests(t *ldtest.T) {
 	// InitCanFail lets the client be created even when the data source never initializes, so that a
 	// correct (strict) SDK can still answer evaluations with the default. A short start-wait keeps the
 	// strict SDK from blocking for a long time while its first poll fails.
+	sdkKey := "my-sdk-key"
 	client := NewSDKClient(t, WithConfig(servicedef.SDKConfigParams{
-		Credential:      "my-sdk-key",
+		Credential:      sdkKey,
 		InitCanFail:     true,
 		StartWaitTimeMS: o.Some(ldtime.UnixMillisecondTime(2000)),
 		Polling: o.Some(servicedef.SDKConfigPollingParams{


### PR DESCRIPTION
## What

Adds a server-side polling contract test that verifies an SDK does not silently corrupt flag data when a data-source response body cannot be decoded as valid UTF-8.

The mock polling service serves a body that is valid JSON **except** for a single invalid UTF-8 byte (`0xFF`) spliced into the middle of a flag's string value. Because the bad byte sits inside a JSON string, the body is structurally still JSON:

- An SDK that decodes the body **strictly** raises on the invalid byte, rejects the whole payload, and never initializes from it — so an evaluation returns the caller's default.
- An SDK that decodes with **byte replacement** (e.g. Python `str.decode(errors='replace')`) turns the `0xFF` into U+FFFD, parses the now-valid JSON, and applies a **corrupted** flag value. This is the latent bug the test catches.

The test evaluates the flag (off-variation whose value is the corrupted string) and asserts the SDK returns the evaluation default, i.e. it did **not** apply data from an undecodable payload. If the SDK returns the U+FFFD value `"AB<U+FFFD>CD"`, the test fails with an explicit message.

## Gating

Baked into the existing **server-side polling** suite (`doServerSidePollTests`) — no new capability. It runs by default for every polling-capable server-side SDK; the polling group already requires the `server-side-polling` capability.

If it turns out some SDKs legitimately fail (i.e. we decide lenient decoding is acceptable for them), a dedicated opt-in capability can be added later to gate it.

## How it works

- Builds a valid flag payload via the mockld data builder, serializes it, then splices `0xFF` into the flag's string value.
- Serves the raw bytes through a custom `http.Handler` on a `NewMockEndpoint` (no new mock-service plumbing needed).
- Configures the client with `initCanFail: true` and a short start-wait so the client is created in both SDK states (strict SDK stays uninitialized and answers with the default; lenient SDK initializes and answers with the corrupted value).

## Verification (Python async SDK, before/after)

Demonstrated against the LaunchDarkly Python SDK's async data source, which had this exact bug (fixed in python-server-sdk#489, which switched the async transport from `response.text(errors='replace')` to strict decoding):

- **Before the fix** (`errors='replace'`): the test **fails** — the SDK initialized from the corrupt body and served the U+FFFD-corrupted value `{"value": "AB<U+FFFD>CD", "variationIndex": 0, "reason": {"kind": "OFF"}}`.
- **After the fix** (strict decode): the test **passes** — the SDK rejects the undecodable payload and returns the default.

Confirmed the test runs (not skipped) under the stock server-side capability set.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Overview**
> Adds a **server-side polling** contract test that checks SDKs **reject** poll responses whose body is not valid UTF-8, instead of applying flag data after lenient byte replacement (e.g. `0xFF` → U+FFFD).
> 
> The harness builds a normal flag payload, splices an invalid byte into a string variation, and serves it from a **mock HTTP endpoint**. It then evaluates the flag with `initCanFail` and a short start-wait, and expects the **evaluation default**—not the corrupted `"ABCD"` value that a replace-decoding SDK would use.
> 
> The new **`undecodable payload`** subtest is wired into `doServerSidePollTests` alongside existing request and payload tests; it uses the existing **server-side-polling** capability gate.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 73cd5240a46ef148d8e8e6dd7f6c23a836dbbcfd. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->