### PR TITLE
feat: Remove FDv2 payload-filter test scenarios

### DIFF
--- a/docs/service_spec.md
+++ b/docs/service_spec.md
@@ -181,19 +181,6 @@ For tests that involve tags, the test harness will set the `tags` property of th
 
 This means that the SDK has a type corresponding to the old-style user model, and supports directly passing such user data to SDK methods as an alternative to context data. If this capability is present, the test harness may send a `user` property with old-style user JSON for test commands that would normally take a `context` property. If this capability is absent, `user` will never be set.
 
-#### Capability `"filtering"`
-
-This means that the SDK supports the "filter" configuration option for streaming/polling data sources,
-and will send a `?filter=name` query parameter along with streaming/polling requests.
-
-For tests that involve filtering, the test harness will set the `payloadFilter` property of the `dataSystem` configuration object. The property will either be omitted if no filter is requested, or a non-empty string if requested.
-
-#### Capability `"filtering-strict"`
-
-When initially adding support for the `filtering` capability, the test harness assumed there were no character restrictions on the payload filter key. Later investigation has determined this is not the case.
-
-If this capability is set, the test harness will send a filter key that contains a character that is not allowed in a filter key. The test service should ignore the invalid key and connect as if no filter was specified.
-
 #### Capability `"evaluation-hooks"`
 
 This means that the SDK has support for hooks and has the ability to register evaluation hooks.
@@ -398,7 +385,6 @@ A `POST` request indicates that the test harness wants to start an instance of t
     * `synchronizers` (array, optional): A list of data synchronizers. Each synchronizer has:
       * `streaming` (object, optional): Streaming configuration (`baseUri`, `initialRetryDelayMs`).
       * `polling` (object, optional): Polling configuration (`baseUri`, `pollIntervalMs`).
-    * `payloadFilter` (string, optional): If set, the SDK should include this value as a `?filter=` query parameter on streaming/polling requests. See the `"filtering"` capability.
     * `connectionModeConfig` (object, optional): Connection mode configuration. Properties are:
       * `initialConnectionMode` (string, optional): The connection mode the SDK should start in (e.g. `"streaming"`, `"polling"`, `"offline"`, `"background"`, `"one-shot"`). For client-side FDv2, the test harness sends exactly one of `useDefaultDataSystem` (at the `dataSystem` level) or `initialConnectionMode`; it cannot send both but must send one.
       * `customConnectionModes` (object, optional): A map of custom connection mode names to their definitions. Each definition has:

--- a/sdktests/common_tests_base.go
+++ b/sdktests/common_tests_base.go
@@ -3,7 +3,6 @@ package sdktests
 import (
 	"encoding/json"
 	"fmt"
-	"regexp"
 
 	"github.com/launchdarkly/go-sdk-common/v3/ldcontext"
 	m "github.com/launchdarkly/go-test-helpers/v2/matchers"
@@ -41,51 +40,6 @@ const (
 	flagRequestGET    flagRequestMethod = "GET"
 	flagRequestREPORT flagRequestMethod = "REPORT"
 )
-
-// Represents a key identifying a filtered environment. This key is passed into
-// SDKs when configuring the polling or streaming data source, and should be
-// appended to the end of streaming/polling requests as a URL query parameter
-// named "filter".
-//
-// Example: "foo" -> "?filter=foo"
-type environmentFilter struct {
-	o.Maybe[string]
-}
-
-// IsValid returns true if the filter key is a valid environment key.
-//
-// In this context, valid means either is missing, or passes the required regex.
-func (p environmentFilter) IsValid() bool {
-	if !p.IsDefined() {
-		return true
-	}
-
-	regex := regexp.MustCompile(`^[a-zA-Z0-9][._\-a-zA-Z0-9]*$`)
-	return regex.MatchString(p.Value())
-}
-
-// String returns a human-readable representation of the filter key,
-// suitable for test output.
-func (p environmentFilter) String() string {
-	return fmt.Sprintf("environment_filter_key=\"%s\"", p.Value())
-}
-
-// Matcher checks that if the filter is present, the query parameter map contains a parameter
-// named "filter" with its value.
-// If the filter is not present, it checks that the query parameter map *does not* contain
-// a parameter named "filter".
-func (p environmentFilter) Matcher(strict bool) m.Matcher {
-	hasFilter := m.MapIncluding(
-		m.KV("filter", m.Equal(p.Value())),
-	)
-
-	if !p.IsDefined() {
-		hasFilter = m.Not(hasFilter)
-	} else if strict && !p.IsValid() {
-		hasFilter = m.Not(hasFilter)
-	}
-	return UniqueQueryParameters().Should(hasFilter)
-}
 
 func newCommonTestsBase(t *ldtest.T, testName string, baseSDKConfigurers ...SDKConfigurer) commonTestsBase {
 	c := commonTestsBase{
@@ -203,16 +157,6 @@ func (c commonTestsBase) withAvailableTransports(t *ldtest.T) []transportProtoco
 			requireContext(t).harness.CertificateAuthorityFile()))
 	}
 	return configurers
-}
-
-// Returns a set of environment filters for testing, along with a filter representing
-// "no filter".
-func (c commonTestsBase) environmentFilters() []environmentFilter {
-	return []environmentFilter{
-		{o.None[string]()},
-		{o.Some("encoding_not_necessary")},
-		{o.Some("encoding necessary +! %& ( )")},
-	}
 }
 
 func (c commonTestsBase) withFlagRequestMethod(method flagRequestMethod) SDKConfigurer {

--- a/sdktests/common_tests_poll_request.go
+++ b/sdktests/common_tests_poll_request.go
@@ -108,54 +108,39 @@ func (c CommonPollingTests) LargePayloads(t *ldtest.T) {
 
 func (c CommonPollingTests) RequestURLPath(t *ldtest.T, pathMatcher func(flagRequestMethod) m.Matcher) {
 	t.Run("URL path is computed correctly", func(t *ldtest.T) {
-		for _, filter := range c.environmentFilters() {
-			t.Run(h.IfElse(filter.IsDefined(), filter.String(), "no environment filter"), func(t *ldtest.T) {
-				// The environment filtering feature is only tested on server-side SDKs that support
-				// the "filtering" capability. All other SDKs should be tested against the
-				// "no filter" scenario (!filter.IsDefined()), since that was the default functionality
-				// previous to the introduction of filtering.
-				if filter.IsDefined() {
-					t.RequireCapability(servicedef.CapabilityFiltering)
-					t.RequireCapability(servicedef.CapabilityServerSide)
-				}
-				for _, trailingSlash := range []bool{false, true} {
-					t.Run(h.IfElse(trailingSlash, "base URI has a trailing slash",
-						"base URI has no trailing slash"), func(t *ldtest.T) {
-						for _, method := range c.availableFlagRequestMethods(t) {
-							t.Run(string(method), func(t *ldtest.T) {
-								dataSystem := NewSDKDataSystem(t, nil, c.pollingDataSystemOptions()...)
+		for _, trailingSlash := range []bool{false, true} {
+			t.Run(h.IfElse(trailingSlash, "base URI has a trailing slash",
+				"base URI has no trailing slash"), func(t *ldtest.T) {
+				for _, method := range c.availableFlagRequestMethods(t) {
+					t.Run(string(method), func(t *ldtest.T) {
+						dataSystem := NewSDKDataSystem(t, nil, c.pollingDataSystemOptions()...)
 
-								pollURI := strings.TrimSuffix(dataSystem.Synchronizers[0].Endpoint().BaseURL(), "/")
-								if trailingSlash {
-									pollURI += "/"
-								}
+						pollURI := strings.TrimSuffix(dataSystem.Synchronizers[0].Endpoint().BaseURL(), "/")
+						if trailingSlash {
+							pollURI += "/"
+						}
 
-								var uriConfigurer SDKConfigurer
-								if c.isClientSide {
-									uriConfigurer = WithConnectionModeSynchronizer("polling", servicedef.DataSynchronizer{
-										Polling: o.Some(servicedef.SDKConfigPollingParams{BaseURI: pollURI}),
-									})
-								} else {
-									uriConfigurer = WithPollingSynchronizer(servicedef.SDKConfigPollingParams{
-										BaseURI: pollURI,
-									})
-								}
-								baseConfigurers := []SDKConfigurer{
-									c.withFlagRequestMethod(method),
-									WithPayloadFilter(filter),
-									uriConfigurer,
-								}
-								if c.isClientSide {
-									baseConfigurers = append(baseConfigurers, WithInitialConnectionMode("polling"))
-								}
-								_ = NewSDKClient(t, c.baseSDKConfigurationPlus(baseConfigurers...)...)
-
-								request := dataSystem.Synchronizers[0].Endpoint().RequireConnection(t, time.Second)
-								m.In(t).For("request path").Assert(request.URL.Path, pathMatcher(method))
-								strict := t.Capabilities().Has(servicedef.CapabilityFilteringStrict)
-								m.In(t).For("filter key").Assert(request.URL.RawQuery, filter.Matcher(strict))
+						var uriConfigurer SDKConfigurer
+						if c.isClientSide {
+							uriConfigurer = WithConnectionModeSynchronizer("polling", servicedef.DataSynchronizer{
+								Polling: o.Some(servicedef.SDKConfigPollingParams{BaseURI: pollURI}),
+							})
+						} else {
+							uriConfigurer = WithPollingSynchronizer(servicedef.SDKConfigPollingParams{
+								BaseURI: pollURI,
 							})
 						}
+						baseConfigurers := []SDKConfigurer{
+							c.withFlagRequestMethod(method),
+							uriConfigurer,
+						}
+						if c.isClientSide {
+							baseConfigurers = append(baseConfigurers, WithInitialConnectionMode("polling"))
+						}
+						_ = NewSDKClient(t, c.baseSDKConfigurationPlus(baseConfigurers...)...)
+
+						request := dataSystem.Synchronizers[0].Endpoint().RequireConnection(t, time.Second)
+						m.In(t).For("request path").Assert(request.URL.Path, pathMatcher(method))
 					})
 				}
 			})

--- a/sdktests/common_tests_stream_request.go
+++ b/sdktests/common_tests_stream_request.go
@@ -55,51 +55,36 @@ func (c CommonStreamingTests) RequestMethodAndHeaders(t *ldtest.T, credential st
 
 func (c CommonStreamingTests) RequestURLPath(t *ldtest.T, pathMatcher func(flagRequestMethod) m.Matcher) {
 	t.Run("URL path is computed correctly", func(t *ldtest.T) {
-		for _, filter := range c.environmentFilters() {
-			t.Run(h.IfElse(filter.IsDefined(), filter.String(), "no environment filter"), func(t *ldtest.T) {
-				// The environment filtering feature is only tested on server-side SDKs that support
-				// the "filtering" capability. All other SDKs should be tested against the
-				// "no filter" scenario (!filter.IsDefined()), since that was the default functionality
-				// previous to the introduction of filtering.
-				if filter.IsDefined() {
-					t.RequireCapability(servicedef.CapabilityFiltering)
-					t.RequireCapability(servicedef.CapabilityServerSide)
-				}
-				for _, trailingSlash := range []bool{false, true} {
-					t.Run(h.IfElse(trailingSlash, "base URI has a trailing slash",
-						"base URI has no trailing slash"), func(t *ldtest.T) {
-						for _, method := range c.availableFlagRequestMethods(t) {
-							t.Run(string(method), func(t *ldtest.T) {
-								dataSystem, configurers := c.setupDataSystems(t, nil)
+		for _, trailingSlash := range []bool{false, true} {
+			t.Run(h.IfElse(trailingSlash, "base URI has a trailing slash",
+				"base URI has no trailing slash"), func(t *ldtest.T) {
+				for _, method := range c.availableFlagRequestMethods(t) {
+					t.Run(string(method), func(t *ldtest.T) {
+						dataSystem, configurers := c.setupDataSystems(t, nil)
 
-								streamURI := strings.TrimSuffix(dataSystem.Synchronizers[0].Endpoint().BaseURL(), "/")
-								if trailingSlash {
-									streamURI += "/"
-								}
+						streamURI := strings.TrimSuffix(dataSystem.Synchronizers[0].Endpoint().BaseURL(), "/")
+						if trailingSlash {
+							streamURI += "/"
+						}
 
-								var uriConfigurer SDKConfigurer
-								if c.isClientSide {
-									uriConfigurer = WithConnectionModeSynchronizer("streaming", servicedef.DataSynchronizer{
-										Streaming: o.Some(servicedef.SDKConfigStreamingParams{BaseURI: streamURI}),
-									})
-								} else {
-									uriConfigurer = WithStreamingSynchronizer(servicedef.SDKConfigStreamingParams{
-										BaseURI: streamURI,
-									})
-								}
-								_ = NewSDKClient(t, c.baseSDKConfigurationPlus(
-									append(configurers,
-										WithPayloadFilter(filter),
-										uriConfigurer,
-										c.withFlagRequestMethod(method),
-									)...)...)
-
-								request := dataSystem.Synchronizers[0].Endpoint().RequireConnection(t, time.Second)
-								m.In(t).For("request path").Assert(request.URL.Path, pathMatcher(method))
-								strict := t.Capabilities().Has(servicedef.CapabilityFilteringStrict)
-								m.In(t).For("filter key").Assert(request.URL.RawQuery, filter.Matcher(strict))
+						var uriConfigurer SDKConfigurer
+						if c.isClientSide {
+							uriConfigurer = WithConnectionModeSynchronizer("streaming", servicedef.DataSynchronizer{
+								Streaming: o.Some(servicedef.SDKConfigStreamingParams{BaseURI: streamURI}),
+							})
+						} else {
+							uriConfigurer = WithStreamingSynchronizer(servicedef.SDKConfigStreamingParams{
+								BaseURI: streamURI,
 							})
 						}
+						_ = NewSDKClient(t, c.baseSDKConfigurationPlus(
+							append(configurers,
+								uriConfigurer,
+								c.withFlagRequestMethod(method),
+							)...)...)
+
+						request := dataSystem.Synchronizers[0].Endpoint().RequireConnection(t, time.Second)
+						m.In(t).For("request path").Assert(request.URL.Path, pathMatcher(method))
 					})
 				}
 			})

--- a/sdktests/testapi_sdk_client.go
+++ b/sdktests/testapi_sdk_client.go
@@ -94,17 +94,6 @@ func WithServiceEndpoints(endpoints servicedef.SDKConfigServiceEndpointsParams) 
 	})
 }
 
-// WithPayloadFilter is used to with StartSDKClient to apply a non-default payload filter configuration
-func WithPayloadFilter(filter environmentFilter) SDKConfigurer {
-	return helpers.ConfigOptionFunc[servicedef.SDKConfigParams](func(configOut *servicedef.SDKConfigParams) error {
-		dataSystem := configOut.DataSystem.OrElse(servicedef.DataSystem{})
-		dataSystem.PayloadFilter = filter.Maybe
-
-		configOut.DataSystem = o.Some(dataSystem)
-		return nil
-	})
-}
-
 // WithDataSynchronizer is used with StartSDKClient to add a data synchronizer configuration.
 // Synchronizers are used in order: the first added is the primary, second is secondary, etc.
 func WithDataSynchronizer(synchronizer servicedef.DataSynchronizer) SDKConfigurer {

--- a/servicedef/sdk_config.go
+++ b/servicedef/sdk_config.go
@@ -56,7 +56,6 @@ type DataSystem struct {
 	Initializers         []DataInitializer               `json:"initializers"`
 	Synchronizers        []DataSynchronizer              `json:"synchronizers"`
 	FDv1Fallback         o.Maybe[SDKConfigPollingParams] `json:"fdv1Fallback,omitempty"`
-	PayloadFilter        o.Maybe[string]                 `json:"payloadFilter,omitempty"`
 	ConnectionModeConfig o.Maybe[ConnectionModeConfig]   `json:"connectionModeConfig,omitempty"`
 }
 

--- a/servicedef/service_params.go
+++ b/servicedef/service_params.go
@@ -26,8 +26,6 @@ const (
 	CapabilityServiceEndpoints            = "service-endpoints"
 	CapabilityTags                        = "tags"
 	CapabilityUserType                    = "user-type"
-	CapabilityFiltering                   = "filtering"
-	CapabilityFilteringStrict             = "filtering-strict"
 	CapabilityAutoEnvAttributes           = "auto-env-attributes"
 	CapabilityMigrations                  = "migrations"
 	CapabilityEventSampling               = "event-sampling"


### PR DESCRIPTION
Payload filter is no longer intended to be supported for FDv2. Therefore, this test removes the payload filter contract tests for the v3 branch.

AFAICT, the specs don't really address payload filtering in FDv2, so I don't _think_ there's any concern there.

These SDKs currently support payload filtering in FDv2 and I assume we would want to remove that support:
* Java
* Go
* Ruby
* Python
* Node

These SDKs already don't support payload filtering FDv2:
* C++
* .NET

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Overview**
> Removes **payload filter** support from the SDK test harness contract, aligned with FDv2 no longer intending to support `?filter=` on streaming/polling requests.
> 
> The service spec drops the `"filtering"` and `"filtering-strict"` capabilities and the `dataSystem.payloadFilter` configuration field. Harness types remove `CapabilityFiltering`, `DataSystem.PayloadFilter`, `WithPayloadFilter`, and the `environmentFilter` helper (validation and query-string matchers).
> 
> **Polling and streaming** URL path tests no longer iterate filter scenarios or assert `filter` query parameters; they still cover trailing slashes, GET vs REPORT, and path computation.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 246d80b8bee2886f8a33c09ff018eaba6a3d6a64. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->