### PR TITLE
chore: Run CI on v3 branch

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,11 +1,11 @@
 name: Build and Test
 on:
   push:
-    branches: [ 'v2' ]
+    branches: [ 'v3' ]
     paths-ignore:
       - '**.md' # Do not need to run CI for markdown changes.
   pull_request:
-    branches: [ 'v2', 'feat/**' ]
+    branches: [ 'v3', 'feat/**' ]
     paths-ignore:
       - '**.md'
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Overview**
> Points the Build and Test workflow at the `v3` branch instead of `v2`.
> 
> CI now runs on pushes to `v3` and on PRs targeting `v3` or `feat/**`. Job steps are unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 87bbd676b7ff8cf20fc7bae30e58b3833aed45ae. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->