### PR TITLE
feat: Assert the FDv2 polling request sends the basis query parameter

### DIFF
--- a/sdktests/server_side_poll_all.go
+++ b/sdktests/server_side_poll_all.go
@@ -13,6 +13,7 @@ func doServerSidePollTests(t *ldtest.T) {
 
 	t.Run("requests", doServerSidePollRequestTests)
 	t.Run("payload", doServerSidePollPayloadTests)
+	t.Run("fdv2 basis", doServerSidePollFDv2BasisTests)
 	t.Run("interval", func(t *ldtest.T) {
 		doPollIntervalTests(t, WithCredential("my-sdk-key"))
 	})

--- a/sdktests/server_side_poll_fdv2_basis.go
+++ b/sdktests/server_side_poll_fdv2_basis.go
@@ -11,8 +11,8 @@ import (
 )
 
 // doServerSidePollFDv2BasisTests verifies the basis query parameter that an FDv2 polling SDK
-// sends. The parameter carries the state from the selector of the most recent
-// payload-transferred event.
+// sends. The SDK sends the state from the selector of the most recent payload-transferred
+// event as the basis query parameter on its polling requests.
 func doServerSidePollFDv2BasisTests(t *ldtest.T) {
 	sdkKey := "my-sdk-key"
 
@@ -24,41 +24,33 @@ func doServerSidePollFDv2BasisTests(t *ldtest.T) {
 	pollTests.FDv2RequestSendsBasisSelector(t)
 }
 
-// FDv2RequestSendsBasisSelector checks the basis query parameter across two consecutive polls.
+// FDv2RequestSendsBasisSelector checks that the polling synchronizer sends the basis query
+// parameter.
 //
-// The first poll happens before the SDK has a selector, so it must not send basis. Each poll
-// response carries a payload-transferred event with a known state, so the next poll must send
-// that state as the basis query parameter.
+// A polling initializer seeds the SDK with a selector at startup. That selector carries the
+// state from the initializer's payload-transferred event. The synchronizer's first poll must
+// therefore send that state as the basis query parameter.
 func (c CommonPollingTests) FDv2RequestSendsBasisSelector(t *ldtest.T) {
-	t.Run("sends basis query parameter on subsequent polls", func(t *ldtest.T) {
-		// The second poll only happens after the polling interval elapses. Server-side SDKs
-		// clamp the interval to 30 seconds, so waiting for it makes this test long-running.
-		t.LongRunning()
-
+	t.Run("sends the basis query parameter from the selector", func(t *ldtest.T) {
 		const basisState = "poll-basis-state"
 
-		// Every poll response carries a payload-transferred event whose state is basisState.
+		// Both the initializer and the synchronizer serve a payload-transferred event whose
+		// state is basisState.
 		sdkData := mockld.FDv2SDKDataFromServerSDKData(
 			mockld.NewServerSDKDataBuilder().Build(),
 			"xfer-full", "initial", basisState,
 		)
 
-		options := append(c.pollingDataSystemOptions(), DataSystemOptionPollInterval(time.Second))
-		dataSystem := NewSDKDataSystem(t, sdkData, options...)
+		dataSystem := NewSDKDataSystemCustom(t, sdkData,
+			DataSystemOptionPollingInitializer(sdkData),
+			DataSystemOptionPolling())
+		dataSystem.CreateEndpoints()
 
 		_ = NewSDKClient(t, c.baseSDKConfigurationPlus(dataSystem)...)
 
-		endpoint := dataSystem.Synchronizers[0].Endpoint()
-
-		// Allow a generous timeout for the first request to cover SDK startup.
-		firstRequest := endpoint.RequireConnection(t, time.Second*15)
-		m.In(t).For("basis query parameter on first poll").
-			Assert(firstRequest.URL.Query().Get("basis"), m.Equal(""))
-
-		// The second poll must send the state from the first response as the basis parameter.
-		// The timeout covers the clamped 30-second interval plus SDK jitter.
-		secondRequest := endpoint.RequireConnection(t, time.Second*35)
-		m.In(t).For("basis query parameter on second poll").
-			Assert(secondRequest.URL.Query().Get("basis"), m.Equal(basisState))
+		// Allow a generous timeout to cover SDK startup and the initializer handoff.
+		request := dataSystem.Synchronizers[0].Endpoint().RequireConnection(t, time.Second*15)
+		m.In(t).For("basis query parameter").
+			Assert(request.URL.Query().Get("basis"), m.Equal(basisState))
 	})
 }

--- a/sdktests/server_side_poll_fdv2_basis.go
+++ b/sdktests/server_side_poll_fdv2_basis.go
@@ -1,0 +1,64 @@
+package sdktests
+
+import (
+	"time"
+
+	"github.com/launchdarkly/sdk-test-harness/v2/framework/ldtest"
+	"github.com/launchdarkly/sdk-test-harness/v2/mockld"
+	"github.com/launchdarkly/sdk-test-harness/v2/servicedef"
+
+	m "github.com/launchdarkly/go-test-helpers/v2/matchers"
+)
+
+// doServerSidePollFDv2BasisTests verifies the basis query parameter that an FDv2 polling SDK
+// sends. The parameter carries the state from the selector of the most recent
+// payload-transferred event.
+func doServerSidePollFDv2BasisTests(t *ldtest.T) {
+	sdkKey := "my-sdk-key"
+
+	pollTests := NewCommonPollingTests(t, "doServerSidePollFDv2BasisTests",
+		WithConfig(servicedef.SDKConfigParams{
+			Credential: sdkKey,
+		}))
+
+	pollTests.FDv2RequestSendsBasisSelector(t)
+}
+
+// FDv2RequestSendsBasisSelector checks the basis query parameter across two consecutive polls.
+//
+// The first poll happens before the SDK has a selector, so it must not send basis. Each poll
+// response carries a payload-transferred event with a known state, so the next poll must send
+// that state as the basis query parameter.
+func (c CommonPollingTests) FDv2RequestSendsBasisSelector(t *ldtest.T) {
+	t.Run("sends basis query parameter on subsequent polls", func(t *ldtest.T) {
+		// The second poll only happens after the polling interval elapses. Server-side SDKs
+		// clamp the interval to 30 seconds, so waiting for it makes this test long-running.
+		t.LongRunning()
+
+		const basisState = "poll-basis-state"
+
+		// Every poll response carries a payload-transferred event whose state is basisState.
+		sdkData := mockld.FDv2SDKDataFromServerSDKData(
+			mockld.NewServerSDKDataBuilder().Build(),
+			"xfer-full", "initial", basisState,
+		)
+
+		options := append(c.pollingDataSystemOptions(), DataSystemOptionPollInterval(time.Second))
+		dataSystem := NewSDKDataSystem(t, sdkData, options...)
+
+		_ = NewSDKClient(t, c.baseSDKConfigurationPlus(dataSystem)...)
+
+		endpoint := dataSystem.Synchronizers[0].Endpoint()
+
+		// Allow a generous timeout for the first request to cover SDK startup.
+		firstRequest := endpoint.RequireConnection(t, time.Second*15)
+		m.In(t).For("basis query parameter on first poll").
+			Assert(firstRequest.URL.Query().Get("basis"), m.Equal(""))
+
+		// The second poll must send the state from the first response as the basis parameter.
+		// The timeout covers the clamped 30-second interval plus SDK jitter.
+		secondRequest := endpoint.RequireConnection(t, time.Second*35)
+		m.In(t).For("basis query parameter on second poll").
+			Assert(secondRequest.URL.Query().Get("basis"), m.Equal(basisState))
+	})
+}


### PR DESCRIPTION
## Summary

Adds a server-side FDv2 polling contract test that inspects the request query string for the payload selector.

## The gap

The harness had no FDv2 server-side polling test that inspected the request query string for the payload selector. The existing FDv2 poll request assertions checked only method, headers, path, the `filter` key, and (client-side only) `withReasons`; the mock poll handler ignored the query string. The only `basis` query-param assertion in the repo was on the streaming reconnect path (`common_tests_stream_fdv2.go`, in `validatePayloadReceived`).

Because of this, an SDK sending the selector under the wrong query-param name passed all FDv2 polling tests. That bug was just found in the Python SDK, which sent `selector` instead of `basis`.

## Expected behavior (CSFDV2)

The FDv2 polling request MUST include a query parameter named `basis` whose value is the `state` field from the selector of the most recent `payload-transferred` event, but ONLY once the SDK has a selector:

- On the FIRST poll the SDK has no selector, so the request MUST NOT include `basis` (absent or empty).
- On a SUBSEQUENT poll (after a response carried a `payload-transferred` with a state), the request MUST include `?basis=<that state>`.

This mirrors the Go server SDK, which sends `basis` on polling only when the selector is defined, and matches the streaming reconnect assertion in `common_tests_stream_fdv2.go`.

## What the test does

1. Configures the SDK for FDv2 polling by reusing `pollingDataSystemOptions()` (the same setup as the other server-side poll tests).
2. Serves poll responses whose `payload-transferred` event carries a known `state` (`poll-basis-state`), via the existing `standardPollingHandler` in `mockld/polling_service.go`.
3. Captures the FIRST poll request and asserts `basis` is absent/empty.
4. Waits for the SECOND poll request and asserts `basis` equals that `state`.

It reuses the existing `server-side-polling` capability (`servicedef.CapabilityServerSidePolling`); no new capability is introduced. It is wired into `doServerSidePollTests` in `server_side_poll_all.go`.

## Design note

The second poll only happens after the polling interval elapses, and server-side SDKs clamp the interval to a 30-second minimum (see the existing interval clamp test). The test is therefore marked `t.LongRunning()`, consistent with the polling-interval tests that also await a second server-side poll.

Refs SDK-2919.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Overview**
> Adds server-side FDv2 **polling** contract coverage for the **`basis`** query parameter, closing a gap where only streaming reconnect asserted selector state on the URL.
> 
> A new **`fdv2 basis`** suite under server-side poll tests wires **`FDv2RequestSendsBasisSelector`**: FDv2 data with a known **`payload-transferred`** state, polling initializer plus synchronizer, then asserts the synchronizer’s first captured poll request has **`basis`** equal to that state (after initializer handoff).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 24effe066ec86d63744f9a1c21c241c85678c040. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->