### PR TITLE
feat: Verify SDKs read all three persistent-store tombstone shapes

### DIFF
--- a/sdktests/server_side_persistence_base.go
+++ b/sdktests/server_side_persistence_base.go
@@ -240,6 +240,8 @@ func (s *ServerSidePersistentTests) Run(t *ldtest.T) {
 				time.Second, time.Millisecond*20, "failed to serve defaults after flag deletion")
 		})
 
+		t.Run("tombstones", s.doTombstoneTests)
+
 		t.Run("caches flag for duration", func(t *ldtest.T) {
 			persistence := NewPersistence()
 			persistence.SetStore(servicedef.SDKConfigPersistentStore{

--- a/sdktests/server_side_persistence_tombstones.go
+++ b/sdktests/server_side_persistence_tombstones.go
@@ -1,0 +1,199 @@
+package sdktests
+
+// A tombstone is the record an SDK writes to a persistent store to mark an item
+// deleted. Version-based conflict resolution needs it: with no record at all, a
+// stale out-of-order update would bring the item back.
+//
+// The store already addresses the record by key - the Redis hash field, the
+// Consul key, or the DynamoDB sort key - so the key inside the JSON body is
+// redundant. Our SDKs write three different shapes anyway, and any SDK can be
+// pointed at a store that a different SDK wrote. These tests prove that a
+// reader accepts all three shapes, does not depend on the inner key, and does
+// not bring a deleted item back to life.
+
+import (
+	"fmt"
+	"maps"
+
+	"github.com/stretchr/testify/require"
+
+	m "github.com/launchdarkly/go-test-helpers/v2/matchers"
+	o "github.com/launchdarkly/sdk-test-harness/v2/framework/opt"
+
+	"github.com/launchdarkly/go-sdk-common/v3/ldcontext"
+	"github.com/launchdarkly/go-sdk-common/v3/ldreason"
+	"github.com/launchdarkly/go-sdk-common/v3/ldvalue"
+	"github.com/launchdarkly/go-server-sdk-evaluation/v3/ldbuilders"
+	"github.com/launchdarkly/sdk-test-harness/v2/framework/ldtest"
+	"github.com/launchdarkly/sdk-test-harness/v2/servicedef"
+)
+
+const (
+	// tombstonePlaceholderKey is what Go v5+, the Relay Proxy, and Rust put in
+	// the body of a full-object tombstone in place of the real key.
+	tombstonePlaceholderKey = "$deleted"
+
+	tombstonedFlagKey    = "tombstoned-flag-key"
+	tombstonedSegmentKey = "tombstoned-segment-key"
+	segmentMatchFlagKey  = "segment-match-flag-key"
+
+	tombstoneVersion = 100
+)
+
+// tombstoneShape is one encoding of a deleted item, as written by some of our SDKs.
+type tombstoneShape struct {
+	name string
+	body string
+}
+
+// keylessTombstone is written by .NET, Java, Node (Redis upsert path), and Haskell.
+func keylessTombstone(version int) string {
+	return fmt.Sprintf(`{"version":%d,"deleted":true}`, version)
+}
+
+// keyedTombstone is written by Python, Ruby, C++, Erlang, and Node (init path).
+// The key it carries is the real key of the item, which the store already knows.
+func keyedTombstone(key string, version int) string {
+	return fmt.Sprintf(`{"key":%q,"version":%d,"deleted":true}`, key, version)
+}
+
+func flagTombstoneShapes(t *ldtest.T, key string) []tombstoneShape {
+	// A full flag object keyed "$deleted" is written by Go v5+, the Relay Proxy,
+	// and Rust. The real key survives only as the store's own address for the
+	// record.
+	placeholderFlag, err := ldbuilders.NewFlagBuilder(tombstonePlaceholderKey).
+		Version(tombstoneVersion).Deleted(true).Build().MarshalJSON()
+	require.NoError(t, err)
+
+	return []tombstoneShape{
+		{name: "body has no key", body: keylessTombstone(tombstoneVersion)},
+		{name: "body repeats the item key", body: keyedTombstone(key, tombstoneVersion)},
+		{name: "body is a full object keyed " + tombstonePlaceholderKey, body: string(placeholderFlag)},
+	}
+}
+
+// segmentTombstoneShapes builds the same three shapes for a deleted segment.
+// The full-object shape includes includedKey so that a reader which treats the
+// tombstone as a live segment produces a segment match we can observe.
+func segmentTombstoneShapes(t *ldtest.T, key string, includedKey string) []tombstoneShape {
+	placeholder := ldbuilders.NewSegmentBuilder(tombstonePlaceholderKey).
+		Version(tombstoneVersion).Included(includedKey).Build()
+	placeholder.Deleted = true
+	placeholderSegment, err := placeholder.MarshalJSON()
+	require.NoError(t, err)
+
+	return []tombstoneShape{
+		{name: "body has no key", body: keylessTombstone(tombstoneVersion)},
+		{name: "body repeats the item key", body: keyedTombstone(key, tombstoneVersion)},
+		{name: "body is a full object keyed " + tombstonePlaceholderKey, body: string(placeholderSegment)},
+	}
+}
+
+// doTombstoneTests runs the tombstone-shape tests. It belongs to the daemon mode
+// sub-tree: there is no data source, so everything the SDK serves comes straight
+// out of the store, and the cache is off so that every read hits the store.
+func (s *ServerSidePersistentTests) doTombstoneTests(t *ldtest.T) {
+	t.Run("flags", s.doFlagTombstoneTests)
+	t.Run("segments", s.doSegmentTombstoneTests)
+}
+
+func (s *ServerSidePersistentTests) daemonModePersistence() *Persistence {
+	persistence := NewPersistence()
+	persistence.SetStore(servicedef.SDKConfigPersistentStore{
+		Type: s.persistentStore.Type(),
+		DSN:  s.persistentStore.DSN(),
+	})
+	persistence.SetCache(servicedef.SDKConfigPersistentCache{
+		Mode: servicedef.CacheModeOff,
+	})
+	return persistence
+}
+
+func (s *ServerSidePersistentTests) doFlagTombstoneTests(t *ldtest.T) {
+	context := ldcontext.New("user-key")
+
+	for _, shape := range flagTombstoneShapes(t, tombstonedFlagKey) {
+		s.runWithEmptyStore(t, shape.name, func(t *ldtest.T) {
+			features := maps.Clone(s.initialFlags)
+			features[tombstonedFlagKey] = shape.body
+			require.NoError(t, s.persistentStore.WriteMap(s.defaultPrefix, "features", features))
+
+			client := NewSDKClient(t, s.daemonModePersistence())
+
+			// One unrecognized record must not spoil the whole collection.
+			pollUntilFlagValueUpdated(t, client, "flag-key", context,
+				ldvalue.String("default"), ldvalue.String("fallthrough"), ldvalue.String("default"))
+
+			// The deleted flag must not come back as a live flag.
+			allFlags := client.EvaluateAllFlags(t, servicedef.EvaluateAllFlagsParams{
+				Context: o.Some(context),
+			})
+			m.In(t).Assert(allFlags, EvalAllFlagsStateMap().Should(
+				m.ValueForKey("flag-key").Should(m.JSONEqual(ldvalue.String("fallthrough")))))
+			requireFlagAbsentFromAllFlags(t, allFlags, tombstonedFlagKey)
+
+			// Asking for the deleted flag must look the same as asking for a flag
+			// that was never there.
+			result := client.EvaluateFlag(t, servicedef.EvaluateFlagParams{
+				FlagKey:      tombstonedFlagKey,
+				Context:      o.Some(context),
+				ValueType:    servicedef.ValueTypeAny,
+				DefaultValue: ldvalue.String("default"),
+				Detail:       true,
+			})
+			m.In(t).Assert(result.Value, m.Equal(ldvalue.String("default")))
+			m.In(t).Assert(result.Reason.Value().GetErrorKind(), m.Equal(ldreason.EvalErrorFlagNotFound))
+		})
+	}
+}
+
+func (s *ServerSidePersistentTests) doSegmentTombstoneTests(t *ldtest.T) {
+	context := ldcontext.New("user-key")
+
+	// This flag matches the deleted segment. A deleted segment matches nothing,
+	// so the flag must serve "not-matched". If the SDK reads the tombstone as a
+	// live segment instead, the full-object shape includes this context and the
+	// flag serves "matched".
+	segmentMatchFlag, err := makeFlagToCheckSegmentMatch(segmentMatchFlagKey, tombstonedSegmentKey,
+		ldvalue.String("not-matched"), ldvalue.String("matched")).MarshalJSON()
+	require.NoError(t, err)
+
+	for _, shape := range segmentTombstoneShapes(t, tombstonedSegmentKey, context.Key()) {
+		s.runWithEmptyStore(t, shape.name, func(t *ldtest.T) {
+			features := maps.Clone(s.initialFlags)
+			features[segmentMatchFlagKey] = string(segmentMatchFlag)
+			require.NoError(t, s.persistentStore.WriteMap(s.defaultPrefix, "features", features))
+			require.NoError(t, s.persistentStore.WriteMap(s.defaultPrefix, "segments",
+				map[string]string{tombstonedSegmentKey: shape.body}))
+
+			client := NewSDKClient(t, s.daemonModePersistence())
+
+			// The flags are still readable with a tombstone sitting in the
+			// segments collection.
+			pollUntilFlagValueUpdated(t, client, "flag-key", context,
+				ldvalue.String("default"), ldvalue.String("fallthrough"), ldvalue.String("default"))
+
+			// Reading the tombstone must neither fail the evaluation nor produce a
+			// segment match.
+			result := client.EvaluateFlag(t, servicedef.EvaluateFlagParams{
+				FlagKey:      segmentMatchFlagKey,
+				Context:      o.Some(context),
+				ValueType:    servicedef.ValueTypeAny,
+				DefaultValue: ldvalue.String("default"),
+				Detail:       true,
+			})
+			m.In(t).Assert(result.Value, m.Equal(ldvalue.String("not-matched")))
+		})
+	}
+}
+
+// requireFlagAbsentFromAllFlags fails if all-flags state has anything at all for
+// the given key, either a value or an entry in the flag metadata.
+func requireFlagAbsentFromAllFlags(
+	t *ldtest.T, response servicedef.EvaluateAllFlagsResponse, flagKey string) {
+	_, present := response.State[flagKey]
+	require.False(t, present, "all-flags returned a value for deleted flag %q", flagKey)
+
+	_, present = response.State["$flagsState"].AsValueMap().TryGet(flagKey)
+	require.False(t, present, "all-flags returned metadata for deleted flag %q", flagKey)
+}


### PR DESCRIPTION
[SDK-2959](https://launchdarkly.atlassian.net/browse/SDK-2959)

## What

Adds contract tests that plant tombstone records directly in a persistent store and check that the SDK reading them behaves correctly, for each of the three tombstone shapes our SDKs write.

A tombstone is the record an SDK writes to mark an item deleted, so that version-based conflict resolution can reject a stale out-of-order update. The store already addresses the record by key (Redis hash field, Consul key, DynamoDB sort key), so the `key` inside the JSON body is redundant. Three incompatible shapes are in circulation:

| Shape | Written by |
| --- | --- |
| `{"version":N,"deleted":true}` | .NET, Java, Node (Redis upsert path), Haskell |
| `{"key":"<real-key>","version":N,"deleted":true}` | Python, Ruby, C++, Erlang, Node (init path) |
| full flag/segment object with `"key":"$deleted"` | Go v5+, Relay Proxy, Rust |

Two confirmed bugs motivated this: Python failed its entire all-flags read on the keyless shape (SDK-2941 / FROPS-511), and Rust parses the Go/Relay shape as a *live* flag, resurrecting deleted flags. These tests prove no SDK depends on the inner key, which is the prerequisite for eventually dropping it.

## Tests

New file `sdktests/server_side_persistence_tombstones.go`, registered with one line from `ServerSidePersistentTests.Run` inside the existing `daemon mode` sub-tree (no data source, `CacheModeOff`). No new capability: it runs automatically for every store an SDK declares (`persistent-data-store-redis` / `-consul` / `-dynamodb`).

`tombstones/flags/<shape>` — plants a valid flag plus a tombstone in one `features` write, then asserts:
1. the valid flag still evaluates to its expected value (catches a reader that fails the whole collection on one unrecognized record);
2. the tombstoned key is absent from all-flags state, both as a value and in `$flagsState` (catches a reader that resurrects a tombstone as a live flag);
3. evaluating the tombstoned key returns the caller's default with reason `FLAG_NOT_FOUND`, matching what the neighbouring daemon-mode tests assert.

`tombstones/segments/<shape>` — plants a tombstone in the `segments` namespace plus a flag whose rule matches that segment key, then asserts the valid flag is still readable and the segment-matching flag serves its no-match variation. The `$deleted` full-object segment includes the evaluation context in its `included` list, so an SDK that reads it as a live segment would serve `matched` instead.

All assertions are behavioral, so they read identically across Redis, Consul, and DynamoDB. Every planted shape carries a parseable `version`, which DynamoDB's `WriteMap` requires.

## Out of scope

No changes to `basicDeletedFlagValidationMatcher`, no v3 port (the file is self-contained so the port is a copy plus one line), no capability changes, no CHANGELOG/version edits.

## Verification

`make lint` → `0 issues`. `make build`, `go vet ./...`, and `make test` all pass. The tests themselves need a live SDK test service plus Redis/Consul/DynamoDB, so they were not executed end to end here.

To run against an SDK, start Redis / Consul / DynamoDB-local and the SDK's test service, then:

```shell
./sdk-test-harness -url http://localhost:8000 \
  -enable-persistence-tests \
  -run 'persistent data store/./daemon mode/tombstones'
```

The full test path is `persistent data store/<store>/daemon mode/tombstones/{flags,segments}/<shape>`. Drop the `-run` filter to exercise the whole persistence suite.

[SDK-2959]: https://launchdarkly.atlassian.net/browse/SDK-2959?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Overview**
> Adds daemon-mode contract tests that plant deleted-item **tombstones** in Redis/Consul/DynamoDB and assert SDKs treat them as deleted, regardless of which of the three JSON shapes other SDKs write.
> 
> For **flags**, each shape is stored next to a live flag. The suite checks that the live flag still evaluates, the tombstoned key is absent from all-flags (value and `$flagsState`), and a direct eval returns the default with `FLAG_NOT_FOUND`. For **segments**, a tombstone sits in the segments collection while a segment-match flag must serve the no-match variation (the `$deleted` full-object shape includes the context so a false resurrection would match).
> 
> Tests run under existing `persistent data store/*/daemon mode` with cache off and no new capability.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c95ea452175dd79c7246786f5b4819cd1876f92e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->
