### PR TITLE
chore: port long-running test framework support from v3

### DIFF
--- a/framework/ldtest/test_scope.go
+++ b/framework/ldtest/test_scope.go
@@ -41,6 +41,9 @@ type TestConfiguration struct {
 
 	// Capabilities is a list of strings which are used T.RequireCapability.
 	Capabilities []string
+
+	// EnableLongRunningTests indicates whether tests marked with LongRunning() should be run.
+	EnableLongRunningTests bool
 }
 
 // Run starts a top-level test scope.
@@ -136,6 +139,15 @@ func (t *T) Run(name string, action func(*T)) {
 // a non-zero exit code on termination, as regular failures do.
 func (t *T) NonCritical(explanation string) {
 	t.nonCritical = explanation
+}
+
+// LongRunning indicates that this test takes a long time to run (10+ seconds or minutes).
+// If EnableLongRunningTests is false in the test configuration, the test will be skipped.
+// Use the -enable-long-running-tests flag to run these tests.
+func (t *T) LongRunning() {
+	if !t.env.config.EnableLongRunningTests {
+		t.SkipWithReason("use -enable-long-running-tests to run")
+	}
 }
 
 // Errorf reports a test failure. It is equivalent to Go's testing.T.Errorf. It does not cause the test

--- a/main.go
+++ b/main.go
@@ -82,7 +82,7 @@ func run(params commandParams) (*ldtest.Results, error) {
 	countingLogger := ldtest.NewCountingTestLogger(testLogger)
 	testLogger = countingLogger
 
-	results := sdktests.RunSDKTestSuite(harness, params.filters, countingLogger)
+	results := sdktests.RunSDKTestSuite(harness, params.filters, countingLogger, params.enableLongRunningTests)
 
 	fmt.Println()
 	logErr := testLogger.EndLog(results)

--- a/params.go
+++ b/params.go
@@ -17,6 +17,7 @@ type commandParams struct {
 	debug                  bool
 	debugAll               bool
 	enablePersistenceTests bool
+	enableLongRunningTests bool
 	jUnitFile              string
 	recordFailures         string
 	skipFile               string
@@ -36,6 +37,8 @@ func (c *commandParams) Read(args []string) bool {
 	fs.BoolVar(&c.debugAll, "debug-all", false, "enable debug logging for all tests")
 	fs.BoolVar(&c.enablePersistenceTests, "enable-persistence-tests", false,
 		"enable tests that require external persistence support")
+	fs.BoolVar(&c.enableLongRunningTests, "enable-long-running-tests", false,
+		"enable tests that take a long time to run (10+ seconds)")
 	fs.StringVar(&c.jUnitFile, "junit", "", "write JUnit XML output to the specified path")
 	fs.StringVar(&c.recordFailures, "record-failures", "", "record failed test IDs to the given file.\n"+
 		"recorded tests can be skipped by the next run of the harness via -skip-from")

--- a/sdktests/testsuite_entry_point.go
+++ b/sdktests/testsuite_entry_point.go
@@ -16,6 +16,7 @@ func RunSDKTestSuite(
 	harness *harness.TestHarness,
 	filter ldtest.Filter,
 	testLogger ldtest.TestLogger,
+	enableLongRunningTests bool,
 ) ldtest.Results {
 	capabilities := harness.TestServiceInfo().Capabilities
 	var importantCapabilities framework.Capabilities
@@ -58,9 +59,10 @@ func RunSDKTestSuite(
 	}
 
 	config := ldtest.TestConfiguration{
-		Filter:       filter,
-		Capabilities: harness.TestServiceInfo().Capabilities,
-		TestLogger:   testLogger,
+		Filter:                 filter,
+		Capabilities:           harness.TestServiceInfo().Capabilities,
+		TestLogger:             testLogger,
+		EnableLongRunningTests: enableLongRunningTests,
 		Context: SDKTestContext{
 			harness: harness,
 			sdkKind: sdkKind,


### PR DESCRIPTION
## Summary

Ports the framework scaffolding portion of [launchdarkly/sdk-test-harness#314](https://github.com/launchdarkly/sdk-test-harness/pull/314) (Jason Bailey, "fix: Add support for optional long running tests") from v3 to v2.

## What ships

- `-enable-long-running-tests` CLI flag (default false). Mirrors the `-enable-persistence-tests` shape.
- `EnableLongRunningTests bool` on `ldtest.TestConfiguration`.
- `(t *T) LongRunning()` method. Long-running tests call it at the top of their body; if the flag isn't set, the test skips with reason `"use -enable-long-running-tests to run"`.
- Threaded through `RunSDKTestSuite` and `main.go`.

## What's deliberately not ported

The original commit ([`01a245c`](https://github.com/launchdarkly/sdk-test-harness/commit/01a245c318ca55fe6b5e9c586c86ebf1c9468659)) also added 237 lines to `sdktests/common_tests_stream_fdv2.go`. That file exercises v3-only FDv2 shapes and has no place on v2. Skipped.

## Why now

Scaffolding for follow-up work on [#404](https://github.com/launchdarkly/sdk-test-harness/pull/404). Review feedback there ([discussion](https://github.com/launchdarkly/sdk-test-harness/pull/404#discussion_r3770093528), [discussion](https://github.com/launchdarkly/sdk-test-harness/pull/404#discussion_r3770094107)) argued against exposing an SDK-side servicedef knob to compress the extended-regime timing in the RETRY-conformance tests. The consensus was that those tests should run at real timing gated by the long-running-tests mechanism — which requires that mechanism to exist on v2 first.

Once this lands, #404 rebases onto v2 tip and its RETRY-conformance tests get `t.LongRunning()` calls at the top of their bodies, plus timing rewritten to production defaults.

## Verification

- `go build ./...` — clean.
- `go run . -h` — new flag visible: `-enable-long-running-tests   enable tests that take a long time to run (10+ seconds)`.
- `go test ./...` — full suite green. No behavior change to existing v2 tests since none of them call `t.LongRunning()`.

## Test plan

- [x] Confirm the port matches the shape of #314's framework portion.
- [ ] Confirm the CLI flag help text is acceptable (verbatim from Jason's original).
- [ ] Confirm no v3-only content bled through.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Overview**
> Adds optional **long-running test** gating on v2, mirroring the existing `-enable-persistence-tests` pattern.
> 
> The harness accepts `-enable-long-running-tests` (default false). That value flows through `main` → `RunSDKTestSuite` → `ldtest.TestConfiguration.EnableLongRunningTests`. Tests can call `t.LongRunning()` at the start; when the flag is off they skip with reason `use -enable-long-running-tests to run`.
> 
> No existing v2 tests call `LongRunning()` yet, so default runs behave the same until follow-up tests adopt the helper.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 536af50faefa5da88e42d39d8e5241521b0ff372. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->