### PR TITLE
chore: Change versioning strategy to 'prerelease'

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -4,7 +4,7 @@
       "draft": true,
       "release-type": "go",
       "bump-minor-pre-major": true,
-      "versioning": "default",
+      "versioning": "prerelease",
       "include-component-in-tag": false,
       "prerelease": true,
       "prerelease-type": "alpha",


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Overview**
> Updates **release-please** so `versioning` is **`prerelease`** instead of **`default`** in `release-please-config.json`.
> 
> That matches the existing **`prerelease: true`** and **`prerelease-type: alpha`** settings, so future release PRs should bump prerelease versions (e.g. alpha tags) rather than using default semver behavior alone.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b671348a608b4e52c54b9b0ebf9411e7b6550063. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->