### PR TITLE
feat: Verify per-context private attributes are not applied to other contexts

### DIFF
--- a/sdktests/common_tests_events_contexts.go
+++ b/sdktests/common_tests_events_contexts.go
@@ -378,4 +378,125 @@ func (c CommonEventTests) EventContexts(t *ldtest.T) {
 			}
 		}
 	}
+
+	c.eventContextPrivateAttributeScoping(t, dataSource)
+}
+
+// eventContextPrivateAttributeScoping verifies that private attributes declared by a context in
+// _meta.privateAttributes are applied only to that context, and not to any other context that the
+// same client subsequently sends events for. An SDK that merges them into its configured private
+// attribute list - rather than into a per-context copy of it - redacts attributes from contexts
+// that never declared them private.
+//
+// The globally configured private attribute is included in every expectation so that an SDK cannot
+// pass these subtests by discarding its configured private attributes along with the per-context ones.
+func (c CommonEventTests) eventContextPrivateAttributeScoping(t *ldtest.T, dataSource SDKConfigurer) {
+	eventsConfig := servicedef.SDKConfigEventParams{GlobalPrivateAttributes: []string{"globallyPrivate"}}
+
+	setAttributes := func(b *ldcontext.Builder) {
+		b.SetString("selfPrivate", "1")
+		b.SetString("globallyPrivate", "2")
+		b.SetString("visible", "3")
+	}
+	withSelfPrivate := func(b *ldcontext.Builder) {
+		setAttributes(b)
+		b.Private("selfPrivate")
+	}
+	redactAttrs := func(context ldcontext.Context, attrs ...string) ldcontext.Context {
+		builder := ldcontext.NewBuilderFromContext(context)
+		for _, attr := range attrs {
+			builder.SetValue(attr, ldvalue.Null())
+		}
+		return builder.Build()
+	}
+
+	newClientAndSink := func(t *ldtest.T, initialContext ldcontext.Context) (*SDKClient, *SDKEventSink) {
+		events := NewSDKEventSinkWithGzip(t, t.Capabilities().Has(servicedef.CapabilityEventGzip))
+		client := NewSDKClient(t, c.baseSDKConfigurationPlus(
+			WithClientSideInitialContext(initialContext),
+			WithEventsConfig(eventsConfig),
+			dataSource,
+			events)...)
+		if c.isClientSide {
+			// Consume the identify event that a client-side SDK sends for its initial context
+			client.FlushEvents(t)
+			_ = events.ExpectAnalyticsEvents(t, defaultEventTimeout)
+		}
+		return client, events
+	}
+
+	expectIdentifyEvent := func(
+		t *ldtest.T, client *SDKClient, events *SDKEventSink,
+		context ldcontext.Context, expectedContext ldcontext.Context, redactedShouldBe redactedAttrsByKind,
+	) {
+		client.FlushEvents(t)
+		payload := events.ExpectAnalyticsEvents(t, defaultEventTimeout)
+		m.In(t).Assert(payload, m.Items(
+			m.AllOf(
+				IsIdentifyEventForContext(context),
+				m.JSONProperty("context").Should(JSONMatchesEventContext(expectedContext, redactedShouldBe)),
+			),
+		))
+	}
+
+	t.Run("private attributes of one context are not applied to later contexts", func(t *ldtest.T) {
+		selfPrivateContexts := data.NewContextFactory("EventContextPrivateScopingSelf", withSelfPrivate)
+		noPrivateContexts := data.NewContextFactory("EventContextPrivateScopingNone", setAttributes)
+
+		client, events := newClientAndSink(t, noPrivateContexts.NextUniqueContext())
+
+		selfPrivateContext := selfPrivateContexts.NextUniqueContext()
+		client.SendIdentifyEvent(t, selfPrivateContext)
+		expectIdentifyEvent(t, client, events, selfPrivateContext,
+			redactAttrs(selfPrivateContext, "selfPrivate", "globallyPrivate"),
+			redactedAttrsByKind{"user": {"selfPrivate", "globallyPrivate"}})
+
+		noPrivateContext := noPrivateContexts.NextUniqueContext()
+		client.SendIdentifyEvent(t, noPrivateContext)
+		expectIdentifyEvent(t, client, events, noPrivateContext,
+			redactAttrs(noPrivateContext, "globallyPrivate"),
+			redactedAttrsByKind{"user": {"globallyPrivate"}})
+	})
+
+	// A multi-kind context is filtered one kind at a time, so private attributes declared by one kind
+	// must not be applied to the other kinds of the same context. Both orderings are covered because
+	// SDKs may filter the individual contexts in either order.
+	for _, kindWithPrivate := range []ldcontext.Kind{"org", "user"} {
+		kindWithPrivate := kindWithPrivate
+		t.Run("private attributes of one kind are not applied to other kinds of the same context"+
+			" (declared by "+string(kindWithPrivate)+")", func(t *ldtest.T) {
+			makeFactory := func(kind ldcontext.Kind) *data.ContextFactory {
+				builderAction := setAttributes
+				if kind == kindWithPrivate {
+					builderAction = withSelfPrivate
+				}
+				return data.NewContextFactory(
+					"EventContextPrivateScoping-"+string(kindWithPrivate)+"-"+string(kind),
+					func(b *ldcontext.Builder) {
+						b.Kind(kind)
+						builderAction(b)
+					})
+			}
+			orgContexts, userContexts := makeFactory("org"), makeFactory("user")
+
+			client, events := newClientAndSink(t, data.NewContextFactory(
+				"EventContextPrivateScopingInitial-"+string(kindWithPrivate), setAttributes).NextUniqueContext())
+
+			orgContext, userContext := orgContexts.NextUniqueContext(), userContexts.NextUniqueContext()
+			multiContext := ldcontext.NewMultiBuilder().Add(orgContext).Add(userContext).Build()
+
+			redactedShouldBe := redactedAttrsByKind{
+				"org":  {"globallyPrivate"},
+				"user": {"globallyPrivate"},
+			}
+			redactedShouldBe[string(kindWithPrivate)] = []string{"selfPrivate", "globallyPrivate"}
+			expectedContext := ldcontext.NewMultiBuilder().
+				Add(redactAttrs(orgContext, redactedShouldBe["org"]...)).
+				Add(redactAttrs(userContext, redactedShouldBe["user"]...)).
+				Build()
+
+			client.SendIdentifyEvent(t, multiContext)
+			expectIdentifyEvent(t, client, events, multiContext, expectedContext, redactedShouldBe)
+		})
+	}
 }


### PR DESCRIPTION
Adds contract coverage for private attributes declared in a context's `_meta.privateAttributes` leaking into an SDK's *globally configured* private attribute list, so they get applied to unrelated contexts.

- Port of #429 to the `v2` line. Nearly every SDK's CI pulls the harness from `v2` (ruby, php, erlang, rust, haskell, java, dotnet, ios, android, flutter, roku, node-client), so without this the regression below is untested for those SDKs.
- 3 new subtests under `events/context properties`; runs for server-side, client-side and PHP suites. No existing test or expectation changed.
- Reproduces [ruby-server-sdk#416](https://github.com/launchdarkly/ruby-server-sdk/pull/416): `ContextFilter` did `@private_attributes.concat(context.private_attributes)`, mutating the configured list, so a context that declared nothing private still had the *previous* context's private attributes redacted.

**Requirements**

- [x] I have added test coverage for new or changed functionality
- [x] I have followed the repository's [pull request submission guidelines](../blob/master/CONTRIBUTING.md#submitting-pull-requests)
- [ ] I have validated my changes against all supported platform versions — validation across SDKs in progress, results posted as a comment

**Related issues**

- launchdarkly/ruby-server-sdk#416 — the bug this covers
- #429 — the same change on the `v3` line

<details>
<summary>Implementation details</summary>

**Why the existing tests could not catch it**

`makeEventContextTestParams` creates a *new client* per parameter, so the `ContextFilter` is always fresh, and every context within one parameter comes from a single factory with identical `_meta.privateAttributes`. A leaked private attribute is therefore always an already-expected private attribute. The existing multi-kind fixtures don't catch it either: they either set no per-context privates, or set them only on the kind that is filtered last, and the leaked names don't exist as attributes on the other kind.

**What the new tests do**

`eventContextPrivateAttributeScoping` uses **one client** for multiple identify events, and each context carries the same three attributes (`selfPrivate`, `globallyPrivate`, `visible`) while differing only in what it declares private:

1. `private attributes of one context are not applied to later contexts` — identify a context declaring `selfPrivate` private, then identify a different context that declares nothing private, and assert `selfPrivate` is still visible on the second one.
2. + 3. `private attributes of one kind are not applied to other kinds of the same context (declared by org / by user)` — a multi-kind context where only one kind declares `selfPrivate` private; the other kind must keep it. Both orderings are covered because SDKs filter the individual contexts in an arbitrary order — with the Ruby bug present, only the `org` variant fails (Ruby filters `org` first), so a single-ordering test would catch this only half the time.

`globallyPrivate` is configured via `GlobalPrivateAttributes` and asserted redacted in every expectation, so an SDK cannot pass by throwing away its configured private attributes along with the per-context ones.

**Verification**

Negative control against ruby-server-sdk with the #416 fix locally reverted to `.concat(...)`: subtests 1 and 2 fail with the second context wrongly reporting `redactedAttributes: ["selfPrivate","globallyPrivate"]`; all three pass with the fix in place.

</details>


Link to Devin session: https://app.devin.ai/sessions/6e3076285f2849919b966a4f801075ca
Requested by: @kinyoklion

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Overview**
> Adds **three new subtests** under `events/context properties` via `eventContextPrivateAttributeScoping`, hooked from `EventContexts`. Existing expectations are unchanged.
> 
> The harness reuses **one SDK client** for multiple identify events so failures like mutating the global private-attribute list (e.g. ruby-server-sdk#416) are detectable—prior cases mostly created a fresh client per scenario.
> 
> **Coverage:** (1) a context that marks `selfPrivate` private must not cause a later context with no per-context privates to redact `selfPrivate`; (2) for multi-kind contexts, privates declared on `org` or `user` must not redact the same attribute on the other kind—both orderings are tested.
> 
> Every assertion still expects **`globallyPrivate`** (from `GlobalPrivateAttributes`) to be redacted so SDKs cannot pass by dropping all configured privates.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3fa29c4568b37f3d3507e719ffd69d49d2862a75. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->