### PR TITLE
feat: Verify per-context private attributes are not applied to other contexts

### DIFF
--- a/sdktests/common_tests_events_contexts.go
+++ b/sdktests/common_tests_events_contexts.go
@@ -394,4 +394,125 @@ func (c CommonEventTests) EventContexts(t *ldtest.T) {
 			}
 		}
 	}
+
+	c.eventContextPrivateAttributeScoping(t, dataSystem)
+}
+
+// eventContextPrivateAttributeScoping verifies that private attributes declared by a context in
+// _meta.privateAttributes are applied only to that context, and not to any other context that the
+// same client subsequently sends events for. An SDK that merges them into its configured private
+// attribute list - rather than into a per-context copy of it - redacts attributes from contexts
+// that never declared them private.
+//
+// The globally configured private attribute is included in every expectation so that an SDK cannot
+// pass these subtests by discarding its configured private attributes along with the per-context ones.
+func (c CommonEventTests) eventContextPrivateAttributeScoping(t *ldtest.T, dataSystem SDKConfigurer) {
+	eventsConfig := servicedef.SDKConfigEventParams{GlobalPrivateAttributes: []string{"globallyPrivate"}}
+
+	setAttributes := func(b *ldcontext.Builder) {
+		b.SetString("selfPrivate", "1")
+		b.SetString("globallyPrivate", "2")
+		b.SetString("visible", "3")
+	}
+	withSelfPrivate := func(b *ldcontext.Builder) {
+		setAttributes(b)
+		b.Private("selfPrivate")
+	}
+	redactAttrs := func(context ldcontext.Context, attrs ...string) ldcontext.Context {
+		builder := ldcontext.NewBuilderFromContext(context)
+		for _, attr := range attrs {
+			builder.SetValue(attr, ldvalue.Null())
+		}
+		return builder.Build()
+	}
+
+	newClientAndSink := func(t *ldtest.T, initialContext ldcontext.Context) (*SDKClient, *SDKEventSink) {
+		events := NewSDKEventSinkWithGzip(t, t.Capabilities().Has(servicedef.CapabilityEventGzip))
+		client := NewSDKClient(t, c.baseSDKConfigurationPlus(
+			WithClientSideInitialContext(initialContext),
+			WithEventsConfig(eventsConfig),
+			dataSystem,
+			events)...)
+		if c.isClientSide {
+			// Consume the identify event that a client-side SDK sends for its initial context
+			client.FlushEvents(t)
+			_ = events.ExpectAnalyticsEvents(t, defaultEventTimeout)
+		}
+		return client, events
+	}
+
+	expectIdentifyEvent := func(
+		t *ldtest.T, client *SDKClient, events *SDKEventSink,
+		context ldcontext.Context, expectedContext ldcontext.Context, redactedShouldBe redactedAttrsByKind,
+	) {
+		client.FlushEvents(t)
+		payload := events.ExpectAnalyticsEvents(t, defaultEventTimeout)
+		m.In(t).Assert(payload, m.Items(
+			m.AllOf(
+				IsIdentifyEventForContext(context),
+				m.JSONProperty("context").Should(JSONMatchesEventContext(expectedContext, redactedShouldBe)),
+			),
+		))
+	}
+
+	t.Run("private attributes of one context are not applied to later contexts", func(t *ldtest.T) {
+		selfPrivateContexts := data.NewContextFactory("EventContextPrivateScopingSelf", withSelfPrivate)
+		noPrivateContexts := data.NewContextFactory("EventContextPrivateScopingNone", setAttributes)
+
+		client, events := newClientAndSink(t, noPrivateContexts.NextUniqueContext())
+
+		selfPrivateContext := selfPrivateContexts.NextUniqueContext()
+		client.SendIdentifyEvent(t, selfPrivateContext)
+		expectIdentifyEvent(t, client, events, selfPrivateContext,
+			redactAttrs(selfPrivateContext, "selfPrivate", "globallyPrivate"),
+			redactedAttrsByKind{"user": {"selfPrivate", "globallyPrivate"}})
+
+		noPrivateContext := noPrivateContexts.NextUniqueContext()
+		client.SendIdentifyEvent(t, noPrivateContext)
+		expectIdentifyEvent(t, client, events, noPrivateContext,
+			redactAttrs(noPrivateContext, "globallyPrivate"),
+			redactedAttrsByKind{"user": {"globallyPrivate"}})
+	})
+
+	// A multi-kind context is filtered one kind at a time, so private attributes declared by one kind
+	// must not be applied to the other kinds of the same context. Both orderings are covered because
+	// SDKs may filter the individual contexts in either order.
+	for _, kindWithPrivate := range []ldcontext.Kind{"org", "user"} {
+		kindWithPrivate := kindWithPrivate
+		t.Run("private attributes of one kind are not applied to other kinds of the same context"+
+			" (declared by "+string(kindWithPrivate)+")", func(t *ldtest.T) {
+			makeFactory := func(kind ldcontext.Kind) *data.ContextFactory {
+				builderAction := setAttributes
+				if kind == kindWithPrivate {
+					builderAction = withSelfPrivate
+				}
+				return data.NewContextFactory(
+					"EventContextPrivateScoping-"+string(kindWithPrivate)+"-"+string(kind),
+					func(b *ldcontext.Builder) {
+						b.Kind(kind)
+						builderAction(b)
+					})
+			}
+			orgContexts, userContexts := makeFactory("org"), makeFactory("user")
+
+			client, events := newClientAndSink(t, data.NewContextFactory(
+				"EventContextPrivateScopingInitial-"+string(kindWithPrivate), setAttributes).NextUniqueContext())
+
+			orgContext, userContext := orgContexts.NextUniqueContext(), userContexts.NextUniqueContext()
+			multiContext := ldcontext.NewMultiBuilder().Add(orgContext).Add(userContext).Build()
+
+			redactedShouldBe := redactedAttrsByKind{
+				"org":  {"globallyPrivate"},
+				"user": {"globallyPrivate"},
+			}
+			redactedShouldBe[string(kindWithPrivate)] = []string{"selfPrivate", "globallyPrivate"}
+			expectedContext := ldcontext.NewMultiBuilder().
+				Add(redactAttrs(orgContext, redactedShouldBe["org"]...)).
+				Add(redactAttrs(userContext, redactedShouldBe["user"]...)).
+				Build()
+
+			client.SendIdentifyEvent(t, multiContext)
+			expectIdentifyEvent(t, client, events, multiContext, expectedContext, redactedShouldBe)
+		})
+	}
 }


### PR DESCRIPTION
Adds `events/context properties` coverage for private attributes declared in a context's `_meta.privateAttributes` leaking onto other contexts — the Ruby SDK bug fixed in launchdarkly/ruby-server-sdk#416, which the existing suite could not detect.

- New subtest: two identify events on one client, the first context declaring `selfPrivate` private, the second not — the second must not have it redacted.
- New subtests (both kind orderings): one multi-kind context where only one kind declares `selfPrivate` private — the other kind must not have it redacted.
- A globally configured private attribute is expected redacted in every assertion, so an SDK cannot pass by dropping its configured private attributes along with the per-context ones.
- No new capability gate: this is required behavior for every SDK, so all SDKs run it.

**Requirements**

- [x] I have added test coverage for new or changed functionality
- [x] I have followed the repository's [pull request submission guidelines](../blob/master/CONTRIBUTING.md#submitting-pull-requests)
- [ ] I have validated my changes against all supported platform versions

<details>
<summary>Implementation details</summary>

**Why existing tests miss it**

`makeEventContextTestParams` builds one client per test param, and every context that param then generates comes from a single `data.ContextFactory` with identical `_meta.privateAttributes`. An SDK that merges per-context private attributes into its long-lived configured list (rather than a per-context copy) therefore leaks only attributes that are already expected to be redacted. The multi-kind factories are also blind to it: they either declare no per-context privates, or declare them only on the kind filtered last (`data.NewContextFactoriesForExercisingAllAttributes` gives `org` just `name` while `other` carries `Private("a","c")`), and the leaked names do not exist on the other kind.

**What the new tests do**

`CommonEventTests.eventContextPrivateAttributeScoping` is called at the end of `EventContexts`, so it runs for server-side, client-side, and PHP SDKs. Each context carries `selfPrivate`, `globallyPrivate`, and `visible`; `globalPrivateAttributes` is configured as `["globallyPrivate"]`.

- Sequential case: identify `selfPrivate`-declaring context (expect `selfPrivate` + `globallyPrivate` redacted), then identify a context that declares nothing private (expect only `globallyPrivate` redacted). Pre-#416 Ruby redacts `selfPrivate` from the second context too.
- Multi-kind case: `org` + `user` in one context, only one kind declaring `selfPrivate` private; run once per kind so the leak is caught regardless of the order an SDK filters individual contexts in.

Both cases still assert `globallyPrivate` is redacted, which is what distinguishes a correct fix (copy the list) from a wrong one (stop applying configured privates).

**Testing**

`make build`, `make lint` (0 issues), and `make test` pass. SDK-level validation is in progress: the new subtests are being run against SDK contract test services, including the Ruby SDK before and after #416.

**Alternatives considered**

Adding more `eventContextTestParams` entries — rejected, the leak is only observable across two contexts with *different* private attributes within one client, which that table cannot express.

</details>


Link to Devin session: https://app.devin.ai/sessions/6e3076285f2849919b966a4f801075ca
Requested by: @kinyoklion

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Overview**
> Adds **`eventContextPrivateAttributeScoping`** at the end of **`EventContexts`**, so server-side, client-side, and PHP SDKs all run it.
> 
> The new coverage catches SDKs that merge **`_meta.privateAttributes`** into a long-lived global list instead of a per-context copy (e.g. Ruby server SDK before #416). A **sequential identify** case sends one context that marks **`selfPrivate`** private, then another that does not—only **`globallyPrivate`** (from **`globalPrivateAttributes`**) must be redacted on the second event. **Multi-kind** subtests run for both **`org`** and **`user`** as the kind that declares **`selfPrivate`**, so redaction cannot leak across kinds when filtering one kind at a time.
> 
> Every assertion still expects **`globallyPrivate`** redacted, so passing by dropping all configured private attributes along with per-context ones fails the suite.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 62615b408353d8f7cf05700a39136f361b627bc2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->